### PR TITLE
Improve admin logging

### DIFF
--- a/docsource/releasenotes.rst
+++ b/docsource/releasenotes.rst
@@ -16,6 +16,7 @@ UPDATED FEATURES / MAJOR BUG FIXES:
   code. No plan to use this code and drastically increases database size and
   codebase complexity. All workspace mongo database type_[MD5] collections may
   be deleted after upgrading.
+* Improved logging for the ``administer()`` method.
 * Fixed a bug where mongo connections would not be released when redeploying
   the server in an already running glassfish instance.
 * Fixed a bug where objects from deleted workspaces could be listed in 

--- a/src/us/kbase/workspace/kbase/WorkspaceAdministration.java
+++ b/src/us/kbase/workspace/kbase/WorkspaceAdministration.java
@@ -12,6 +12,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,6 +37,7 @@ import us.kbase.workspace.SetPermissionsParams;
 import us.kbase.workspace.WorkspaceIdentity;
 import us.kbase.workspace.database.Workspace;
 import us.kbase.workspace.database.WorkspaceIdentifier;
+import us.kbase.workspace.database.WorkspaceInformation;
 import us.kbase.workspace.database.WorkspaceUser;
 import us.kbase.workspace.database.exceptions.CorruptWorkspaceDBException;
 import us.kbase.workspace.database.exceptions.NoSuchObjectException;
