### PR TITLE
Several bugfixes, some found in JGI testing

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -28,6 +28,8 @@ UPDATED FEATURES / MAJOR BUG FIXES:
 - Empty strings are now accepted as map keys
 - Fixed a NPE when calling list_referencing_object_counts with a non-existent
   object version
+- Fixed a race condition that could occur when operating on an object that's in
+  mid save
 
 KNOWN BUGS:
 - When filtering list_object output, deleted, hidden and early versions of

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -19,6 +19,29 @@ TOs are limited to 1GB
 TO subdata is limited to 15MB
 TO provenance is limited to 1MB
 
+VERSION: 0.3.4 (Released TBD)
+--------------------------------------
+NEW FEATURES:
+- N/A
+
+UPDATED FEATURES / MAJOR BUG FIXES:
+- Empty strings are now accepted as map keys
+- Fixed a NPE when calling list_referencing_object_counts with a non-existent
+  object version
+
+KNOWN BUGS:
+- When filtering list_object output, deleted, hidden and early versions of
+  objects are filtered *after* the limit is applied. This means that fewer
+  objects than the limit may be returned, and in extreme cases where many
+  hidden, deleted, or lower version objects are found no objects may be
+  returned.
+  
+ANTICIPATED FUTURE DEVELOPMENTS:
+- Garbage collection
+- ACLs based on KBase groups
+- KBase Search API
+- Improvements to returning the subset of an object
+
 VERSION: 0.3.3 (Released 10/28/14)
 --------------------------------------
 NEW FEATURES:

