### PR TITLE
Remove skip, deprecate list_referencing_object_counts

### DIFF
--- a/docsource/knownuserbugs.rst
+++ b/docsource/knownuserbugs.rst
@@ -1,12 +1,5 @@
 Known user-facing bugs
 ======================
 
-* The ``list_objects`` ``skip`` parameter behaves unintuitively and is
-  deprecated and will be removed in a future version. The same object may
-  appear in ``list_objects`` results even when the ``skip`` parameter setting
-  should ensure that each set of returned objects is disjoint with all the
-  others. 
-* The completion time and cpu load of the ``list_objects`` API call is
-  proportional to the value of the ``skip`` parameter. Skipping
-  hundreds of thousands of objects is strongly discouraged. ``skip`` will be
-  removed from the API at some point in the future.
+.. todo::
+   Find or create some user-facing bugs

--- a/docsource/releasenotes.rst
+++ b/docsource/releasenotes.rst
@@ -1,6 +1,21 @@
 Workspace service release notes
 ===============================
 
+VERSION: 0.5.0 (Released TBD)
+-----------------------------
+
+BACKWARDS INCOMPATIBILITIES:
+
+* The ``skip`` parameter of ``list_objects`` has been removed.
+
+NEW FEATURES:
+
+* None
+
+UPDATED FEATURES / MAJOR BUG FIXES:
+
+* ``list_referencing_object_counts`` has been deprecated.
+
 VERSION: 0.4.0 (Released 2/2/16)
 -----------------------------
 

--- a/src/us/kbase/workspace/ListObjectsParams.java
+++ b/src/us/kbase/workspace/ListObjectsParams.java
@@ -56,8 +56,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  *                         metadata will be null.
  *                 boolean excludeGlobal - exclude objects in global workspaces. This
  *                         parameter only has an effect when filtering by types alone.
- *                 int skip - DEPRECATED. Skip the first X objects. Maximum value is 2^31,
- *                         skip values < 0 are treated as 0, the default.
  *                 int limit - limit the output to X objects. Default and maximum value
  *                         is 10000. Limit values < 1 are treated as 10000, the default.
  * </pre>
@@ -82,7 +80,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "showAllVersions",
     "includeMetadata",
     "excludeGlobal",