@@ -44,6 +48,25 @@ import us.kbase.workspace.exceptions.WorkspaceAuthorizationException;
 
 public class WorkspaceAdministration {
 	
+	private static final String REMOVE_MODULE_OWNERSHIP =
+			"removeModuleOwnership";
+	private static final String GRANT_MODULE_OWNERSHIP =
+			"grantModuleOwnership";
+	private static final String LIST_WORKSPACE_OWNERS = "listWorkspaceOwners";
+	private static final String LIST_WORKSPACES = "listWorkspaces";
+	private static final String SAVE_OBJECTS = "saveObjects";
+	private static final String SET_GLOBAL_PERMISSION = "setGlobalPermission";
+	private static final String GET_PERMISSIONS = "getPermissions";
+	private static final String SET_PERMISSIONS = "setPermissions";
+	private static final String CREATE_WORKSPACE = "createWorkspace";
+	private static final String SET_WORKSPACE_OWNER = "setWorkspaceOwner";
+	private static final String REMOVE_ADMIN = "removeAdmin";
+	private static final String ADD_ADMIN = "addAdmin";
+	private static final String LIST_ADMINS = "listAdmins";
+	private static final String DENY_MOD_REQUEST = "denyModRequest";
+	private static final String APPROVE_MOD_REQUEST = "approveModRequest";
+	private static final String LIST_MOD_REQUESTS = "listModRequests";
+
 	private final static ObjectMapper MAPPER = new ObjectMapper()
 			.registerModule(new JacksonTupleModule());
 	
@@ -62,6 +85,10 @@ public class WorkspaceAdministration {
 		if (admin != null && !admin.isEmpty()) {
 			internaladmins.add(admin);
 		}
+	}
+	
+	private static Logger getLogger() {
+		return LoggerFactory.getLogger(WorkspaceAdministration.class);
 	}
 
 	public Object runCommand(AuthToken token, UObject command)
@@ -89,77 +116,103 @@ public class WorkspaceAdministration {
 			throw ioe;
 		}
 		final String fn = (String) cmd.getCommand();
-		if ("listModRequests".equals(fn)) {
+		if (LIST_MOD_REQUESTS.equals(fn)) {
+			getLogger().info(LIST_MOD_REQUESTS);
 			return ws.listModuleRegistrationRequests();
 		}
-		if ("approveModRequest".equals(fn)) {
-			ws.resolveModuleRegistration((String) cmd.getModule(), true);
+		if (APPROVE_MOD_REQUEST.equals(fn)) {
+			final String mod = cmd.getModule();
+			getLogger().info(APPROVE_MOD_REQUEST + " " + mod);
+			ws.resolveModuleRegistration(mod, true);
 			return null;
 		}
-		if ("denyModRequest".equals(fn)) {
-			ws.resolveModuleRegistration((String) cmd.getModule(), false);
+		if (DENY_MOD_REQUEST.equals(fn)) {
+			final String mod = cmd.getModule();
+			getLogger().info(DENY_MOD_REQUEST + " " + mod);
+			ws.resolveModuleRegistration(mod, false);
 			return null;
 		}
-		if ("listAdmins".equals(fn)) {
+		if (LIST_ADMINS.equals(fn)) {
+			getLogger().info(LIST_ADMINS);
 			final Set<String> strAdm = new HashSet<String>();
 			strAdm.addAll(usersToStrings(ws.getAdmins()));
 			strAdm.addAll(internaladmins);
 			return strAdm;
 		}
-		if ("addAdmin".equals(fn)) {
-			ws.addAdmin(getUser(cmd));
+		if (ADD_ADMIN.equals(fn)) {
+			final WorkspaceUser user = getUser(cmd);
+			getLogger().info(ADD_ADMIN + " " + user.getUser());
+			ws.addAdmin(user);
 			return null;
 		}
-		if ("removeAdmin".equals(fn)) {
-			ws.removeAdmin(getUser(cmd));
+		if (REMOVE_ADMIN.equals(fn)) {
+			final WorkspaceUser user = getUser(cmd);
+			getLogger().info(REMOVE_ADMIN + " " + user.getUser());
+			ws.removeAdmin(user);
 			return null;
 		}
-		if ("setWorkspaceOwner".equals(fn)) {
+		if (SET_WORKSPACE_OWNER.equals(fn)) {
 			final SetWorkspaceOwnerParams params =
 					getParams(cmd, SetWorkspaceOwnerParams.class);
 			
 			final WorkspaceIdentifier wsi = processWorkspaceIdentifier(
 							params.wsi);
-			return wsInfoToTuple(ws.setWorkspaceOwner(null, wsi,
+			final WorkspaceInformation info = ws.setWorkspaceOwner(null, wsi,
 					params.new_user == null ? null :
-					getUser(params.new_user), params.new_name, true));
+					getUser(params.new_user), params.new_name, true);
+			getLogger().info(SET_WORKSPACE_OWNER + " " + info.getId() + " " +
+					info.getOwner().getUser());
+			return wsInfoToTuple(info);
 		}
-		if ("createWorkspace".equals(fn)) {
-			final CreateWorkspaceParams params = getParams(cmd, CreateWorkspaceParams.class);
+		if (CREATE_WORKSPACE.equals(fn)) {
+			final CreateWorkspaceParams params = getParams(cmd,
+					CreateWorkspaceParams.class);
 			return wsmeth.createWorkspace(params, getUser(cmd));
 		}
-		if ("setPermissions".equals(fn)) {
-			final SetPermissionsParams params = getParams(cmd, SetPermissionsParams.class);
+		if (SET_PERMISSIONS.equals(fn)) {
+			final SetPermissionsParams params = getParams(cmd,
+					SetPermissionsParams.class);
 			wsmeth.setPermissions(params, null, true);
 			return null;
 		}
-		if ("getPermissions".equals(fn)) {
-			final WorkspaceIdentity params = getParams(cmd, WorkspaceIdentity.class);
+		if (GET_PERMISSIONS.equals(fn)) {
+			final WorkspaceIdentity params = getParams(cmd,
+					WorkspaceIdentity.class);
 			return wsmeth.getPermissions(params, getUser(cmd));
 		}
-		if ("setGlobalPermission".equals(fn)) {
-			final SetGlobalPermissionsParams params = getParams(cmd, SetGlobalPermissionsParams.class);
+		if (SET_GLOBAL_PERMISSION.equals(fn)) {
+			final SetGlobalPermissionsParams params = getParams(cmd,
+					SetGlobalPermissionsParams.class);
 			wsmeth.setGlobalPermission(params, getUser(cmd));
 			return null;
 		}
-		if ("saveObjects".equals(fn)) {
-			final SaveObjectsParams params = getParams(cmd, SaveObjectsParams.class);
+		if (SAVE_OBJECTS.equals(fn)) {
+			final SaveObjectsParams params = getParams(cmd,
+					SaveObjectsParams.class);
 			return wsmeth.saveObjects(params, getUser(cmd), token);
 		}
-		if ("listWorkspaces".equals(fn)) {
-			final ListWorkspaceInfoParams params = getParams(cmd, ListWorkspaceInfoParams.class);
+		if (LIST_WORKSPACES.equals(fn)) {
+			final ListWorkspaceInfoParams params = getParams(cmd,
+					ListWorkspaceInfoParams.class);
 			return wsmeth.listWorkspaceInfo(params, getUser(cmd));
 		}
-		if ("listWorkspaceOwners".equals(fn)) {
+		if (LIST_WORKSPACE_OWNERS.equals(fn)) {
+			getLogger().info(LIST_WORKSPACE_OWNERS);
 			return usersToStrings(ws.getAllWorkspaceOwners());
 		}
-		if ("grantModuleOwnership".equals(fn)) {
-			final GrantModuleOwnershipParams params = getParams(cmd, GrantModuleOwnershipParams.class);
+		if (GRANT_MODULE_OWNERSHIP.equals(fn)) {
+			final GrantModuleOwnershipParams params = getParams(cmd,
+					GrantModuleOwnershipParams.class);
+			getLogger().info(GRANT_MODULE_OWNERSHIP + " " + params.getMod() +
+					" " + params.getNewOwner());
 			wsmeth.grantModuleOwnership(params, null, true);
 			return null;
 		}
-		if ("removeModuleOwnership".equals(fn)) {
-			final RemoveModuleOwnershipParams params = getParams(cmd, RemoveModuleOwnershipParams.class);
+		if (REMOVE_MODULE_OWNERSHIP.equals(fn)) {
+			final RemoveModuleOwnershipParams params = getParams(cmd,
+					RemoveModuleOwnershipParams.class);
+			getLogger().info(REMOVE_MODULE_OWNERSHIP + " " + params.getMod() +
+					" " + params.getOldOwner());
 			wsmeth.removeModuleOwnership(params, null, true);
 			return null;
 		}
@@ -201,8 +254,8 @@ public class WorkspaceAdministration {
 			throws IOException {
 		final UObject p = input.getParams();
 		if (p == null) {
-			throw new NullPointerException("Method parameters " + clazz.getSimpleName()
-					+ " may not be null");
+			throw new NullPointerException("Method parameters " +
+					clazz.getSimpleName() + " may not be null");
 		}
 		try {
 			return MAPPER.readValue(p.getPlacedStream(), clazz);

--- a/src/us/kbase/workspace/kbase/WorkspaceAdministration.java
+++ b/src/us/kbase/workspace/kbase/WorkspaceAdministration.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import us.kbase.auth.AuthException;
 import us.kbase.auth.AuthToken;
 import us.kbase.common.service.JacksonTupleModule;
+import us.kbase.common.service.Tuple9;
 import us.kbase.common.service.UObject;
 import us.kbase.typedobj.exceptions.NoSuchPrivilegeException;
 import us.kbase.typedobj.exceptions.TypeStorageException;
@@ -167,34 +169,57 @@ public class WorkspaceAdministration {
 		if (CREATE_WORKSPACE.equals(fn)) {
 			final CreateWorkspaceParams params = getParams(cmd,
 					CreateWorkspaceParams.class);
-			return wsmeth.createWorkspace(params, getUser(cmd));
+			Tuple9<Long, String, String, String, Long, String, String, String,
+			Map<String, String>> ws =  wsmeth.createWorkspace(
+					params, getUser(cmd));
+			getLogger().info(CREATE_WORKSPACE + " " + ws.getE1() + " " +
+					ws.getE3());
+			return ws;
 		}
 		if (SET_PERMISSIONS.equals(fn)) {
 			final SetPermissionsParams params = getParams(cmd,
 					SetPermissionsParams.class);
+			//TODO maybe set perms should return wsinfo so can provide ID vs. name
+			getLogger().info(SET_PERMISSIONS + " " + params.getId() + " " +
+					params.getWorkspace() + " " + params.getNewPermission() +
+					" " + StringUtils.join(params.getUsers(), " "));
 			wsmeth.setPermissions(params, null, true);
 			return null;
 		}
 		if (GET_PERMISSIONS.equals(fn)) {
 			final WorkspaceIdentity params = getParams(cmd,
 					WorkspaceIdentity.class);
-			return wsmeth.getPermissions(params, getUser(cmd));
+			final WorkspaceUser user = getUser(cmd);
+			//TODO would be better if could provide ID vs. name
+			getLogger().info(GET_PERMISSIONS + " " + params.getId() + " " +
+					params.getWorkspace() + " " + user.getUser());
+			return wsmeth.getPermissions(params, user);
 		}
 		if (SET_GLOBAL_PERMISSION.equals(fn)) {
 			final SetGlobalPermissionsParams params = getParams(cmd,
 					SetGlobalPermissionsParams.class);
+			final WorkspaceUser user = getUser(cmd);
+			//TODO would be better if could provide ID vs. name
+			getLogger().info(SET_GLOBAL_PERMISSION + " " + params.getId() +
+					" " + params.getWorkspace() + " " +
+					params.getNewPermission() + " " + user.getUser());
 			wsmeth.setGlobalPermission(params, getUser(cmd));
 			return null;
 		}
 		if (SAVE_OBJECTS.equals(fn)) {
 			final SaveObjectsParams params = getParams(cmd,
 					SaveObjectsParams.class);
-			return wsmeth.saveObjects(params, getUser(cmd), token);
+			final WorkspaceUser user = getUser(cmd);
+			//method has its own logging
+			getLogger().info(SAVE_OBJECTS + " " + user.getUser());
+			return wsmeth.saveObjects(params, user, token);
 		}
 		if (LIST_WORKSPACES.equals(fn)) {
 			final ListWorkspaceInfoParams params = getParams(cmd,
 					ListWorkspaceInfoParams.class);
-			return wsmeth.listWorkspaceInfo(params, getUser(cmd));
+			final WorkspaceUser user = getUser(cmd);
+			getLogger().info(LIST_WORKSPACES + " " + user.getUser());
+			return wsmeth.listWorkspaceInfo(params, user);
 		}
 		if (LIST_WORKSPACE_OWNERS.equals(fn)) {
 			getLogger().info(LIST_WORKSPACE_OWNERS);

--- a/src/us/kbase/workspace/test/kbase/LoggingTest.java
+++ b/src/us/kbase/workspace/test/kbase/LoggingTest.java
@@ -1,0 +1,317 @@
+package us.kbase.workspace.test.kbase;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.ini4j.Ini;
+import org.ini4j.Profile.Section;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.productivity.java.syslog4j.SyslogIF;
+
+import us.kbase.auth.AuthService;
+import us.kbase.auth.AuthUser;
+import us.kbase.common.mongo.GetMongoDB;
+import us.kbase.common.mongo.exceptions.InvalidHostException;
+import us.kbase.common.service.JsonClientException;
+import us.kbase.common.service.UObject;
+import us.kbase.common.service.UnauthorizedException;
+import us.kbase.common.service.JsonServerSyslog.SyslogOutput;
+import us.kbase.common.test.TestException;
+import us.kbase.common.test.controllers.mongo.MongoController;
+import us.kbase.workspace.CreateWorkspaceParams;
+import us.kbase.workspace.ObjectSaveData;
+import us.kbase.workspace.RegisterTypespecParams;
+import us.kbase.workspace.SaveObjectsParams;
+import us.kbase.workspace.WorkspaceClient;
+import us.kbase.workspace.WorkspaceServer;
+import us.kbase.workspace.test.WorkspaceTestCommon;
+import us.kbase.workspace.test.kbase.JSONRPCLayerTester.ServerThread;
+
+import com.mongodb.DB;
+import com.mongodb.MongoClient;
+
+/** Tests application logging only - not the standard logging that comes with
+ * JsonServerServlet.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class LoggingTest {
+	
+	//TODO L go through all this crap and cut unnecessary stuff
+
+	private static final String DB_WS_NAME = "LoggingTest";
+	private static final String DB_TYPE_NAME = "LoggingTest_Types";
+
+	private static final String ATYPE = "SomeModule.AType";
+	private static final String BTYPE = "SomeModule.BType";
+	private static String USER1;
+	private static String USER2;
+	private static MongoController mongo;
+	private static WorkspaceServer SERVER;
+	private static WorkspaceClient CLIENT1;
+	private static WorkspaceClient CLIENT2;
+	private static AuthUser AUTH_USER1;
+	private static AuthUser AUTH_USER2;
+	private static WorkspaceClient CLIENT_NO_AUTH;
+	private static SysLogOutputMock logout;
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		logout = new SysLogOutputMock();
+		
+		USER1 = System.getProperty("test.user1");
+		USER2 = System.getProperty("test.user2");
+		if (USER1.equals(USER2)) {
+			throw new TestException("All the test users must be unique: " + 
+					StringUtils.join(Arrays.asList(USER1, USER2), " "));
+		}
+		String p1 = System.getProperty("test.pwd1");
+		String p2 = System.getProperty("test.pwd2");
+		
+//		WorkspaceTestCommon.stfuLoggers();
+		mongo = new MongoController(WorkspaceTestCommon.getMongoExe(),
+				Paths.get(WorkspaceTestCommon.getTempDir()),
+				WorkspaceTestCommon.useWiredTigerEngine());
+		System.out.println("Using mongo temp dir " + mongo.getTempDir());
+		
+		final String mongohost = "localhost:" + mongo.getServerPort();
+		MongoClient mongoClient = new MongoClient(mongohost);
+		
+		SERVER = startupWorkspaceServer(mongohost,
+				mongoClient.getDB(DB_WS_NAME), 
+				DB_TYPE_NAME, p1);
+		SERVER.changeSyslogOutput(logout);
+		int port = SERVER.getServerPort();
+		System.out.println("Started test server 1 on port " + port);
+		try {
+			CLIENT1 = new WorkspaceClient(new URL("http://localhost:" + port), USER1, p1);
+		} catch (UnauthorizedException ue) {
+			throw new TestException("Unable to login with test.user1: " + USER1 +
+					"\nPlease check the credentials in the test configuration.", ue);
+		}
+		try {
+			CLIENT2 = new WorkspaceClient(new URL("http://localhost:" + port), USER2, p2);
+		} catch (UnauthorizedException ue) {
+			throw new TestException("Unable to login with test.user2: " + USER2 +
+					"\nPlease check the credentials in the test configuration.", ue);
+		}
+		AUTH_USER1 = AuthService.login(USER1, p1);
+		AUTH_USER2 = AuthService.login(USER2, p2);
+
+		CLIENT_NO_AUTH = new WorkspaceClient(new URL("http://localhost:" + port));
+		CLIENT1.setIsInsecureHttpConnectionAllowed(true);
+		CLIENT2.setIsInsecureHttpConnectionAllowed(true);
+		CLIENT_NO_AUTH.setIsInsecureHttpConnectionAllowed(true);
+		CLIENT1.setStreamingModeOn(true); //for JSONRPCLayerLongTest
+		
+		//set up a basic type for test use that doesn't worry about type checking
+		CLIENT1.requestModuleOwnership("SomeModule");
+		administerCommand(CLIENT2, "approveModRequest", "module", "SomeModule");
+		CLIENT1.registerTypespec(new RegisterTypespecParams()
+			.withDryrun(0L)
+			.withSpec(
+					"module SomeModule {" + 
+						"/* @optional thing */" +
+						"typedef structure {" +
+							"string thing;" +
+						"} AType;" +
+						"/* @optional thing */" +
+						"typedef structure {" +
+							"string thing;" +
+						"} BType;" +
+					"};"
+					)
+			.withNewTypes(Arrays.asList("AType", "BType")));
+		CLIENT1.releaseModule("SomeModule");
+	}
+	
+	//TODO move to common, used everywhere
+	//http://quirkygba.blogspot.com/2009/11/setting-environment-variables-in-java.html
+	@SuppressWarnings("unchecked")
+	protected static Map<String, String> getenv() throws NoSuchFieldException,
+			SecurityException, IllegalArgumentException, IllegalAccessException {
+		Map<String, String> unmodifiable = System.getenv();
+		Class<?> cu = unmodifiable.getClass();
+		Field m = cu.getDeclaredField("m");
+		m.setAccessible(true);
+		return (Map<String, String>) m.get(unmodifiable);
+	}
+
+	public static void administerCommand(WorkspaceClient client,
+			String command, String... params)
+			throws IOException, JsonClientException {
+		Map<String, String> releasemod = new HashMap<String, String>();
+		releasemod.put("command", command);
+		for (int i = 0; i < params.length / 2; i++)
+			releasemod.put(params[i * 2], params[i * 2 + 1]);
+		client.administer(new UObject(releasemod));
+	}
+	
+	private static WorkspaceServer startupWorkspaceServer(String mongohost,
+			DB db, String typedb, String user1Password)
+			throws InvalidHostException, UnknownHostException, IOException,
+			NoSuchFieldException, IllegalAccessException, Exception,
+			InterruptedException {
+		WorkspaceTestCommon.initializeGridFSWorkspaceDB(db, typedb);
+		
+		//write the server config file:
+		File iniFile = File.createTempFile("test", ".cfg",
+				new File(WorkspaceTestCommon.getTempDir()));
+		if (iniFile.exists()) {
+			iniFile.delete();
+		}
+		System.out.println("Created temporary config file: " + iniFile.getAbsolutePath());
+		Ini ini = new Ini();
+		Section ws = ini.add("Workspace");
+		ws.add("mongodb-host", mongohost);
+		ws.add("mongodb-database", db.getName());
+		ws.add("backend-secret", "foo");
+		ws.add("ws-admin", USER2);
+		ws.add("kbase-admin-user", USER1);
+		ws.add("kbase-admin-pwd", user1Password);
+		ws.add("temp-dir", Paths.get(WorkspaceTestCommon.getTempDir()).resolve("tempForJSONRPCLayerTester"));
+		ws.add("ignore-handle-service", "true");
+		ini.store(iniFile);
+		iniFile.deleteOnExit();
+		
+		//set up env
+		Map<String, String> env = getenv();
+		env.put("KB_DEPLOYMENT_CONFIG", iniFile.getAbsolutePath());
+		env.put("KB_SERVICE_NAME", "Workspace");
+
+		WorkspaceServer.clearConfigForTests();
+		WorkspaceServer server = new WorkspaceServer();
+		new ServerThread(server).start();
+		System.out.println("Main thread waiting for server to start up");
+		while (server.getServerPort() == null) {
+			Thread.sleep(1000);
+		}
+		return server;
+	}
+	
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		if (SERVER != null) {
+			System.out.print("Killing server... ");
+			SERVER.stopServer();
+			System.out.println("Done");
+		}
+		if (mongo != null) {
+			System.out.println("destroying mongo temp files");
+			mongo.destroy(WorkspaceTestCommon.deleteTempFiles());
+		}
+	}
+
+	@Before
+	public void clearDB() throws Exception {
+		logout.reset();
+		DB wsdb1 = GetMongoDB.getDB("localhost:" + mongo.getServerPort(),
+				DB_WS_NAME);
+		WorkspaceTestCommon.destroyDB(wsdb1);
+	}
+	
+	private static class LogEvent {
+		public int level;
+		public String message;
+		
+		@Override
+		public String toString() {
+			StringBuilder builder = new StringBuilder();
+			builder.append("LogEvent [level=");
+			builder.append(level);
+			builder.append(", message=");
+			builder.append(message);
+			builder.append("]");
+			return builder.toString();
+		}
+	}
+	
+	private static class SysLogOutputMock extends SyslogOutput {
+		
+		public List<LogEvent> events = new LinkedList<LogEvent>(); 
+		
+		@Override
+		public void logToSystem(SyslogIF log, int level, String message) {
+			LogEvent e = new LogEvent();
+			e.level = level;
+			e.message = message;
+			events.add(e);
+		}
+		
+		@Override
+		public PrintWriter logToFile(File f, PrintWriter pw, int level,
+				String message) throws Exception {
+			throw new UnsupportedOperationException();
+		}
+		
+		public void reset() {
+			events.clear();
+		}
+	}
+	
+	private static class ExpectedLog {
+		
+		public int level;
+		public String ip;
+		public String method;
+		public String url;
+		public String fullMessage;
+		public String serviceName = "TestDocServer";
+
+		public ExpectedLog(int level, String ip, String method) {
+			this.level = level;
+			this.ip = ip;
+			this.method = method;
+		}
+		
+		public ExpectedLog withURL(String url) {
+			this.url = url;
+			return this;
+		}
+		
+		public ExpectedLog withFullMsg(String msg) {
+			this.fullMessage = msg;
+			return this;
+		}
+		
+		public ExpectedLog withServiceName(String name) {
+			this.serviceName = name;
+			return this;
+		}
+	}
+
+	@Test
+	public void saveObject() throws Exception {
+		String ws = "myws";
+		CLIENT1.createWorkspace(new CreateWorkspaceParams()
+				.withWorkspace(ws));
+		logout.reset();
+		List<ObjectSaveData> d = new LinkedList<ObjectSaveData>();
+		for (String name: Arrays.asList("foo", "bar", "baz")) {
+			d.add(new ObjectSaveData()
+					.withData(new UObject(new HashMap<String, Object>()))
+					.withName(name)
+					.withType(name.equals("bar") ? BTYPE : ATYPE));
+		}
+		CLIENT1.saveObjects(new SaveObjectsParams()
+				.withWorkspace(ws)
+				.withObjects(d));
+		for (LogEvent l: logout.events) {
+			System.out.println(l);
+		}
+	}
+}

--- a/src/us/kbase/workspace/test/kbase/LoggingTest.java
+++ b/src/us/kbase/workspace/test/kbase/LoggingTest.java
@@ -37,13 +37,17 @@ import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.workspace.CopyObjectParams;
 import us.kbase.workspace.CreateWorkspaceParams;
 import us.kbase.workspace.GetObjectInfoNewParams;
+import us.kbase.workspace.ListWorkspaceInfoParams;
 import us.kbase.workspace.ObjectIdentity;
 import us.kbase.workspace.ObjectSaveData;
 import us.kbase.workspace.RegisterTypespecParams;
 import us.kbase.workspace.RenameObjectParams;
 import us.kbase.workspace.SaveObjectsParams;
+import us.kbase.workspace.SetGlobalPermissionsParams;
+import us.kbase.workspace.SetPermissionsParams;
 import us.kbase.workspace.SubObjectIdentity;
 import us.kbase.workspace.WorkspaceClient;
+import us.kbase.workspace.WorkspaceIdentity;
 import us.kbase.workspace.WorkspaceServer;
 import us.kbase.workspace.test.WorkspaceTestCommon;
 import us.kbase.workspace.test.kbase.JSONRPCLayerTester.ServerThread;
@@ -659,6 +663,115 @@ public class LoggingTest {
 		checkLogging(convertAdminExp(Arrays.asList(
 				new AdminExp("start method", false),
 				new AdminExp("listWorkspaceOwners", true),
+				new AdminExp("end method", false))));
+		logout.reset();
+		
+	}
+	
+	@Test
+	public void adminWorkspaceCommands() throws Exception {
+		final String ws = "myws";
+		Map<String, Object> ac = new HashMap<String, Object>();
+		
+		// create workspace
+		ac.put("command", "createWorkspace");
+		ac.put("user", USER1);
+		ac.put("params", new CreateWorkspaceParams().withWorkspace(ws));
+		CLIENT2.administer(new UObject(ac));
+		checkLogging(convertAdminExp(Arrays.asList(
+				new AdminExp("start method", false),
+				new AdminExp("createWorkspace 1 " + USER1, true),
+				new AdminExp("end method", false))));
+		logout.reset();
+		
+		// set perms
+		ac.put("command", "setPermissions");
+		ac.remove("user");
+		ac.put("params", new SetPermissionsParams().withWorkspace(ws)
+				.withUsers(Arrays.asList(USER1, USER2))
+				.withNewPermission("w"));
+		CLIENT2.administer(new UObject(ac));
+		checkLogging(convertAdminExp(Arrays.asList(
+				new AdminExp("start method", false),
+				new AdminExp("setPermissions null myws w " + USER1 + " " +
+						USER2, true),
+				new AdminExp("end method", false))));
+		logout.reset();
+		
+		ac.put("params", new SetPermissionsParams().withId(1L)
+				.withUsers(Arrays.asList(USER2))
+				.withNewPermission("a"));
+		CLIENT2.administer(new UObject(ac));
+		checkLogging(convertAdminExp(Arrays.asList(
+				new AdminExp("start method", false),
+				new AdminExp("setPermissions 1 null a " + USER2, true),
+				new AdminExp("end method", false))));
+		logout.reset();
+		
+		// get perms
+		ac.put("command", "getPermissions");
+		ac.put("user", USER1);
+		ac.put("params", new WorkspaceIdentity().withWorkspace(ws));
+		CLIENT2.administer(new UObject(ac));
+		checkLogging(convertAdminExp(Arrays.asList(
+				new AdminExp("start method", false),
+				new AdminExp("getPermissions null myws " + USER1, true),
+				new AdminExp("end method", false))));
+		logout.reset();
+		
+		ac.put("params", new WorkspaceIdentity().withId(1L));
+		CLIENT2.administer(new UObject(ac));
+		checkLogging(convertAdminExp(Arrays.asList(
+				new AdminExp("start method", false),
+				new AdminExp("getPermissions 1 null " + USER1, true),
+				new AdminExp("end method", false))));
+		logout.reset();
+		
+		// set global
+		ac.put("command", "setGlobalPermission");
+		ac.put("user", USER1);
+		ac.put("params", new SetGlobalPermissionsParams().withWorkspace(ws)
+				.withNewPermission("r"));
+		CLIENT2.administer(new UObject(ac));
+		checkLogging(convertAdminExp(Arrays.asList(
+				new AdminExp("start method", false),
+				new AdminExp("setGlobalPermission null myws r " + USER1, true),
+				new AdminExp("end method", false))));
+		logout.reset();
+		
+		ac.put("params", new SetGlobalPermissionsParams().withId(1L)
+				.withNewPermission("n"));
+		CLIENT2.administer(new UObject(ac));
+		checkLogging(convertAdminExp(Arrays.asList(
+				new AdminExp("start method", false),
+				new AdminExp("setGlobalPermission 1 null n " + USER1, true),
+				new AdminExp("end method", false))));
+		logout.reset();
+		
+		// save objs
+		ac.put("command", "saveObjects");
+		ac.put("user", USER1);
+		ac.put("params", new SaveObjectsParams().withWorkspace(ws)
+				.withObjects(Arrays.asList(new ObjectSaveData()
+						.withData(new UObject(new HashMap<String, String>()))
+						.withName("foo")
+						.withType(ATYPE))));
+		CLIENT2.administer(new UObject(ac));
+		checkLogging(convertAdminExp(Arrays.asList(
+				new AdminExp("start method", false),
+				new AdminExp("saveObjects " + USER1, true),
+				new AdminExp("Object 1/1/1 SomeModule.AType-1.0", true),
+				new AdminExp("end method", false))));
+		logout.reset();
+		
+		// list ws
+		ac.put("command", "listWorkspaces");
+		ac.put("user", USER1);
+		ac.put("params", new ListWorkspaceInfoParams());
+		CLIENT2.administer(new UObject(ac));
+		checkLogging(convertAdminExp(Arrays.asList(
+				new AdminExp("start method", false),
+				new AdminExp("listWorkspaces " + USER1, true),
 				new AdminExp("end method", false))));
 		logout.reset();
 		


### PR DESCRIPTION
Add logging to the administer() function beyond that automatically provided in JsonServerServlet. Logs which subfunction was called, and in most cases, the arguments to the subfunction.

Also add tests for existing application logging.