--- a/src/us/kbase/typedobj/core/JsonDocumentLocation.java
+++ b/src/us/kbase/typedobj/core/JsonDocumentLocation.java
@@ -271,9 +271,9 @@ public class JsonDocumentLocation {
 		private final String location;
 		
 		private JsonMapLocation(final String location) {
-			if (location == null || location.isEmpty()) {
+			if (location == null) {
 				throw new IllegalArgumentException(
-						"Map locations cannot be null or the empty string");
+						"Map locations cannot be null");
 			}
 			this.location = location;
 		}

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -126,7 +126,7 @@ public class WorkspaceServer extends JsonServerServlet {
     //TODO check shock version
     //TODO shock client should ignore extra fields
 	
-	private static final String VER = "0.3.3";
+	private static final String VER = "0.3.4";
 
 	//required deploy parameters:
 	private static final String HOST = "mongodb-host";

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -2668,10 +2668,21 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 			//this is another place where extremely rare failures could cause
 			//problems
 			final int ver;
+			final int latestver = (Integer) objdata.get(o).get(LATEST_VERSION);
 			if (o.getVersion() == null) {
-				ver = (Integer) objdata.get(o).get(LATEST_VERSION);
+				ver = latestver;
 			} else {
 				ver = o.getVersion();
+				if (ver > latestver) {
+					final Map<String, Object> obj = objdata.get(o);
+					final String name = (String) obj.get(Fields.OBJ_NAME);
+					final Long id = (Long) obj.get(Fields.OBJ_ID);
+					
+					throw new NoSuchObjectException(String.format(
+							"No object with id %s (name %s) and version %s exists "
+							+ "in workspace %s", id, name, ver,
+							o.getWorkspaceIdentifier().getID()), o);
+				}
 			}
 			@SuppressWarnings("unchecked")
 			final List<Integer> refs = (List<Integer>) objdata.get(o).get(

--- a/src/us/kbase/workspace/database/mongo/QueryMethods.java
+++ b/src/us/kbase/workspace/database/mongo/QueryMethods.java
@@ -281,6 +281,7 @@ public class QueryMethods {
 		return ret;
 	}
 	
+	//method assumes at least one version exists
 	Map<ResolvedMongoObjectIDNoVer, List<Map<String, Object>>> queryAllVersions(
 			final HashSet<ResolvedMongoObjectIDNoVer> objIDs,
 			final Set<String> fields)

--- a/src/us/kbase/workspace/database/mongo/QueryMethods.java
+++ b/src/us/kbase/workspace/database/mongo/QueryMethods.java
@@ -205,6 +205,10 @@ public class QueryMethods {
 					rwsi.getID());
 			query.put(Fields.OBJ_NAME, new BasicDBObject(
 					"$in", names.get(rwsi).keySet()));
+			//if ver count < 1, we're in a race condition or the database went
+			//down after saving the object but before saving the version
+			//so don't look at objects with no versions
+			query.put(Fields.OBJ_VCNT, new BasicDBObject("$gt", 0));
 			orquery.add(query);
 		}
 		for (final ResolvedMongoWSID rwsi: ids.keySet()) {
@@ -212,6 +216,8 @@ public class QueryMethods {
 					rwsi.getID());
 			query.put(Fields.OBJ_ID, new BasicDBObject(
 					"$in", ids.get(rwsi).keySet()));
+			//see notes in loop above
+			query.put(Fields.OBJ_VCNT, new BasicDBObject("$gt", 0));
 			orquery.add(query);
 		}
 		fields.add(Fields.OBJ_ID);

--- a/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
@@ -1,6 +1,7 @@
 package us.kbase.workspace.test.database.mongo;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -307,23 +308,41 @@ public class MongoInternalsTest {
 		}
 		
 		try {
-			//TODO fix NPE here, this is a queryVersions problem vs. queryAllVersions
 			mwdb.copyObject(user, oidrwWithVer, new ObjectIDResolvedWS(rwsi, "foo"));
 			fail("copied object with no version");
 		} catch (NoSuchObjectException nsoe) {
 			assertThat("correct exception message", nsoe.getMessage(),
-					is(String.format("No object with name %s exists in workspace %s",
+					is(String.format("No object with id 1 (name %s) and version 1 exists in workspace %s",
 							objname, rwsi.getID())));
 		}
 		
-		//TODO fix & test queryVersions method. Handled queryAllVersions and queryCollections.
-
-		//TODO this reproduces the problem found very rarely in JGI jenkins tests
-		//race condition on save/get
-		mwdb.getObjects(oidsetver);
+		try {
+			mwdb.getObjects(oidsetver);
+			fail("got object with no version");
+		} catch (NoSuchObjectException nsoe) {
+			assertThat("correct exception message", nsoe.getMessage(),
+					is(String.format("No object with id 1 (name %s) and version 1 exists in workspace %s",
+							objname, rwsi.getID())));
+		}
 		
-		//TODO fix these issues across the board - all methods.
+		try {
+			mwdb.getObjectProvenance(oidsetver);
+			fail("got object with no version");
+		} catch (NoSuchObjectException nsoe) {
+			assertThat("correct exception message", nsoe.getMessage(),
+					is(String.format("No object with id 1 (name %s) and version 1 exists in workspace %s",
+							objname, rwsi.getID())));
+		}
 		
+		assertNull("can't get object mid save", mwdb.getObjectInformation(oidsetver, false, true).get(0));
+		try {
+			mwdb.getObjectInformation(oidsetver, false, false);
+			fail("got object with no version");
+		} catch (NoSuchObjectException nsoe) {
+			assertThat("correct exception message", nsoe.getMessage(),
+					is(String.format("No object with id 1 (name %s) and version 1 exists in workspace %s",
+							objname, rwsi.getID())));
+		}
 	}
 
 	private ResolvedSaveObject createResolvedWSObj(String objname,

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
@@ -80,7 +80,7 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 	
 	@Test
 	public void ver() throws Exception {
-		assertThat("got correct version", CLIENT_NO_AUTH.ver(), is("0.3.3"));
+		assertThat("got correct version", CLIENT_NO_AUTH.ver(), is("0.3.4"));
 	}
 	
 	@Test

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
@@ -2292,7 +2292,7 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 	
 	@Test
 	public void listReferencingObjects() throws Exception {
-		CLIENT1.createWorkspace(new CreateWorkspaceParams().withWorkspace("referingobjs"));
+		long wsid = CLIENT1.createWorkspace(new CreateWorkspaceParams().withWorkspace("referingobjs")).getE1();
 		
 		CLIENT1.saveObjects(new SaveObjectsParams().withWorkspace("referingobjs")
 				.withObjects(Arrays.asList(new ObjectSaveData().withData(new UObject(new HashMap<String, String>()))
@@ -2320,6 +2320,16 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 		compareObjectInfo(retrefs.get(0), Arrays.asList(ref, prov), false);
 		List<Long> refcnts = CLIENT1.listReferencingObjectCounts(loi);
 		assertThat("got correct refcounts", refcnts, is(Arrays.asList(2L)));
+		
+		loi.set(0, new ObjectIdentity().withRef("referingobjs/std/2"));
+		try {
+			refcnts = CLIENT1.listReferencingObjectCounts(loi);
+			fail("got ref counts with bad obj id");
+		} catch (ServerException se) {
+			assertThat("correct excep message", se.getLocalizedMessage(),
+					is("No object with id 1 (name std) and version 2 exists in workspace " +
+							wsid));
+		}
 	}
 	
 	@Test

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -1256,6 +1256,27 @@ public class WorkspaceTest extends WorkspaceTester {
 	}
 
 	@Test
+	public void saveEmptyStringKey() throws Exception {
+		WorkspaceUser user = new WorkspaceUser("foo");
+
+		WorkspaceIdentifier wspace = new WorkspaceIdentifier("saveEmptyStringKey");
+		ws.createWorkspace(user, wspace.getName(), false, null, null);
+		Provenance mtprov = new Provenance(user);
+		Map<String, Object> data = new HashMap<String, Object>();
+		data.put("", 3);
+		//should work
+		ws.saveObjects(user, wspace, Arrays.asList(
+				new WorkspaceSaveObject(data, SAFE_TYPE1, null, mtprov,
+						false)
+				), getIdFactory(user));
+		@SuppressWarnings("unchecked")
+		Map<String, Object> dataObj = (Map<String, Object>)
+				ws.getObjects(user, Arrays.asList(
+				new ObjectIdentifier(wspace, 1))).get(0).getData();
+		assertThat("data saved correctly", dataObj, is(data));
+	}
+	
+	@Test
 	public void saveObjectWithTypeChecking() throws Exception {
 		final String specTypeCheck1 =
 				"module TestTypeChecking {" +

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -51,6 +51,7 @@ import us.kbase.workspace.database.AllUsers;
 import us.kbase.workspace.database.ModuleInfo;
 import us.kbase.workspace.database.ObjectChain;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
+import us.kbase.workspace.database.ObjectIDResolvedWS;
 import us.kbase.workspace.database.ObjectIdentifier;
 import us.kbase.workspace.database.ObjectInformation;
 import us.kbase.workspace.database.Permission;
@@ -4707,7 +4708,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		WorkspaceIdentifier wsisrcdel1 = new WorkspaceIdentifier("refssourcedel1");
 		WorkspaceIdentifier wsisrc2gl = new WorkspaceIdentifier("refssourcegl");
 		
-		ws.createWorkspace(user1, wsitar1.getName(), false, null, null);
+		long wsid = ws.createWorkspace(user1, wsitar1.getName(), false, null, null).getId();
 		ws.setPermissions(user1, wsitar1, Arrays.asList(user2), Permission.READ);
 		ws.createWorkspace(user2, wsitar2.getName(), false, null, null);
 		ws.setPermissions(user2, wsitar2, Arrays.asList(user1), Permission.READ);
@@ -5000,6 +5001,26 @@ public class WorkspaceTest extends WorkspaceTester {
 					is("Object 1 cannot be accessed: User refUser2 may not read workspace refssource1"));
 			assertThat("correct object returned", ioe.getInaccessibleObject(),
 					is(new ObjectIdentifier(wsisrc1, 1)));
+		}
+		
+		try {
+			ws.getReferencingObjectCounts(user1, Arrays.asList(
+					new ObjectIdentifier(wsitar1, "single", 2)));
+			fail("Able to get ref obj count for non-existant obj version");
+		} catch (NoSuchObjectException ioe) {
+			assertThat("correct exception message", ioe.getLocalizedMessage(),
+					is("No object with id 7 (name single) and version 2 exists in workspace " + wsid));
+			ObjectIDResolvedWS resobj = ioe.getResolvedInaccessibleObject();
+			assertThat("correct ws id in returned oid", resobj.getWorkspaceIdentifier().getID(),
+					is(wsid));
+			assertThat("correct ws name in returned oid", resobj.getWorkspaceIdentifier().getName(),
+					is(wsitar1.getName()));
+			assertThat("correct objid in returned oid", resobj.getId(),
+					is((Long) null));
+			assertThat("correct obj name in returned oid", resobj.getName(),
+					is("single"));
+			assertThat("correct obj ver in returned oid", resobj.getVersion(),
+					is(2));
 		}
 		
 		ws.setGlobalPermission(user2, wsisrc2gl, Permission.NONE);


### PR DESCRIPTION
This can wait for deploy until March, but I found some of these during JGI testing so I'm fixing them now.

Fixes:
Empty strings being rejected as map keys
NPE when calling get ref counts with a non-existant object version
Race conditions when simultaneously operating on and saving an object