-    "skip",
     "limit"
 })
 public class ListObjectsParams {
@@ -119,8 +116,6 @@ public class ListObjectsParams {
     private java.lang.Long includeMetadata;
     @JsonProperty("excludeGlobal")
     private java.lang.Long excludeGlobal;
-    @JsonProperty("skip")
-    private java.lang.Long skip;
     @JsonProperty("limit")
     private java.lang.Long limit;
     private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
@@ -365,21 +360,6 @@ public class ListObjectsParams {
         return this;
     }
 
-    @JsonProperty("skip")
-    public java.lang.Long getSkip() {
-        return skip;
-    }
-
-    @JsonProperty("skip")
-    public void setSkip(java.lang.Long skip) {
-        this.skip = skip;
-    }
-
-    public ListObjectsParams withSkip(java.lang.Long skip) {
-        this.skip = skip;
-        return this;
-    }
-
     @JsonProperty("limit")
     public java.lang.Long getLimit() {
         return limit;
@@ -407,7 +387,7 @@ public class ListObjectsParams {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((((((((((((((((((((((((((((((("ListObjectsParams"+" [workspaces=")+ workspaces)+", ids=")+ ids)+", type=")+ type)+", perm=")+ perm)+", savedby=")+ savedby)+", meta=")+ meta)+", after=")+ after)+", before=")+ before)+", minObjectID=")+ minObjectID)+", maxObjectID=")+ maxObjectID)+", showDeleted=")+ showDeleted)+", showOnlyDeleted=")+ showOnlyDeleted)+", showHidden=")+ showHidden)+", showAllVersions=")+ showAllVersions)+", includeMetadata=")+ includeMetadata)+", excludeGlobal=")+ excludeGlobal)+", skip=")+ skip)+", limit=")+ limit)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((((((((((((((((((("ListObjectsParams"+" [workspaces=")+ workspaces)+", ids=")+ ids)+", type=")+ type)+", perm=")+ perm)+", savedby=")+ savedby)+", meta=")+ meta)+", after=")+ after)+", before=")+ before)+", minObjectID=")+ minObjectID)+", maxObjectID=")+ maxObjectID)+", showDeleted=")+ showDeleted)+", showOnlyDeleted=")+ showOnlyDeleted)+", showHidden=")+ showHidden)+", showAllVersions=")+ showAllVersions)+", includeMetadata=")+ includeMetadata)+", excludeGlobal=")+ excludeGlobal)+", limit=")+ limit)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/src/us/kbase/workspace/WorkspaceClient.java
+++ b/src/us/kbase/workspace/WorkspaceClient.java
@@ -590,10 +590,13 @@ public class WorkspaceClient {
     /**
      * <p>Original spec-file function name: list_referencing_object_counts</p>
      * <pre>
+     * DEPRECATED
+     *         
      * List the number of times objects have been referenced.
      * This count includes both provenance and object-to-object references
      * and, unlike list_referencing_objects, includes objects that are
      * inaccessible to the user.
+     * @deprecated
      * </pre>
      * @param   objectIds   instance of list of type {@link us.kbase.workspace.ObjectIdentity ObjectIdentity}
      * @return   parameter "counts" of list of Long

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -2,7 +2,6 @@ package us.kbase.workspace;
 
 import java.util.List;
 import java.util.Map;
-
 import us.kbase.auth.AuthToken;
 import us.kbase.common.service.JsonServerMethod;
 import us.kbase.common.service.JsonServerServlet;
@@ -754,10 +753,13 @@ public class WorkspaceServer extends JsonServerServlet {
     /**
      * <p>Original spec-file function name: list_referencing_object_counts</p>
      * <pre>
+     * DEPRECATED
+     *         
      * List the number of times objects have been referenced.
      * This count includes both provenance and object-to-object references
      * and, unlike list_referencing_objects, includes objects that are
      * inaccessible to the user.
+     * @deprecated
      * </pre>
      * @param   objectIds   instance of list of type {@link us.kbase.workspace.ObjectIdentity ObjectIdentity}
      * @return   parameter "counts" of list of Long
@@ -956,7 +958,6 @@ public class WorkspaceServer extends JsonServerServlet {
 			.withShowAllVersions(longToBoolean(params.getShowAllVersions()))
 			.withIncludeMetaData(longToBoolean(params.getIncludeMetadata()))
 			.withExcludeGlobal(longToBoolean(params.getExcludeGlobal()))
-			.withSkip(longToInt(params.getSkip(), "Skip", -1))
 			.withLimit(longToInt(params.getLimit(), "Limit", -1));
 		
 		returnVal = objInfoToTuple(ws.listObjects(lop), false);

--- a/src/us/kbase/workspace/database/GetObjectInformationParameters.java
+++ b/src/us/kbase/workspace/database/GetObjectInformationParameters.java
@@ -26,7 +26,6 @@ public class GetObjectInformationParameters {
 	final private boolean showOnlyDeleted;
 	final private boolean showAllVers;
 	final private boolean includeMetaData;
-	final private int skip;
 	final private int limit;
 	
 	GetObjectInformationParameters(
@@ -43,7 +42,6 @@ public class GetObjectInformationParameters {
 			final boolean showOnlyDeleted,
 			final boolean showAllVers,
 			final boolean includeMetaData,
-			final int skip,
 			final int limit) {
 		super();
 		this.pset = pset;
@@ -59,7 +57,6 @@ public class GetObjectInformationParameters {
 		this.showOnlyDeleted = showOnlyDeleted;
 		this.showAllVers = showAllVers;
 		this.includeMetaData = includeMetaData;
-		this.skip = skip;
 		this.limit = limit;
 	}
 
@@ -156,13 +153,6 @@ public class GetObjectInformationParameters {
 	 */
 	public boolean isIncludeMetaData() {
 		return includeMetaData;
-	}
-
-	/** Get the number of objects to skip before listing objects.
-	 * @return the number of objects to skip.
-	 */
-	public int getSkip() {
-		return skip;
 	}
 
 	/** Get the maximum number of objects to list.

--- a/src/us/kbase/workspace/database/ListObjectsParameters.java
+++ b/src/us/kbase/workspace/database/ListObjectsParameters.java
@@ -38,7 +38,6 @@ public class ListObjectsParameters {
 	private boolean showAllVers = false;
 	private boolean includeMetaData = false;
 	private boolean excludeGlobal = false;
-	private int skip = -1;
 	private int limit = MAX_INFO_COUNT;
 	
 	/** Create a set of parameters for calling the list objects method.
@@ -367,27 +366,6 @@ public class ListObjectsParameters {
 		return this;
 	}
 
-	/** Get the number of objects to skip before listing objects.
-	 * @return the number of objects to skip.
-	 */
-	public int getSkip() {
-		return skip;
-	}
-
-	/** Get the number of objects to skip before listing objects.
-	 * If skip < 0, skip is set to 0.
-	 * @param skip the number of objects to skip.
-	 * @return this ListObjectsParameters instance.
-	 */
-	public ListObjectsParameters withSkip(final int skip) {
-		if (skip < 0) {
-			this.skip = 0;
-		} else {
-			this.skip = skip;
-		}
-		return this;
-	}
-
 	/** Get the maximum number of objects to list.
 	 * @return the maximum number of objects to list.
 	 */
@@ -417,7 +395,7 @@ public class ListObjectsParameters {
 		return new GetObjectInformationParameters(
 				perms, type, savers, meta, after, before, minObjectID,
 				maxObjectID, showHidden, showDeleted, showOnlyDeleted,
-				showAllVers, includeMetaData, skip, limit);
+				showAllVers, includeMetaData, limit);
 		
 	}
 }

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -72,7 +72,6 @@ public class Workspace {
 	
 	//TODO limit all methods that return a set or list or map
 	//TODO generalize descent into DAG for all methods
-	//TODO deprecate skip
 	
 	//TODO general unit tests
 	//TODO BIG GC garbage collection - make a static thread that calls a gc() method, waits until all reads done - read counting, read methods must register to static object. Set latest object version on version deletion. How delete entire object? have deleted obj collection with 30 day expiration?

--- a/src/us/kbase/workspace/database/mongo/ObjectInfoUtils.java
+++ b/src/us/kbase/workspace/database/mongo/ObjectInfoUtils.java
@@ -83,7 +83,7 @@ public class ObjectInfoUtils {
 		}
 		final DBObject verq = buildQuery(params);
 		final DBObject projection = buildProjection(params);
-		final DBCursor cur = buildCursor(verq, projection, params.getSkip());
+		final DBCursor cur = buildCursor(verq, projection);
 		
 		//querying on versions directly so no need to worry about race 
 		//condition where the workspace object was saved but no versions
@@ -121,18 +121,13 @@ public class ObjectInfoUtils {
 
 	private DBCursor buildCursor(
 			final DBObject verq,
-			final DBObject projection,
-			final int skip)
+			final DBObject projection)
 			throws WorkspaceCommunicationException {
 		final DBCursor cur;
 		try {
 			cur = query.getDatabase().getCollection(
 					query.getVersionCollection())
 					.find(verq, projection);
-			//TODO skip is deprecated, remove when possible
-			if (skip > 0) {
-				cur.skip(skip);
-			}
 		} catch (MongoException me) {
 			throw new WorkspaceCommunicationException(
 					"There was a problem communicating with the database", me);

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
@@ -2227,7 +2227,7 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 	}
 	
 	@Test
-	public void listObjectsPagination() throws Exception {
+	public void listObjectsLimit() throws Exception {
 		String ws = "pagination";
 		CLIENT1.createWorkspace(new CreateWorkspaceParams().withWorkspace(ws));
 		
@@ -2240,19 +2240,15 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 				.withObjects(objs));
 		
 		//this depends on the natural sort order of mongo
-		checkObjectPagination(ws, null, null, 1, 200);
-		checkObjectPagination(ws, -1L, 0L, 1, 200);
-		checkObjectPagination(ws, -1L, 50L, 1, 50);
-		checkObjectPagination(ws, 100L, 50L, 101, 150);
-		checkObjectPagination(ws, 100L, 100L, 101, 200);
-		checkObjectPagination(ws, 150L, 100L, 151, 200);
-		checkObjectPagination(ws, 150L, 1L, 151, 151);
-		checkObjectPagination(ws, 200L, -1L, 2, 1); //hack
+		checkObjectPagination(ws, null, 1, 200);
+		checkObjectPagination(ws, 0L, 1, 200);
+		checkObjectPagination(ws, 1L, 1, 1);
+		checkObjectPagination(ws, 50L, 1, 50);
+		checkObjectPagination(ws, 200L, 1, 200);
+		checkObjectPagination(ws, 201L, 1, 200);
 		
 		failListObjects(Arrays.asList(ws), null, null, null, null, 0L, 0L,
-				0L, 0L, 4000000000L, 1L, "Skip can be no greater than 2147483647");
-		failListObjects(Arrays.asList(ws), null, null, null, null, 0L, 0L,
-				0L, 0L, 1L, 4000000000L, "Limit can be no greater than 2147483647");
+				0L, 0L, 4000000000L, "Limit can be no greater than 2147483647");
 	}
 	
 	@Test
@@ -2532,12 +2528,14 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 		assertThat("one obj list returned", retrefs.size(), is(1));
 		assertThat("two refs returned", retrefs.get(0).size(), is(2));
 		compareObjectInfo(retrefs.get(0), Arrays.asList(ref, prov), false);
+		@SuppressWarnings("deprecation")
 		List<Long> refcnts = CLIENT1.listReferencingObjectCounts(loi);
 		assertThat("got correct refcounts", refcnts, is(Arrays.asList(2L)));
 		
 		loi.set(0, new ObjectIdentity().withRef("referingobjs/std/2"));
 		try {
-			refcnts = CLIENT1.listReferencingObjectCounts(loi);
+			@SuppressWarnings({ "deprecation", "unused" })
+			List<Long> foo = CLIENT1.listReferencingObjectCounts(loi);
 			fail("got ref counts with bad obj id");
 		} catch (ServerException se) {
 			assertThat("correct excep message", se.getLocalizedMessage(),

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
@@ -1034,11 +1034,11 @@ public class JSONRPCLayerTester {
 	}
 
 	protected void checkObjectPagination(String wsname,
-			Long skip, Long limit, int minid, int maxid) 
+			Long limit, int minid, int maxid) 
 			throws Exception {
 		List<Tuple11<Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>>> res =
 				CLIENT1.listObjects(new ListObjectsParams()
-				.withWorkspaces(Arrays.asList(wsname)).withSkip(skip)
+				.withWorkspaces(Arrays.asList(wsname))
 				.withLimit(limit));
 				
 		assertThat("correct number of objects returned", res.size(), is(maxid - minid + 1));
@@ -1114,19 +1114,19 @@ public class JSONRPCLayerTester {
 			Long showDeleted, Long allVers, Long includeMeta, String exp)
 			throws Exception {
 		failListObjects(wsnames, wsids, type, perm, meta, showHidden,
-				showDeleted, allVers, includeMeta, -1, -1, exp);
+				showDeleted, allVers, includeMeta, -1, exp);
 	}
 
 	protected void failListObjects(List<String> wsnames, List<Long> wsids,
 			String type, String perm, Map<String, String> meta, Long showHidden,
-			Long showDeleted, Long allVers, Long includeMeta, long skip, long limit, String exp)
+			Long showDeleted, Long allVers, Long includeMeta, long limit, String exp)
 			throws Exception {
 		try {
 			CLIENT1.listObjects(new ListObjectsParams().withWorkspaces(wsnames)
 					.withIds(wsids).withType(type).withShowHidden(showHidden)
 					.withShowDeleted(showDeleted).withShowAllVersions(allVers)
 					.withIncludeMetadata(includeMeta).withPerm(perm).withMeta(meta)
-					.withSkip(skip).withLimit(limit));
+					.withLimit(limit));
 			fail("listed objects with bad params");
 		} catch (ServerException se) {
 			assertThat("correct excep message", se.getLocalizedMessage(),

--- a/src/us/kbase/workspace/test/workspace/WorkspaceLongTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceLongTest.java
@@ -255,7 +255,7 @@ public class WorkspaceLongTest extends WorkspaceTester {
 	}
 	
 	@Test
-	public void listObjectsPagination() throws Exception {
+	public void listObjectsLimit() throws Exception {
 		WorkspaceUser user = new WorkspaceUser("pagUser");
 		WorkspaceIdentifier wsi = new WorkspaceIdentifier("pagination");
 		ws.createWorkspace(user, wsi.getName(), false, null, null).getId();
@@ -268,15 +268,12 @@ public class WorkspaceLongTest extends WorkspaceTester {
 		ws.saveObjects(user, wsi, objs, getIdFactory());
 		
 		//this depends on the natural sort order of mongo
-		checkObjectPagination(user, wsi, -1, 0, 1, 10000);
-		checkObjectPagination(user, wsi, -1, 10001, 1, 10000);
-		checkObjectPagination(user, wsi, -1, 1000000, 1, 10000);
-		checkObjectPagination(user, wsi, -1, 5000, 1, 5000);
-		checkObjectPagination(user, wsi, 10000, 5000, 10001, 15000);
-		checkObjectPagination(user, wsi, 10000, 10000, 10001, 20000);
-		checkObjectPagination(user, wsi, 15000, 10000, 15001, 20000);
-		checkObjectPagination(user, wsi, 15000, 1, 15001, 15001);
-		checkObjectPagination(user, wsi, 20000, -1, 2, 1); //hack so the method expects 0 objects
+		checkObjectLimit(user, wsi, 0, 1, 10000);
+		checkObjectLimit(user, wsi, 1, 1, 1);
+		checkObjectLimit(user, wsi, 10000, 1, 10000);
+		checkObjectLimit(user, wsi, 10001, 1, 10000);
+		checkObjectLimit(user, wsi, 1000000, 1, 10000);
+		checkObjectLimit(user, wsi, 5000, 1, 5000);
 	}
 	
 	//this test takes FOREVER and doesn't actually test anything, it's a performance measurement

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -1281,20 +1281,20 @@ public class WorkspaceTester {
 	}
 	
 	/* depends on inherent mongo ordering */
-	protected void checkObjectPagination(WorkspaceUser user, WorkspaceIdentifier wsi,
-			int skip, int limit, int minid, int maxid)
+	protected void checkObjectLimit(WorkspaceUser user, WorkspaceIdentifier wsi,
+			int limit, int minid, int maxid)
 			throws Exception {
-		checkObjectPagination(user, wsi, skip, limit, minid, maxid,
+		checkObjectLimit(user, wsi, limit, minid, maxid,
 				new HashSet<Long>());
 	}
 	
 	/* depends on inherent mongo ordering */
-	protected void checkObjectPagination(WorkspaceUser user, WorkspaceIdentifier wsi,
-			int skip, int limit, int minid, int maxid, Set<Long> exlude) 
+	protected void checkObjectLimit(WorkspaceUser user, WorkspaceIdentifier wsi,
+			int limit, int minid, int maxid, Set<Long> exlude) 
 			throws Exception {
 		List<ObjectInformation> res = ws.listObjects(
 				new ListObjectsParameters(user, Arrays.asList(wsi))
-				.withSkip(skip).withLimit(limit));
+				.withLimit(limit));
 		assertThat("correct number of objects returned", res.size(),
 				is(maxid - minid + 1 - exlude.size()));
 		for (ObjectInformation oi: res) {
@@ -1303,8 +1303,8 @@ public class WorkspaceTester {
 						oi.getObjectId(), minid, maxid));
 			}
 			if (exlude.contains(oi.getObjectId())) {
-				fail("Got object ID that should have been exluded: "
-						+ oi.getObjectId());
+				fail("Got object ID that should have been excluded: " +
+						oi.getObjectId());
 			}
 		}
 	}

--- a/workspace.spec
+++ b/workspace.spec
@@ -908,12 +908,16 @@ module Workspace {
 	funcdef list_referencing_objects(list<ObjectIdentity> object_ids)
 		returns (list<list<object_info>> referrers) authentication optional;
 		
-	/* 
+	/*
+		DEPRECATED
+	
 		List the number of times objects have been referenced.
 		
 		This count includes both provenance and object-to-object references
 		and, unlike list_referencing_objects, includes objects that are
 		inaccessible to the user.
+		
+		@deprecated
 	*/
 	funcdef list_referencing_object_counts(list<ObjectIdentity> object_ids)
 		returns (list<int> counts) authentication optional;
@@ -1082,8 +1086,6 @@ module Workspace {
 			metadata will be null.
 		boolean excludeGlobal - exclude objects in global workspaces. This
 			parameter only has an effect when filtering by types alone.
-		int skip - DEPRECATED. Skip the first X objects. Maximum value is 2^31,
-			skip values < 0 are treated as 0, the default.
 		int limit - limit the output to X objects. Default and maximum value
 			is 10000. Limit values < 1 are treated as 10000, the default.
 		
@@ -1105,7 +1107,6 @@ module Workspace {
 		boolean showAllVersions;
 		boolean includeMetadata;
 		boolean excludeGlobal;
-		int skip;
 		int limit;
 	} ListObjectsParams;
 	


### PR DESCRIPTION
Skip has all sorts of bad behavior associated with it which has been
discussed ad nauseum

LROC is not really useful generally - this type of thing should be done
in the nightly metrics, if at all. Also, the current plan for GC (if we
ever get around to it) would make the current implementation break, and
alternate implementations would be much slower.