### PR TITLE
Accept and emit Unix epoch times where possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,22 +69,18 @@ compile-java-client:
 	$(ANT) compile_client
 
 compile-typespec-java:
-	gen_java_types -S -o . -u $(URL) $(SERVICE).spec
-	-rm lib/*.jar
+	kb-sdk compile  --java --javasrc src --javasrv --out . \
+		--url $(URL) $(SERVICE).spec
+
 
 compile-typespec:
-	mkdir -p lib/biokbase/$(SERVICE)
-	touch lib/biokbase/__init__.py # do not include code in biokbase/__init__.py
-	touch lib/biokbase/$(SERVICE)/__init__.py 
-	mkdir -p lib/javascript/$(SERVICE)
-	compile_typespec \
-		--client Bio::KBase::$(SERVICE)::Client \
-		--py biokbase.$(SERVICE).client \
-		--js javascript/$(SERVICE)/Client \
+	kb-sdk compile \
+		--out lib \
+		--jsclname javascript/$(SERVICE)/Client \
+		--plclname Bio::KBase::$(SERVICE)::Client \
+		--pyclname biokbase.$(SERVICE).client \
 		--url $(URL) \
-		$(SERVICE).spec lib
-	-rm lib/$(SERVICE_CAPS)Server.p?
-	-rm lib/$(SERVICE_CAPS)Impl.p?
+		$(SERVICE).spec
 
 # configure endpoints used by scripts, and possibly other script runtime options in the future
 configure-scripts:

--- a/docsource/releasenotes.rst
+++ b/docsource/releasenotes.rst
@@ -12,7 +12,9 @@ UPDATED FEATURES / MAJOR BUG FIXES:
 
 * Added the ``custom``, ``subactions``, and ``caller`` fields to
   ``ProvenanceAction``.
-* Added original workspace ID to the data returned by get_objects* methdos.
+* Added original workspace ID to the data returned by get_objects* methods.
+* Unix epoch times are now accepted and emitted where possible (e.g. not in 
+  tuples) as well as string timestamps.
 
 VERSION: 0.4.0 (Released 2/2/16)
 --------------------------------

--- a/lib/Bio/KBase/workspace/Client.pm
+++ b/lib/Bio/KBase/workspace/Client.pm
@@ -1650,6 +1650,7 @@ obj_id is an int
 usermeta is a reference to a hash where the key is a string and the value is a string
 ProvenanceAction is a reference to a hash where the following keys are defined:
 	time has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	caller has a value which is a string
 	service has a value which is a string
 	service_ver has a value which is a string
@@ -1667,12 +1668,14 @@ ProvenanceAction is a reference to a hash where the following keys are defined:
 	custom has a value which is a reference to a hash where the key is a string and the value is a string
 	description has a value which is a string
 timestamp is a string
+epoch is an int
 obj_ref is a string
 ExternalDataUnit is a reference to a hash where the following keys are defined:
 	resource_name has a value which is a string
 	resource_url has a value which is a string
 	resource_version has a value which is a string
 	resource_release_date has a value which is a Workspace.timestamp
+	resource_release_epoch has a value which is a Workspace.epoch
 	data_url has a value which is a string
 	data_id has a value which is a string
 	description has a value which is a string
@@ -1725,6 +1728,7 @@ obj_id is an int
 usermeta is a reference to a hash where the key is a string and the value is a string
 ProvenanceAction is a reference to a hash where the following keys are defined:
 	time has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	caller has a value which is a string
 	service has a value which is a string
 	service_ver has a value which is a string
@@ -1742,12 +1746,14 @@ ProvenanceAction is a reference to a hash where the following keys are defined:
 	custom has a value which is a reference to a hash where the key is a string and the value is a string
 	description has a value which is a string
 timestamp is a string
+epoch is an int
 obj_ref is a string
 ExternalDataUnit is a reference to a hash where the following keys are defined:
 	resource_name has a value which is a string
 	resource_url has a value which is a string
 	resource_version has a value which is a string
 	resource_release_date has a value which is a Workspace.timestamp
+	resource_release_epoch has a value which is a Workspace.epoch
 	data_url has a value which is a string
 	data_id has a value which is a string
 	description has a value which is a string
@@ -2004,6 +2010,7 @@ ObjectProvenanceInfo is a reference to a hash where the following keys are defin
 	creator has a value which is a Workspace.username
 	orig_wsid has a value which is a Workspace.ws_id
 	created has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	refs has a value which is a reference to a list where each element is a Workspace.obj_ref
 	copied has a value which is a Workspace.obj_ref
 	copy_source_inaccessible has a value which is a Workspace.boolean
@@ -2028,6 +2035,7 @@ username is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
 ProvenanceAction is a reference to a hash where the following keys are defined:
 	time has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	caller has a value which is a string
 	service has a value which is a string
 	service_ver has a value which is a string
@@ -2044,11 +2052,13 @@ ProvenanceAction is a reference to a hash where the following keys are defined:
 	subactions has a value which is a reference to a list where each element is a Workspace.SubAction
 	custom has a value which is a reference to a hash where the key is a string and the value is a string
 	description has a value which is a string
+epoch is an int
 ExternalDataUnit is a reference to a hash where the following keys are defined:
 	resource_name has a value which is a string
 	resource_url has a value which is a string
 	resource_version has a value which is a string
 	resource_release_date has a value which is a Workspace.timestamp
+	resource_release_epoch has a value which is a Workspace.epoch
 	data_url has a value which is a string
 	data_id has a value which is a string
 	description has a value which is a string
@@ -2089,6 +2099,7 @@ ObjectProvenanceInfo is a reference to a hash where the following keys are defin
 	creator has a value which is a Workspace.username
 	orig_wsid has a value which is a Workspace.ws_id
 	created has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	refs has a value which is a reference to a list where each element is a Workspace.obj_ref
 	copied has a value which is a Workspace.obj_ref
 	copy_source_inaccessible has a value which is a Workspace.boolean
@@ -2113,6 +2124,7 @@ username is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
 ProvenanceAction is a reference to a hash where the following keys are defined:
 	time has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	caller has a value which is a string
 	service has a value which is a string
 	service_ver has a value which is a string
@@ -2129,11 +2141,13 @@ ProvenanceAction is a reference to a hash where the following keys are defined:
 	subactions has a value which is a reference to a list where each element is a Workspace.SubAction
 	custom has a value which is a reference to a hash where the key is a string and the value is a string
 	description has a value which is a string
+epoch is an int
 ExternalDataUnit is a reference to a hash where the following keys are defined:
 	resource_name has a value which is a string
 	resource_url has a value which is a string
 	resource_version has a value which is a string
 	resource_release_date has a value which is a Workspace.timestamp
+	resource_release_epoch has a value which is a Workspace.epoch
 	data_url has a value which is a string
 	data_id has a value which is a string
 	description has a value which is a string
@@ -2238,6 +2252,7 @@ ObjectData is a reference to a hash where the following keys are defined:
 	creator has a value which is a Workspace.username
 	orig_wsid has a value which is a Workspace.ws_id
 	created has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	refs has a value which is a reference to a list where each element is a Workspace.obj_ref
 	copied has a value which is a Workspace.obj_ref
 	copy_source_inaccessible has a value which is a Workspace.boolean
@@ -2262,6 +2277,7 @@ username is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
 ProvenanceAction is a reference to a hash where the following keys are defined:
 	time has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	caller has a value which is a string
 	service has a value which is a string
 	service_ver has a value which is a string
@@ -2278,11 +2294,13 @@ ProvenanceAction is a reference to a hash where the following keys are defined:
 	subactions has a value which is a reference to a list where each element is a Workspace.SubAction
 	custom has a value which is a reference to a hash where the key is a string and the value is a string
 	description has a value which is a string
+epoch is an int
 ExternalDataUnit is a reference to a hash where the following keys are defined:
 	resource_name has a value which is a string
 	resource_url has a value which is a string
 	resource_version has a value which is a string
 	resource_release_date has a value which is a Workspace.timestamp
+	resource_release_epoch has a value which is a Workspace.epoch
 	data_url has a value which is a string
 	data_id has a value which is a string
 	description has a value which is a string
@@ -2324,6 +2342,7 @@ ObjectData is a reference to a hash where the following keys are defined:
 	creator has a value which is a Workspace.username
 	orig_wsid has a value which is a Workspace.ws_id
 	created has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	refs has a value which is a reference to a list where each element is a Workspace.obj_ref
 	copied has a value which is a Workspace.obj_ref
 	copy_source_inaccessible has a value which is a Workspace.boolean
@@ -2348,6 +2367,7 @@ username is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
 ProvenanceAction is a reference to a hash where the following keys are defined:
 	time has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	caller has a value which is a string
 	service has a value which is a string
 	service_ver has a value which is a string
@@ -2364,11 +2384,13 @@ ProvenanceAction is a reference to a hash where the following keys are defined:
 	subactions has a value which is a reference to a list where each element is a Workspace.SubAction
 	custom has a value which is a reference to a hash where the key is a string and the value is a string
 	description has a value which is a string
+epoch is an int
 ExternalDataUnit is a reference to a hash where the following keys are defined:
 	resource_name has a value which is a string
 	resource_url has a value which is a string
 	resource_version has a value which is a string
 	resource_release_date has a value which is a Workspace.timestamp
+	resource_release_epoch has a value which is a Workspace.epoch
 	data_url has a value which is a string
 	data_id has a value which is a string
 	description has a value which is a string
@@ -2478,6 +2500,7 @@ ObjectData is a reference to a hash where the following keys are defined:
 	creator has a value which is a Workspace.username
 	orig_wsid has a value which is a Workspace.ws_id
 	created has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	refs has a value which is a reference to a list where each element is a Workspace.obj_ref
 	copied has a value which is a Workspace.obj_ref
 	copy_source_inaccessible has a value which is a Workspace.boolean
@@ -2502,6 +2525,7 @@ username is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
 ProvenanceAction is a reference to a hash where the following keys are defined:
 	time has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	caller has a value which is a string
 	service has a value which is a string
 	service_ver has a value which is a string
@@ -2518,11 +2542,13 @@ ProvenanceAction is a reference to a hash where the following keys are defined:
 	subactions has a value which is a reference to a list where each element is a Workspace.SubAction
 	custom has a value which is a reference to a hash where the key is a string and the value is a string
 	description has a value which is a string
+epoch is an int
 ExternalDataUnit is a reference to a hash where the following keys are defined:
 	resource_name has a value which is a string
 	resource_url has a value which is a string
 	resource_version has a value which is a string
 	resource_release_date has a value which is a Workspace.timestamp
+	resource_release_epoch has a value which is a Workspace.epoch
 	data_url has a value which is a string
 	data_id has a value which is a string
 	description has a value which is a string
@@ -2568,6 +2594,7 @@ ObjectData is a reference to a hash where the following keys are defined:
 	creator has a value which is a Workspace.username
 	orig_wsid has a value which is a Workspace.ws_id
 	created has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	refs has a value which is a reference to a list where each element is a Workspace.obj_ref
 	copied has a value which is a Workspace.obj_ref
 	copy_source_inaccessible has a value which is a Workspace.boolean
@@ -2592,6 +2619,7 @@ username is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
 ProvenanceAction is a reference to a hash where the following keys are defined:
 	time has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	caller has a value which is a string
 	service has a value which is a string
 	service_ver has a value which is a string
@@ -2608,11 +2636,13 @@ ProvenanceAction is a reference to a hash where the following keys are defined:
 	subactions has a value which is a reference to a list where each element is a Workspace.SubAction
 	custom has a value which is a reference to a hash where the key is a string and the value is a string
 	description has a value which is a string
+epoch is an int
 ExternalDataUnit is a reference to a hash where the following keys are defined:
 	resource_name has a value which is a string
 	resource_url has a value which is a string
 	resource_version has a value which is a string
 	resource_release_date has a value which is a Workspace.timestamp
+	resource_release_epoch has a value which is a Workspace.epoch
 	data_url has a value which is a string
 	data_id has a value which is a string
 	description has a value which is a string
@@ -3120,6 +3150,7 @@ ObjectData is a reference to a hash where the following keys are defined:
 	creator has a value which is a Workspace.username
 	orig_wsid has a value which is a Workspace.ws_id
 	created has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	refs has a value which is a reference to a list where each element is a Workspace.obj_ref
 	copied has a value which is a Workspace.obj_ref
 	copy_source_inaccessible has a value which is a Workspace.boolean
@@ -3144,6 +3175,7 @@ username is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
 ProvenanceAction is a reference to a hash where the following keys are defined:
 	time has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	caller has a value which is a string
 	service has a value which is a string
 	service_ver has a value which is a string
@@ -3160,11 +3192,13 @@ ProvenanceAction is a reference to a hash where the following keys are defined:
 	subactions has a value which is a reference to a list where each element is a Workspace.SubAction
 	custom has a value which is a reference to a hash where the key is a string and the value is a string
 	description has a value which is a string
+epoch is an int
 ExternalDataUnit is a reference to a hash where the following keys are defined:
 	resource_name has a value which is a string
 	resource_url has a value which is a string
 	resource_version has a value which is a string
 	resource_release_date has a value which is a Workspace.timestamp
+	resource_release_epoch has a value which is a Workspace.epoch
 	data_url has a value which is a string
 	data_id has a value which is a string
 	description has a value which is a string
@@ -3207,6 +3241,7 @@ ObjectData is a reference to a hash where the following keys are defined:
 	creator has a value which is a Workspace.username
 	orig_wsid has a value which is a Workspace.ws_id
 	created has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	refs has a value which is a reference to a list where each element is a Workspace.obj_ref
 	copied has a value which is a Workspace.obj_ref
 	copy_source_inaccessible has a value which is a Workspace.boolean
@@ -3231,6 +3266,7 @@ username is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
 ProvenanceAction is a reference to a hash where the following keys are defined:
 	time has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
 	caller has a value which is a string
 	service has a value which is a string
 	service_ver has a value which is a string
@@ -3247,11 +3283,13 @@ ProvenanceAction is a reference to a hash where the following keys are defined:
 	subactions has a value which is a reference to a list where each element is a Workspace.SubAction
 	custom has a value which is a reference to a hash where the key is a string and the value is a string
 	description has a value which is a string
+epoch is an int
 ExternalDataUnit is a reference to a hash where the following keys are defined:
 	resource_name has a value which is a string
 	resource_url has a value which is a string
 	resource_version has a value which is a string
 	resource_release_date has a value which is a Workspace.timestamp
+	resource_release_epoch has a value which is a Workspace.epoch
 	data_url has a value which is a string
 	data_id has a value which is a string
 	description has a value which is a string
@@ -3474,6 +3512,8 @@ ListWorkspaceInfoParams is a reference to a hash where the following keys are de
 	meta has a value which is a Workspace.usermeta
 	after has a value which is a Workspace.timestamp
 	before has a value which is a Workspace.timestamp
+	after_epoch has a value which is a Workspace.epoch
+	before_epoch has a value which is a Workspace.epoch
 	excludeGlobal has a value which is a Workspace.boolean
 	showDeleted has a value which is a Workspace.boolean
 	showOnlyDeleted has a value which is a Workspace.boolean
@@ -3481,6 +3521,7 @@ permission is a string
 username is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
 timestamp is a string
+epoch is an int
 boolean is an int
 workspace_info is a reference to a list containing 9 items:
 	0: (id) a Workspace.ws_id
@@ -3510,6 +3551,8 @@ ListWorkspaceInfoParams is a reference to a hash where the following keys are de
 	meta has a value which is a Workspace.usermeta
 	after has a value which is a Workspace.timestamp
 	before has a value which is a Workspace.timestamp
+	after_epoch has a value which is a Workspace.epoch
+	before_epoch has a value which is a Workspace.epoch
 	excludeGlobal has a value which is a Workspace.boolean
 	showDeleted has a value which is a Workspace.boolean
 	showOnlyDeleted has a value which is a Workspace.boolean
@@ -3517,6 +3560,7 @@ permission is a string
 username is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
 timestamp is a string
+epoch is an int
 boolean is an int
 workspace_info is a reference to a list containing 9 items:
 	0: (id) a Workspace.ws_id
@@ -3748,6 +3792,8 @@ ListObjectsParams is a reference to a hash where the following keys are defined:
 	meta has a value which is a Workspace.usermeta
 	after has a value which is a Workspace.timestamp
 	before has a value which is a Workspace.timestamp
+	after_epoch has a value which is a Workspace.epoch
+	before_epoch has a value which is a Workspace.epoch
 	minObjectID has a value which is a Workspace.obj_id
 	maxObjectID has a value which is a Workspace.obj_id
 	showDeleted has a value which is a Workspace.boolean
@@ -3765,6 +3811,7 @@ permission is a string
 username is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
 timestamp is a string
+epoch is an int
 obj_id is an int
 boolean is an int
 object_info is a reference to a list containing 11 items:
@@ -3798,6 +3845,8 @@ ListObjectsParams is a reference to a hash where the following keys are defined:
 	meta has a value which is a Workspace.usermeta
 	after has a value which is a Workspace.timestamp
 	before has a value which is a Workspace.timestamp
+	after_epoch has a value which is a Workspace.epoch
+	before_epoch has a value which is a Workspace.epoch
 	minObjectID has a value which is a Workspace.obj_id
 	maxObjectID has a value which is a Workspace.obj_id
 	showDeleted has a value which is a Workspace.boolean
@@ -3815,6 +3864,7 @@ permission is a string
 username is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
 timestamp is a string
+epoch is an int
 obj_id is an int
 boolean is an int
 object_info is a reference to a list containing 11 items:
@@ -7620,6 +7670,37 @@ a string
 
 
 
+=head2 epoch
+
+=over 4
+
+
+
+=item Description
+
+A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in milliseconds.
+
+
+=item Definition
+
+=begin html
+
+<pre>
+an int
+</pre>
+
+=end html
+
+=begin text
+
+an int
+
+=end text
+
+=back
+
+
+
 =head2 type_string
 
 =over 4
@@ -8471,11 +8552,15 @@ a reference to a list containing 11 items:
 An external data unit. A piece of data from a source outside the
 Workspace.
 
+On input, only one of the resource_release_date or
+resource_release_epoch may be supplied. Both are supplied on output.
+
 string resource_name - the name of the resource, for example JGI.
 string resource_url - the url of the resource, for example
         http://genome.jgi.doe.gov
 string resource_version - version of the resource
 timestamp resource_release_date - the release date of the resource
+epoch resource_release_epoch - the release date of the resource
 string data_url - the url of the data, for example
         http://genome.jgi.doe.gov/pages/dynamicOrganismDownload.jsf?
                 organism=BlaspURHD0036
@@ -8494,6 +8579,7 @@ resource_name has a value which is a string
 resource_url has a value which is a string
 resource_version has a value which is a string
 resource_release_date has a value which is a Workspace.timestamp
+resource_release_epoch has a value which is a Workspace.epoch
 data_url has a value which is a string
 data_id has a value which is a string
 description has a value which is a string
@@ -8509,6 +8595,7 @@ resource_name has a value which is a string
 resource_url has a value which is a string
 resource_version has a value which is a string
 resource_release_date has a value which is a Workspace.timestamp
+resource_release_epoch has a value which is a Workspace.epoch
 data_url has a value which is a string
 data_id has a value which is a string
 description has a value which is a string
@@ -8603,10 +8690,14 @@ A provenance action.
         resolved_ws_objects should never be set by the user; it is set by the
         workspace service when returning data.
         
+        On input, only one of the resource_release_date or
+        resource_release_epoch may be supplied. Both are supplied on output.
+        
         The maximum size of the entire provenance object, including all actions,
         is 1MB.
         
-        timestamp time - the time the action was started.
+        timestamp time - the time the action was started
+        epoch epoch - the time the action was started.
         string caller - the name or id of the invoker of this provenance
                 action. In most cases, this will be the same for all PAs.
         string service - the name of the service that performed this action.
@@ -8657,6 +8748,7 @@ A provenance action.
 <pre>
 a reference to a hash where the following keys are defined:
 time has a value which is a Workspace.timestamp
+epoch has a value which is a Workspace.epoch
 caller has a value which is a string
 service has a value which is a string
 service_ver has a value which is a string
@@ -8682,6 +8774,7 @@ description has a value which is a string
 
 a reference to a hash where the following keys are defined:
 time has a value which is a Workspace.timestamp
+epoch has a value which is a Workspace.epoch
 caller has a value which is a string
 service has a value which is a string
 service_ver has a value which is a string
@@ -9438,6 +9531,8 @@ The provenance and supplemental info for an object.
                         0.4.1.
         timestamp created - the date the object was first saved to the
                 workspace.
+        epoch epoch - the date the object was first saved to the
+                workspace.
         list<obj_ref> - the references contained within the object.
         obj_ref copied - the reference of the source object if this object is
                 a copy and the copy source exists and is accessible.
@@ -9463,6 +9558,7 @@ provenance has a value which is a reference to a list where each element is a Wo
 creator has a value which is a Workspace.username
 orig_wsid has a value which is a Workspace.ws_id
 created has a value which is a Workspace.timestamp
+epoch has a value which is a Workspace.epoch
 refs has a value which is a reference to a list where each element is a Workspace.obj_ref
 copied has a value which is a Workspace.obj_ref
 copy_source_inaccessible has a value which is a Workspace.boolean
@@ -9482,6 +9578,7 @@ provenance has a value which is a reference to a list where each element is a Wo
 creator has a value which is a Workspace.username
 orig_wsid has a value which is a Workspace.ws_id
 created has a value which is a Workspace.timestamp
+epoch has a value which is a Workspace.epoch
 refs has a value which is a reference to a list where each element is a Workspace.obj_ref
 copied has a value which is a Workspace.obj_ref
 copy_source_inaccessible has a value which is a Workspace.boolean
@@ -9516,6 +9613,8 @@ The data and supplemental info for an object.
                         0.4.1.
         timestamp created - the date the object was first saved to the
                 workspace.
+        epoch epoch - the date the object was first saved to the
+                workspace.
         list<obj_ref> - the references contained within the object.
         obj_ref copied - the reference of the source object if this object is
                 a copy and the copy source exists and is accessible.
@@ -9542,6 +9641,7 @@ provenance has a value which is a reference to a list where each element is a Wo
 creator has a value which is a Workspace.username
 orig_wsid has a value which is a Workspace.ws_id
 created has a value which is a Workspace.timestamp
+epoch has a value which is a Workspace.epoch
 refs has a value which is a reference to a list where each element is a Workspace.obj_ref
 copied has a value which is a Workspace.obj_ref
 copy_source_inaccessible has a value which is a Workspace.boolean
@@ -9562,6 +9662,7 @@ provenance has a value which is a reference to a list where each element is a Wo
 creator has a value which is a Workspace.username
 orig_wsid has a value which is a Workspace.ws_id
 created has a value which is a Workspace.timestamp
+epoch has a value which is a Workspace.epoch
 refs has a value which is a reference to a list where each element is a Workspace.obj_ref
 copied has a value which is a Workspace.obj_ref
 copy_source_inaccessible has a value which is a Workspace.boolean
@@ -9633,6 +9734,8 @@ excludeGlobal has a value which is a Workspace.boolean
 
 Input parameters for the "list_workspace_info" function.
 
+Only one of each timestamp/epoch pair may be supplied.
+
 Optional parameters:
 permission perm - filter workspaces by minimum permission level. 'None'
         and 'readable' are ignored.
@@ -9644,6 +9747,10 @@ usermeta meta - filter workspaces by the user supplied metadata. NOTE:
 timestamp after - only return workspaces that were modified after this
         date.
 timestamp before - only return workspaces that were modified before
+        this date.
+epoch after_epoch - only return workspaces that were modified after
+        this date.
+epoch before_epoch - only return workspaces that were modified before
         this date.
 boolean excludeGlobal - if excludeGlobal is true exclude world
         readable workspaces. Defaults to false.
@@ -9664,6 +9771,8 @@ owners has a value which is a reference to a list where each element is a Worksp
 meta has a value which is a Workspace.usermeta
 after has a value which is a Workspace.timestamp
 before has a value which is a Workspace.timestamp
+after_epoch has a value which is a Workspace.epoch
+before_epoch has a value which is a Workspace.epoch
 excludeGlobal has a value which is a Workspace.boolean
 showDeleted has a value which is a Workspace.boolean
 showOnlyDeleted has a value which is a Workspace.boolean
@@ -9680,6 +9789,8 @@ owners has a value which is a reference to a list where each element is a Worksp
 meta has a value which is a Workspace.usermeta
 after has a value which is a Workspace.timestamp
 before has a value which is a Workspace.timestamp
+after_epoch has a value which is a Workspace.epoch
+before_epoch has a value which is a Workspace.epoch
 excludeGlobal has a value which is a Workspace.boolean
 showDeleted has a value which is a Workspace.boolean
 showOnlyDeleted has a value which is a Workspace.boolean
@@ -9770,6 +9881,8 @@ Parameters for the 'list_objects' function.
                         type - e.g. Foo.Bar-0 will match Foo.Bar-0.X where X is any
                         existing version.
                 
+                Only one of each timestamp/epoch pair may be supplied.
+                
                 Optional arguments:
                 permission perm - filter objects by minimum permission level. 'None'
                         and 'readable' are ignored.
@@ -9782,6 +9895,10 @@ Parameters for the 'list_objects' function.
                 timestamp after - only return objects that were created after this
                         date.
                 timestamp before - only return objects that were created before this
+                        date.
+                epoch after_epoch - only return objects that were created after this
+                        date.
+                epoch before_epoch - only return objects that were created before this
                         date.
                 obj_id minObjectID - only return objects with an object id greater or
                         equal to this value.
@@ -9819,6 +9936,8 @@ savedby has a value which is a reference to a list where each element is a Works
 meta has a value which is a Workspace.usermeta
 after has a value which is a Workspace.timestamp
 before has a value which is a Workspace.timestamp
+after_epoch has a value which is a Workspace.epoch
+before_epoch has a value which is a Workspace.epoch
 minObjectID has a value which is a Workspace.obj_id
 maxObjectID has a value which is a Workspace.obj_id
 showDeleted has a value which is a Workspace.boolean
@@ -9845,6 +9964,8 @@ savedby has a value which is a reference to a list where each element is a Works
 meta has a value which is a Workspace.usermeta
 after has a value which is a Workspace.timestamp
 before has a value which is a Workspace.timestamp
+after_epoch has a value which is a Workspace.epoch
+before_epoch has a value which is a Workspace.epoch
 minObjectID has a value which is a Workspace.obj_id
 maxObjectID has a value which is a Workspace.obj_id
 showDeleted has a value which is a Workspace.boolean

--- a/lib/Bio/KBase/workspace/Client.pm
+++ b/lib/Bio/KBase/workspace/Client.pm
@@ -9434,7 +9434,7 @@ The provenance and supplemental info for an object.
         username creator - the user that first saved the object to the
                 workspace.
         ws_id orig_wsid - the id of the workspace in which this object was
-                        originally saved. Null for objects saved prior to version
+                        originally saved. Missing for objects saved prior to version
                         0.4.1.
         timestamp created - the date the object was first saved to the
                 workspace.
@@ -9512,7 +9512,7 @@ The data and supplemental info for an object.
         username creator - the user that first saved the object to the
                 workspace.
         ws_id orig_wsid - the id of the workspace in which this object was
-                        originally saved. Null for objects saved prior to version
+                        originally saved. Missing for objects saved prior to version
                         0.4.1.
         timestamp created - the date the object was first saved to the
                 workspace.

--- a/src/us/kbase/workspace/ExternalDataUnit.java
+++ b/src/us/kbase/workspace/ExternalDataUnit.java
@@ -16,11 +16,14 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * <pre>
  * An external data unit. A piece of data from a source outside the
  * Workspace.
+ * On input, only one of the resource_release_date or
+ * resource_release_epoch may be supplied. Both are supplied on output.
  * string resource_name - the name of the resource, for example JGI.
  * string resource_url - the url of the resource, for example
  *         http://genome.jgi.doe.gov
  * string resource_version - version of the resource
  * timestamp resource_release_date - the release date of the resource
+ * epoch resource_release_epoch - the release date of the resource
  * string data_url - the url of the data, for example
  *         http://genome.jgi.doe.gov/pages/dynamicOrganismDownload.jsf?
  *                 organism=BlaspURHD0036
@@ -37,6 +40,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "resource_url",
     "resource_version",
     "resource_release_date",
+    "resource_release_epoch",
     "data_url",
     "data_id",
     "description"
@@ -51,6 +55,8 @@ public class ExternalDataUnit {
     private String resourceVersion;
     @JsonProperty("resource_release_date")
     private String resourceReleaseDate;
+    @JsonProperty("resource_release_epoch")
+    private Long resourceReleaseEpoch;
     @JsonProperty("data_url")
     private String dataUrl;
     @JsonProperty("data_id")
@@ -119,6 +125,21 @@ public class ExternalDataUnit {
         return this;
     }
 
+    @JsonProperty("resource_release_epoch")
+    public Long getResourceReleaseEpoch() {
+        return resourceReleaseEpoch;
+    }
+
+    @JsonProperty("resource_release_epoch")
+    public void setResourceReleaseEpoch(Long resourceReleaseEpoch) {
+        this.resourceReleaseEpoch = resourceReleaseEpoch;
+    }
+
+    public ExternalDataUnit withResourceReleaseEpoch(Long resourceReleaseEpoch) {
+        this.resourceReleaseEpoch = resourceReleaseEpoch;
+        return this;
+    }
+
     @JsonProperty("data_url")
     public String getDataUrl() {
         return dataUrl;
@@ -176,7 +197,7 @@ public class ExternalDataUnit {
 
     @Override
     public String toString() {
-        return ((((((((((((((((("ExternalDataUnit"+" [resourceName=")+ resourceName)+", resourceUrl=")+ resourceUrl)+", resourceVersion=")+ resourceVersion)+", resourceReleaseDate=")+ resourceReleaseDate)+", dataUrl=")+ dataUrl)+", dataId=")+ dataId)+", description=")+ description)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((("ExternalDataUnit"+" [resourceName=")+ resourceName)+", resourceUrl=")+ resourceUrl)+", resourceVersion=")+ resourceVersion)+", resourceReleaseDate=")+ resourceReleaseDate)+", resourceReleaseEpoch=")+ resourceReleaseEpoch)+", dataUrl=")+ dataUrl)+", dataId=")+ dataId)+", description=")+ description)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/src/us/kbase/workspace/ListObjectsParams.java
+++ b/src/us/kbase/workspace/ListObjectsParams.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  *                         type - e.g. Foo.Bar-0 will match Foo.Bar-0.X where X is any
  *                         existing version.
  *                 
+ *                 Only one of each timestamp/epoch pair may be supplied.
+ *                 
  *                 Optional arguments:
  *                 permission perm - filter objects by minimum permission level. 'None'
  *                         and 'readable' are ignored.
@@ -39,6 +41,10 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  *                 timestamp after - only return objects that were created after this
  *                         date.
  *                 timestamp before - only return objects that were created before this
+ *                         date.
+ *                 epoch after_epoch - only return objects that were created after this
+ *                         date.
+ *                 epoch before_epoch - only return objects that were created before this
  *                         date.
  *                 obj_id minObjectID - only return objects with an object id greater or
  *                         equal to this value.
@@ -74,6 +80,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "meta",
     "after",
     "before",
+    "after_epoch",
+    "before_epoch",
     "minObjectID",
     "maxObjectID",
     "showDeleted",
@@ -103,6 +111,10 @@ public class ListObjectsParams {
     private java.lang.String after;
     @JsonProperty("before")
     private java.lang.String before;
+    @JsonProperty("after_epoch")
+    private java.lang.Long afterEpoch;
+    @JsonProperty("before_epoch")
+    private java.lang.Long beforeEpoch;
     @JsonProperty("minObjectID")
     private java.lang.Long minObjectID;
     @JsonProperty("maxObjectID")
@@ -242,6 +254,36 @@ public class ListObjectsParams {
 
     public ListObjectsParams withBefore(java.lang.String before) {
         this.before = before;
+        return this;
+    }
+
+    @JsonProperty("after_epoch")
+    public java.lang.Long getAfterEpoch() {
+        return afterEpoch;
+    }
+
+    @JsonProperty("after_epoch")
+    public void setAfterEpoch(java.lang.Long afterEpoch) {
+        this.afterEpoch = afterEpoch;
+    }
+
+    public ListObjectsParams withAfterEpoch(java.lang.Long afterEpoch) {
+        this.afterEpoch = afterEpoch;
+        return this;
+    }
+
+    @JsonProperty("before_epoch")
+    public java.lang.Long getBeforeEpoch() {
+        return beforeEpoch;
+    }
+
+    @JsonProperty("before_epoch")
+    public void setBeforeEpoch(java.lang.Long beforeEpoch) {
+        this.beforeEpoch = beforeEpoch;
+    }
+
+    public ListObjectsParams withBeforeEpoch(java.lang.Long beforeEpoch) {
+        this.beforeEpoch = beforeEpoch;
         return this;
     }
 
@@ -407,7 +449,7 @@ public class ListObjectsParams {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((((((((((((((((((((((((((((((("ListObjectsParams"+" [workspaces=")+ workspaces)+", ids=")+ ids)+", type=")+ type)+", perm=")+ perm)+", savedby=")+ savedby)+", meta=")+ meta)+", after=")+ after)+", before=")+ before)+", minObjectID=")+ minObjectID)+", maxObjectID=")+ maxObjectID)+", showDeleted=")+ showDeleted)+", showOnlyDeleted=")+ showOnlyDeleted)+", showHidden=")+ showHidden)+", showAllVersions=")+ showAllVersions)+", includeMetadata=")+ includeMetadata)+", excludeGlobal=")+ excludeGlobal)+", skip=")+ skip)+", limit=")+ limit)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((((((((((((((((((((((((("ListObjectsParams"+" [workspaces=")+ workspaces)+", ids=")+ ids)+", type=")+ type)+", perm=")+ perm)+", savedby=")+ savedby)+", meta=")+ meta)+", after=")+ after)+", before=")+ before)+", afterEpoch=")+ afterEpoch)+", beforeEpoch=")+ beforeEpoch)+", minObjectID=")+ minObjectID)+", maxObjectID=")+ maxObjectID)+", showDeleted=")+ showDeleted)+", showOnlyDeleted=")+ showOnlyDeleted)+", showHidden=")+ showHidden)+", showAllVersions=")+ showAllVersions)+", includeMetadata=")+ includeMetadata)+", excludeGlobal=")+ excludeGlobal)+", skip=")+ skip)+", limit=")+ limit)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/src/us/kbase/workspace/ListWorkspaceInfoParams.java
+++ b/src/us/kbase/workspace/ListWorkspaceInfoParams.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * <p>Original spec-file type: ListWorkspaceInfoParams</p>
  * <pre>
  * Input parameters for the "list_workspace_info" function.
+ * Only one of each timestamp/epoch pair may be supplied.
  * Optional parameters:
  * permission perm - filter workspaces by minimum permission level. 'None'
  *         and 'readable' are ignored.
@@ -27,6 +28,10 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * timestamp after - only return workspaces that were modified after this
  *         date.
  * timestamp before - only return workspaces that were modified before
+ *         this date.
+ * epoch after_epoch - only return workspaces that were modified after
+ *         this date.
+ * epoch before_epoch - only return workspaces that were modified before
  *         this date.
  * boolean excludeGlobal - if excludeGlobal is true exclude world
  *         readable workspaces. Defaults to false.
@@ -45,6 +50,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "meta",
     "after",
     "before",
+    "after_epoch",
+    "before_epoch",
     "excludeGlobal",
     "showDeleted",
     "showOnlyDeleted"
@@ -61,6 +68,10 @@ public class ListWorkspaceInfoParams {
     private java.lang.String after;
     @JsonProperty("before")
     private java.lang.String before;
+    @JsonProperty("after_epoch")
+    private Long afterEpoch;
+    @JsonProperty("before_epoch")
+    private Long beforeEpoch;
     @JsonProperty("excludeGlobal")
     private Long excludeGlobal;
     @JsonProperty("showDeleted")
@@ -144,6 +155,36 @@ public class ListWorkspaceInfoParams {
         return this;
     }
 
+    @JsonProperty("after_epoch")
+    public Long getAfterEpoch() {
+        return afterEpoch;
+    }
+
+    @JsonProperty("after_epoch")
+    public void setAfterEpoch(Long afterEpoch) {
+        this.afterEpoch = afterEpoch;
+    }
+
+    public ListWorkspaceInfoParams withAfterEpoch(Long afterEpoch) {
+        this.afterEpoch = afterEpoch;
+        return this;
+    }
+
+    @JsonProperty("before_epoch")
+    public Long getBeforeEpoch() {
+        return beforeEpoch;
+    }
+
+    @JsonProperty("before_epoch")
+    public void setBeforeEpoch(Long beforeEpoch) {
+        this.beforeEpoch = beforeEpoch;
+    }
+
+    public ListWorkspaceInfoParams withBeforeEpoch(Long beforeEpoch) {
+        this.beforeEpoch = beforeEpoch;
+        return this;
+    }
+
     @JsonProperty("excludeGlobal")
     public Long getExcludeGlobal() {
         return excludeGlobal;
@@ -201,7 +242,7 @@ public class ListWorkspaceInfoParams {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((((((((((("ListWorkspaceInfoParams"+" [perm=")+ perm)+", owners=")+ owners)+", meta=")+ meta)+", after=")+ after)+", before=")+ before)+", excludeGlobal=")+ excludeGlobal)+", showDeleted=")+ showDeleted)+", showOnlyDeleted=")+ showOnlyDeleted)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((((("ListWorkspaceInfoParams"+" [perm=")+ perm)+", owners=")+ owners)+", meta=")+ meta)+", after=")+ after)+", before=")+ before)+", afterEpoch=")+ afterEpoch)+", beforeEpoch=")+ beforeEpoch)+", excludeGlobal=")+ excludeGlobal)+", showDeleted=")+ showDeleted)+", showOnlyDeleted=")+ showOnlyDeleted)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/src/us/kbase/workspace/ObjectData.java
+++ b/src/us/kbase/workspace/ObjectData.java
@@ -28,6 +28,8 @@ import us.kbase.common.service.UObject;
  *                         0.4.1.
  *         timestamp created - the date the object was first saved to the
  *                 workspace.
+ *         epoch epoch - the date the object was first saved to the
+ *                 workspace.
  *         list<obj_ref> - the references contained within the object.
  *         obj_ref copied - the reference of the source object if this object is
  *                 a copy and the copy source exists and is accessible.
@@ -52,6 +54,7 @@ import us.kbase.common.service.UObject;
     "creator",
     "orig_wsid",
     "created",
+    "epoch",
     "refs",
     "copied",
     "copy_source_inaccessible",
@@ -73,6 +76,8 @@ public class ObjectData {
     private java.lang.Long origWsid;
     @JsonProperty("created")
     private java.lang.String created;
+    @JsonProperty("epoch")
+    private java.lang.Long epoch;
     @JsonProperty("refs")
     private List<String> refs;
     @JsonProperty("copied")
@@ -174,6 +179,21 @@ public class ObjectData {
 
     public ObjectData withCreated(java.lang.String created) {
         this.created = created;
+        return this;
+    }
+
+    @JsonProperty("epoch")
+    public java.lang.Long getEpoch() {
+        return epoch;
+    }
+
+    @JsonProperty("epoch")
+    public void setEpoch(java.lang.Long epoch) {
+        this.epoch = epoch;
+    }
+
+    public ObjectData withEpoch(java.lang.Long epoch) {
+        this.epoch = epoch;
         return this;
     }
 
@@ -279,7 +299,7 @@ public class ObjectData {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((((((((((((((((((("ObjectData"+" [data=")+ data)+", info=")+ info)+", provenance=")+ provenance)+", creator=")+ creator)+", origWsid=")+ origWsid)+", created=")+ created)+", refs=")+ refs)+", copied=")+ copied)+", copySourceInaccessible=")+ copySourceInaccessible)+", extractedIds=")+ extractedIds)+", handleError=")+ handleError)+", handleStacktrace=")+ handleStacktrace)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((((((((((("ObjectData"+" [data=")+ data)+", info=")+ info)+", provenance=")+ provenance)+", creator=")+ creator)+", origWsid=")+ origWsid)+", created=")+ created)+", epoch=")+ epoch)+", refs=")+ refs)+", copied=")+ copied)+", copySourceInaccessible=")+ copySourceInaccessible)+", extractedIds=")+ extractedIds)+", handleError=")+ handleError)+", handleStacktrace=")+ handleStacktrace)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/src/us/kbase/workspace/ObjectData.java
+++ b/src/us/kbase/workspace/ObjectData.java
@@ -24,7 +24,7 @@ import us.kbase.common.service.UObject;
  *         username creator - the user that first saved the object to the
  *                 workspace.
  *         ws_id orig_wsid - the id of the workspace in which this object was
- *                         originally saved. Null for objects saved prior to version
+ *                         originally saved. Missing for objects saved prior to version
  *                         0.4.1.
  *         timestamp created - the date the object was first saved to the
  *                 workspace.

--- a/src/us/kbase/workspace/ObjectProvenanceInfo.java
+++ b/src/us/kbase/workspace/ObjectProvenanceInfo.java
@@ -26,6 +26,8 @@ import us.kbase.common.service.Tuple11;
  *                         0.4.1.
  *         timestamp created - the date the object was first saved to the
  *                 workspace.
+ *         epoch epoch - the date the object was first saved to the
+ *                 workspace.
  *         list<obj_ref> - the references contained within the object.
  *         obj_ref copied - the reference of the source object if this object is
  *                 a copy and the copy source exists and is accessible.
@@ -49,6 +51,7 @@ import us.kbase.common.service.Tuple11;
     "creator",
     "orig_wsid",
     "created",
+    "epoch",
     "refs",
     "copied",
     "copy_source_inaccessible",
@@ -68,6 +71,8 @@ public class ObjectProvenanceInfo {
     private java.lang.Long origWsid;
     @JsonProperty("created")
     private java.lang.String created;
+    @JsonProperty("epoch")
+    private java.lang.Long epoch;
     @JsonProperty("refs")
     private List<String> refs;
     @JsonProperty("copied")
@@ -154,6 +159,21 @@ public class ObjectProvenanceInfo {
 
     public ObjectProvenanceInfo withCreated(java.lang.String created) {
         this.created = created;
+        return this;
+    }
+
+    @JsonProperty("epoch")
+    public java.lang.Long getEpoch() {
+        return epoch;
+    }
+
+    @JsonProperty("epoch")
+    public void setEpoch(java.lang.Long epoch) {
+        this.epoch = epoch;
+    }
+
+    public ObjectProvenanceInfo withEpoch(java.lang.Long epoch) {
+        this.epoch = epoch;
         return this;
     }
 
@@ -259,7 +279,7 @@ public class ObjectProvenanceInfo {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((((((((((((((((("ObjectProvenanceInfo"+" [info=")+ info)+", provenance=")+ provenance)+", creator=")+ creator)+", origWsid=")+ origWsid)+", created=")+ created)+", refs=")+ refs)+", copied=")+ copied)+", copySourceInaccessible=")+ copySourceInaccessible)+", extractedIds=")+ extractedIds)+", handleError=")+ handleError)+", handleStacktrace=")+ handleStacktrace)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((((((((("ObjectProvenanceInfo"+" [info=")+ info)+", provenance=")+ provenance)+", creator=")+ creator)+", origWsid=")+ origWsid)+", created=")+ created)+", epoch=")+ epoch)+", refs=")+ refs)+", copied=")+ copied)+", copySourceInaccessible=")+ copySourceInaccessible)+", extractedIds=")+ extractedIds)+", handleError=")+ handleError)+", handleStacktrace=")+ handleStacktrace)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/src/us/kbase/workspace/ObjectProvenanceInfo.java
+++ b/src/us/kbase/workspace/ObjectProvenanceInfo.java
@@ -22,7 +22,7 @@ import us.kbase.common.service.Tuple11;
  *         username creator - the user that first saved the object to the
  *                 workspace.
  *         ws_id orig_wsid - the id of the workspace in which this object was
- *                         originally saved. Null for objects saved prior to version
+ *                         originally saved. Missing for objects saved prior to version
  *                         0.4.1.
  *         timestamp created - the date the object was first saved to the
  *                 workspace.

--- a/src/us/kbase/workspace/ProvenanceAction.java
+++ b/src/us/kbase/workspace/ProvenanceAction.java
@@ -26,10 +26,14 @@ import us.kbase.common.service.UObject;
  *         resolved_ws_objects should never be set by the user; it is set by the
  *         workspace service when returning data.
  *         
+ *         On input, only one of the resource_release_date or
+ *         resource_release_epoch may be supplied. Both are supplied on output.
+ *         
  *         The maximum size of the entire provenance object, including all actions,
  *         is 1MB.
  *         
- *         timestamp time - the time the action was started.
+ *         timestamp time - the time the action was started
+ *         epoch epoch - the time the action was started.
  *         string caller - the name or id of the invoker of this provenance
  *                 action. In most cases, this will be the same for all PAs.
  *         string service - the name of the service that performed this action.
@@ -78,6 +82,7 @@ import us.kbase.common.service.UObject;
 @Generated("com.googlecode.jsonschema2pojo")
 @JsonPropertyOrder({
     "time",
+    "epoch",
     "caller",
     "service",
     "service_ver",
@@ -99,6 +104,8 @@ public class ProvenanceAction {
 
     @JsonProperty("time")
     private java.lang.String time;
+    @JsonProperty("epoch")
+    private Long epoch;
     @JsonProperty("caller")
     private java.lang.String caller;
     @JsonProperty("service")
@@ -145,6 +152,21 @@ public class ProvenanceAction {
 
     public ProvenanceAction withTime(java.lang.String time) {
         this.time = time;
+        return this;
+    }
+
+    @JsonProperty("epoch")
+    public Long getEpoch() {
+        return epoch;
+    }
+
+    @JsonProperty("epoch")
+    public void setEpoch(Long epoch) {
+        this.epoch = epoch;
+    }
+
+    public ProvenanceAction withEpoch(Long epoch) {
+        this.epoch = epoch;
         return this;
     }
 
@@ -400,7 +422,7 @@ public class ProvenanceAction {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((((((((((((((((((((((((((((("ProvenanceAction"+" [time=")+ time)+", caller=")+ caller)+", service=")+ service)+", serviceVer=")+ serviceVer)+", method=")+ method)+", methodParams=")+ methodParams)+", script=")+ script)+", scriptVer=")+ scriptVer)+", scriptCommandLine=")+ scriptCommandLine)+", inputWsObjects=")+ inputWsObjects)+", resolvedWsObjects=")+ resolvedWsObjects)+", intermediateIncoming=")+ intermediateIncoming)+", intermediateOutgoing=")+ intermediateOutgoing)+", externalData=")+ externalData)+", subactions=")+ subactions)+", custom=")+ custom)+", description=")+ description)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((((((((((((((((((((("ProvenanceAction"+" [time=")+ time)+", epoch=")+ epoch)+", caller=")+ caller)+", service=")+ service)+", serviceVer=")+ serviceVer)+", method=")+ method)+", methodParams=")+ methodParams)+", script=")+ script)+", scriptVer=")+ scriptVer)+", scriptCommandLine=")+ scriptCommandLine)+", inputWsObjects=")+ inputWsObjects)+", resolvedWsObjects=")+ resolvedWsObjects)+", intermediateIncoming=")+ intermediateIncoming)+", intermediateOutgoing=")+ intermediateOutgoing)+", externalData=")+ externalData)+", subactions=")+ subactions)+", custom=")+ custom)+", description=")+ description)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -29,7 +29,7 @@ import static us.kbase.workspace.kbase.ArgUtils.objInfoToTuple;
 import static us.kbase.workspace.kbase.ArgUtils.translateObjectDataList;
 import static us.kbase.workspace.kbase.ArgUtils.longToBoolean;
 import static us.kbase.workspace.kbase.ArgUtils.longToInt;
-import static us.kbase.workspace.kbase.ArgUtils.parseDate;
+import static us.kbase.workspace.kbase.ArgUtils.chooseDate;
 import static us.kbase.workspace.kbase.KBaseIdentifierFactory.processObjectIdentifier;
 import static us.kbase.workspace.kbase.KBaseIdentifierFactory.processObjectIdentifiers;
 import static us.kbase.workspace.kbase.KBaseIdentifierFactory.processSubObjectIdentifiers;
@@ -39,6 +39,7 @@ import static us.kbase.workspace.kbase.KBasePermissions.translatePermission;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -951,12 +952,19 @@ public class WorkspaceServer extends JsonServerServlet {
 		} else {
 			lop = new ListObjectsParameters(user, wsis, type);
 		}
+		final Date after = chooseDate(params.getAfter(),
+				params.getAfterEpoch(),
+				"Cannot specify both timestamp and epoch for after parameter");
+		final Date before = chooseDate(params.getBefore(),
+				params.getBeforeEpoch(),
+				"Cannot specify both timestamp and epoch for before " +
+				"parameter");
 		lop.withMinimumPermission(params.getPerm() == null ? null :
 				translatePermission(params.getPerm()))
 			.withSavers(ArgUtils.convertUsers(params.getSavedby()))
 			.withMetadata(new WorkspaceUserMetadata(params.getMeta()))
-			.withAfter(parseDate(params.getAfter()))
-			.withBefore(parseDate(params.getBefore()))
+			.withAfter(after)
+			.withBefore(before)
 			.withMinObjectID(checkLong(params.getMinObjectID(), -1))
 			.withMaxObjectID(checkLong(params.getMaxObjectID(), -1))
 			.withShowHidden(longToBoolean(params.getShowHidden()))

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -112,7 +112,7 @@ public class WorkspaceServer extends JsonServerServlet {
     @SuppressWarnings("unused")
 	private static final String gitUrl = "https://github.com/mrcreosote/workspace_deluxe";
     @SuppressWarnings("unused")
-	private static final String gitCommitHash = "8c9b3e7dcb193f891019cf4ecfb2e7f119408460";
+	private static final String gitCommitHash = "26c8545cfcdf6818ee8cd18b728a697d549f1ea9";
 
     //BEGIN_CLASS_HEADER
 	//TODO java doc - really low priority, sorry

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -107,12 +107,9 @@ import us.kbase.workspace.kbase.WorkspaceServerMethods;
  */
 public class WorkspaceServer extends JsonServerServlet {
     private static final long serialVersionUID = 1L;
-    @SuppressWarnings("unused")
-	private static final String version = "0.0.1";
-    @SuppressWarnings("unused")
-	private static final String gitUrl = "https://github.com/mrcreosote/workspace_deluxe";
-    @SuppressWarnings("unused")
-	private static final String gitCommitHash = "26c8545cfcdf6818ee8cd18b728a697d549f1ea9";
+    private static final String version = "0.0.1";
+    private static final String gitUrl = "https://github.com/mrcreosote/workspace_deluxe";
+    private static final String gitCommitHash = "1742eae96c6804c847a63f85140e81a0d13cca27";
 
     //BEGIN_CLASS_HEADER
 	//TODO java doc - really low priority, sorry
@@ -1740,6 +1737,12 @@ public class WorkspaceServer extends JsonServerServlet {
         returnVal.put("message", "");
         returnVal.put("version", VER);
         returnVal.put("git_url", GIT);
+        @SuppressWarnings("unused")
+        String v = version;
+        @SuppressWarnings("unused")
+        String h = gitCommitHash;
+        @SuppressWarnings("unused")
+        String u = gitUrl;
         //END_STATUS
         return returnVal;
     }

--- a/src/us/kbase/workspace/database/Provenance.java
+++ b/src/us/kbase/workspace/database/Provenance.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import us.kbase.common.exceptions.UnimplementedException;
 
 //TODO unit tests
+//TODO javadocs
 //TODO this should keep track of its size & punt if it gets too large
 //TODO consider checking the syntax of urls
 

--- a/src/us/kbase/workspace/kbase/ArgUtils.java
+++ b/src/us/kbase/workspace/kbase/ArgUtils.java
@@ -170,7 +170,7 @@ public class ArgUtils {
 		return ret;
 	}
 
-	public static Date parseDate(final String date) throws ParseException {
+	private static Date parseDate(final String date) throws ParseException {
 		if (date == null) {
 			return null;
 		}

--- a/src/us/kbase/workspace/kbase/WorkspaceServerMethods.java
+++ b/src/us/kbase/workspace/kbase/WorkspaceServerMethods.java
@@ -1,12 +1,12 @@
 package us.kbase.workspace.kbase;
 
 import static us.kbase.common.utils.ServiceUtils.checkAddlArgs;
+import static us.kbase.workspace.kbase.ArgUtils.chooseDate;
 import static us.kbase.workspace.kbase.ArgUtils.getGlobalWSPerm;
 import static us.kbase.workspace.kbase.ArgUtils.wsInfoToTuple;
 import static us.kbase.workspace.kbase.ArgUtils.processProvenance;
 import static us.kbase.workspace.kbase.ArgUtils.longToBoolean;
 import static us.kbase.workspace.kbase.ArgUtils.objInfoToTuple;
-import static us.kbase.workspace.kbase.ArgUtils.parseDate;
 import static us.kbase.workspace.kbase.KBaseIdentifierFactory.processWorkspaceIdentifier;
 import static us.kbase.workspace.kbase.KBasePermissions.translatePermission;
 
@@ -16,6 +16,7 @@ import java.net.UnknownHostException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -282,11 +283,17 @@ public class WorkspaceServerMethods {
 		checkAddlArgs(params.getAdditionalProperties(), params.getClass());
 		final Permission p = params.getPerm() == null ? null :
 				translatePermission(params.getPerm());
+		final Date after = chooseDate(params.getAfter(),
+				params.getAfterEpoch(),
+				"Cannot specify both timestamp and epoch for after parameter");
+		final Date before = chooseDate(params.getBefore(),
+				params.getBeforeEpoch(),
+				"Cannot specify both timestamp and epoch for before " +
+				"parameter");
 		return wsInfoToTuple(ws.listWorkspaces(user,
 				p, ArgUtils.convertUsers(params.getOwners()),
 				new WorkspaceUserMetadata(params.getMeta()),
-				parseDate(params.getAfter()),
-				parseDate(params.getBefore()),
+				after, before,
 				longToBoolean(params.getExcludeGlobal()),
 				longToBoolean(params.getShowDeleted()),
 				longToBoolean(params.getShowOnlyDeleted())));

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
@@ -1120,12 +1120,12 @@ public class JSONRPCLayerTester {
 		}
 	}
 	
-	protected String addSec(String time) throws Exception {
-		return DATE_FORMAT.format(DATE_FORMAT.parse(time).getTime() + 1000);
+	protected long addSec(String time) throws Exception {
+		return DATE_FORMAT.parse(time).getTime() + 1000;
 	}
 	
-	protected String subSec(String time) throws Exception {
-		return DATE_FORMAT.format(DATE_FORMAT.parse(time).getTime() - 1000);
+	protected long subSec(String time) throws Exception {
+		return DATE_FORMAT.parse(time).getTime() - 1000;
 	}
 
 	protected void checkWSInfoList(

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
@@ -464,39 +464,110 @@ public class JSONRPCLayerTester {
 		}
 	}
 	
+	protected static class StringEpoch {
+		public final Long epoch;
+		public final String time;
+		
+		public StringEpoch(long epoch) {
+			this.epoch = epoch;
+			this.time = null;
+		}
+		
+		public StringEpoch(String time) {
+			this.time = time;
+			this.epoch = null;
+		}
+		public StringEpoch(long epoch, String time) {
+			this.time = time;
+			this.epoch = epoch;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((epoch == null) ? 0 : epoch.hashCode());
+			result = prime * result + ((time == null) ? 0 : time.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			StringEpoch other = (StringEpoch) obj;
+			if (epoch == null) {
+				if (other.epoch != null)
+					return false;
+			} else if (!epoch.equals(other.epoch))
+				return false;
+			if (time == null) {
+				if (other.time != null)
+					return false;
+			} else if (!time.equals(other.time))
+				return false;
+			return true;
+		}
+	}
+	
 	protected void checkProvenance(String user, ObjectIdentity id,
 			List<ProvenanceAction> prov, Map<String, String> refmap,
-			Map<String, String> timemap) throws Exception {
+			Map<StringEpoch, StringEpoch> timemap) throws Exception {
+		Date tenback = getOlderDate(10 * 60 * 1000);
+		Date tenfor = getNewerDate(10 * 60 * 1000);
 		ObjectData ret = CLIENT1.getObjects(Arrays.asList(id)).get(0);
 		assertThat("user correct", ret.getCreator(), is(user));
 		assertThat("wsid correct", ret.getOrigWsid(), is(id.getWsid()));
-		assertTrue("created within last 10 mins", 
-				DATE_FORMAT.parse(ret.getCreated())
-				.after(getOlderDate(10 * 60 * 1000)));
+		Date created = DATE_FORMAT.parse(ret.getCreated());
+		assertTrue("created within last 10 mins", created.after(tenback));
+		assertTrue("epoch within last 10 mins", new Date(ret.getEpoch())
+				.after(tenback));
+		assertTrue("not saved in future", created.before(tenfor));
+		assertTrue("epoch not in future", new Date(ret.getEpoch())
+				.before(tenfor));
 		checkProvenance(prov, ret.getProvenance(), refmap, timemap);
+		ret = null;
 		
 		ObjectProvenanceInfo p = CLIENT1.getObjectProvenance(
 				Arrays.asList(id)).get(0);
 		assertThat("user correct", p.getCreator(), is(user));
-		assertThat("wsid correct", ret.getOrigWsid(), is(id.getWsid()));
-		assertTrue("created within last 10 mins", 
-				DATE_FORMAT.parse(p.getCreated())
-				.after(getOlderDate(10 * 60 * 1000)));
+		assertThat("wsid correct", p.getOrigWsid(), is(id.getWsid()));
+		created = DATE_FORMAT.parse(p.getCreated());
+		assertTrue("created within last 10 mins", created.after(tenback));
+		assertTrue("epoch within last 10 mins", new Date(p.getEpoch())
+				.after(tenback));
+		assertTrue("not saved in future", created.before(tenfor));
+		assertTrue("epoch not in future", new Date(p.getEpoch())
+				.before(tenfor));
 		checkProvenance(prov, p.getProvenance(), refmap, timemap);
+		p = null;
 		
 		ret = CLIENT1.getObjectSubset(objIDToSubObjID(Arrays.asList(id)))
 				.get(0);
 		assertThat("user correct", ret.getCreator(), is(user));
 		assertThat("wsid correct", ret.getOrigWsid(), is(id.getWsid()));
-		assertTrue("created within last 10 mins", 
-				DATE_FORMAT.parse(ret.getCreated())
-				.after(getOlderDate(10 * 60 * 1000)));
+		created = DATE_FORMAT.parse(ret.getCreated());
+		assertTrue("created within last 10 mins", created.after(tenback));
+		assertTrue("epoch within last 10 mins", new Date(ret.getEpoch())
+				.after(tenback));
+		assertTrue("not saved in future", created.before(tenfor));
+		assertTrue("epoch not in future", new Date(ret.getEpoch())
+				.before(tenfor));
 		checkProvenance(prov, ret.getProvenance(), refmap, timemap);
 	}
 	
 	protected Date getOlderDate(long ms) {
 		long now = new Date().getTime();
 		return new Date(now - ms);
+	}
+	
+	protected Date getNewerDate(long ms) {
+		long now = new Date().getTime();
+		return new Date(now + ms);
 	}
 	
 	protected void saveProvWithBadTime(String time, String exception) throws Exception {
@@ -532,7 +603,7 @@ public class JSONRPCLayerTester {
 	
 	protected void checkProvenance(List<ProvenanceAction> expected,
 			List<ProvenanceAction> got, Map<String, String> refmap,
-			Map<String, String> timemap) {
+			Map<StringEpoch, StringEpoch> timemap) throws Exception {
 		assertThat("same number actions", got.size(),
 				is(expected.size()));
 		
@@ -571,7 +642,9 @@ public class JSONRPCLayerTester {
 				assertThat("custom equal", gotpa.getCustom(), is(exppa.getCustom()));
 			}
 			assertThat("caller equal", gotpa.getCaller(), is(exppa.getCaller()));
-			assertThat("time equal", gotpa.getTime(), is(timemap.get(exppa.getTime())));
+			StringEpoch se = getStringEpoch(exppa, timemap);
+			assertThat("time equal", gotpa.getTime(), is(se.time));
+			assertThat("epoch equal", gotpa.getEpoch(), is(se.epoch));
 			assertThat("refs equal", gotpa.getInputWsObjects(),
 					is(exppa.getInputWsObjects() == null ? new ArrayList<String>() :
 						exppa.getInputWsObjects()));
@@ -609,9 +682,10 @@ public class JSONRPCLayerTester {
 		
 	}
 	
-	private void checkProvenanceExternalData(
+	private void checkProvenanceExternalData (
 			List<ExternalDataUnit> got,
-			List<ExternalDataUnit> exp, Map<String, String> timemap) {
+			List<ExternalDataUnit> exp, Map<StringEpoch, StringEpoch> timemap)
+			throws Exception {
 		if (exp == null) {
 			assertThat("prov external data empty", got.size(), is(0));
 			return;
@@ -626,12 +700,35 @@ public class JSONRPCLayerTester {
 			assertThat("same data url", g.getDataUrl(), is (e.getDataUrl()));
 			assertThat("same description", g.getDescription(), is (e.getDescription()));
 			assertThat("same resource name", g.getResourceName(), is (e.getResourceName()));
+			StringEpoch se = getStringEpoch(e, timemap);
 			assertThat("same resource rel date", g.getResourceReleaseDate(),
-					is (timemap.get(e.getResourceReleaseDate())));
+					is(se.time));
+			assertThat("same resource rel epoch", g.getResourceReleaseEpoch(),
+					is(se.epoch));
 			assertThat("same resource url", g.getResourceUrl(), is (e.getResourceUrl()));
 			assertThat("same resource ver", g.getResourceVersion(), is (e.getResourceVersion()));
 		}
 		
+	}
+	
+	private StringEpoch getStringEpoch(ExternalDataUnit edu,
+			Map<StringEpoch, StringEpoch> timemap) {
+		if (edu.getResourceReleaseDate() != null) {
+			return timemap.get(new StringEpoch(edu.getResourceReleaseDate()));
+		} else if (edu.getResourceReleaseEpoch() != null){
+			return timemap.get(new StringEpoch(edu.getResourceReleaseEpoch()));
+		}
+		return new StringEpoch(null);
+	}
+	
+	private StringEpoch getStringEpoch(ProvenanceAction edu,
+			Map<StringEpoch, StringEpoch> timemap) {
+		if (edu.getTime() != null) {
+			return timemap.get(new StringEpoch(edu.getTime()));
+		} else if (edu.getEpoch() != null){
+			return timemap.get(new StringEpoch(edu.getEpoch()));
+		}
+		return new StringEpoch(null);
 	}
 
 	protected void failGetObjectInfoNew(GetObjectInfoNewParams params, String exception)

--- a/workspace.spec
+++ b/workspace.spec
@@ -839,7 +839,7 @@ module Workspace {
 		username creator - the user that first saved the object to the
 			workspace.
 		ws_id orig_wsid - the id of the workspace in which this object was
-				originally saved. Null for objects saved prior to version
+				originally saved. Missing for objects saved prior to version
 				0.4.1.
 		timestamp created - the date the object was first saved to the
 			workspace.
@@ -884,7 +884,7 @@ module Workspace {
 		username creator - the user that first saved the object to the
 			workspace.
 		ws_id orig_wsid - the id of the workspace in which this object was
-				originally saved. Null for objects saved prior to version
+				originally saved. Missing for objects saved prior to version
 				0.4.1.
 		timestamp created - the date the object was first saved to the
 			workspace.

--- a/workspace.spec
+++ b/workspace.spec
@@ -52,6 +52,9 @@ module Workspace {
 	*/
 	typedef string timestamp;
 	
+	/* A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in milliseconds. */
+	typedef int epoch; 
+	
 	/* A type string.
 		Specifies the type and its version in a single string in the format
 		[module].[typename]-[major].[minor]:
@@ -313,11 +316,15 @@ module Workspace {
 	/* An external data unit. A piece of data from a source outside the
 		Workspace.
 		
+		On input, only one of the resource_release_date or
+		resource_release_epoch may be supplied. Both are supplied on output.
+		
 		string resource_name - the name of the resource, for example JGI.
 		string resource_url - the url of the resource, for example
 			http://genome.jgi.doe.gov
 		string resource_version - version of the resource
 		timestamp resource_release_date - the release date of the resource
+		epoch resource_release_epoch - the release date of the resource
 		string data_url - the url of the data, for example
 			http://genome.jgi.doe.gov/pages/dynamicOrganismDownload.jsf?
 				organism=BlaspURHD0036
@@ -331,6 +338,7 @@ module Workspace {
 		string resource_url;
 		string resource_version;
 		timestamp resource_release_date;
+		epoch resource_release_epoch;
 		string data_url;
 		string data_id;
 		string description;
@@ -378,10 +386,14 @@ module Workspace {
 		resolved_ws_objects should never be set by the user; it is set by the
 		workspace service when returning data.
 		
+		On input, only one of the time or epoch may be supplied. Both are
+		supplied on output.
+		
 		The maximum size of the entire provenance object, including all actions,
 		is 1MB.
 		
-		timestamp time - the time the action was started.
+		timestamp time - the time the action was started
+		epoch epoch - the time the action was started.
 		string caller - the name or id of the invoker of this provenance
 			action. In most cases, this will be the same for all PAs.
 		string service - the name of the service that performed this action.
@@ -426,6 +438,7 @@ module Workspace {
 	*/
 	typedef structure {
 		timestamp time;
+		epoch epoch;
 		string caller;
 		string service;
 		string service_ver;
@@ -843,6 +856,8 @@ module Workspace {
 				0.4.1.
 		timestamp created - the date the object was first saved to the
 			workspace.
+		epoch epoch - the date the object was first saved to the
+			workspace.
 		list<obj_ref> - the references contained within the object.
 		obj_ref copied - the reference of the source object if this object is
 			a copy and the copy source exists and is accessible.
@@ -862,6 +877,7 @@ module Workspace {
 		username creator;
 		ws_id orig_wsid;
 		timestamp created;
+		epoch epoch;
 		list<obj_ref> refs;
 		obj_ref copied;
 		boolean copy_source_inaccessible;
@@ -888,6 +904,8 @@ module Workspace {
 				0.4.1.
 		timestamp created - the date the object was first saved to the
 			workspace.
+		epoch epoch - the date the object was first saved to the
+			workspace.
 		list<obj_ref> - the references contained within the object.
 		obj_ref copied - the reference of the source object if this object is
 			a copy and the copy source exists and is accessible.
@@ -909,6 +927,7 @@ module Workspace {
 		username creator;
 		ws_id orig_wsid;
 		timestamp created;
+		epoch epoch;
 		list<obj_ref> refs;
 		obj_ref copied;
 		boolean copy_source_inaccessible;
@@ -1015,6 +1034,8 @@ module Workspace {
 	/* 
 		Input parameters for the "list_workspace_info" function.
 		
+		Only one of each timestamp/epoch pair may be supplied.
+		
 		Optional parameters:
 		permission perm - filter workspaces by minimum permission level. 'None'
 			and 'readable' are ignored.
@@ -1026,6 +1047,10 @@ module Workspace {
 		timestamp after - only return workspaces that were modified after this
 			date.
 		timestamp before - only return workspaces that were modified before
+			this date.
+		epoch after_epoch - only return workspaces that were modified after
+			this date.
+		epoch before_epoch - only return workspaces that were modified before
 			this date.
 		boolean excludeGlobal - if excludeGlobal is true exclude world
 			readable workspaces. Defaults to false.
@@ -1041,6 +1066,8 @@ module Workspace {
 		usermeta meta;
 		timestamp after;
 		timestamp before;
+		epoch after_epoch;
+		epoch before_epoch;
 		boolean excludeGlobal;
 		boolean showDeleted;
 		boolean showOnlyDeleted;
@@ -1100,6 +1127,8 @@ module Workspace {
 			type - e.g. Foo.Bar-0 will match Foo.Bar-0.X where X is any
 			existing version.
 		
+		Only one of each timestamp/epoch pair may be supplied.
+		
 		Optional arguments:
 		permission perm - filter objects by minimum permission level. 'None'
 			and 'readable' are ignored.
@@ -1112,6 +1141,10 @@ module Workspace {
 		timestamp after - only return objects that were created after this
 			date.
 		timestamp before - only return objects that were created before this
+			date.
+		epoch after_epoch - only return objects that were created after this
+			date.
+		epoch before_epoch - only return objects that were created before this
 			date.
 		obj_id minObjectID - only return objects with an object id greater or
 			equal to this value.
@@ -1144,6 +1177,8 @@ module Workspace {
 		usermeta meta;
 		timestamp after;
 		timestamp before;
+		epoch after_epoch;
+		epoch before_epoch;
 		obj_id minObjectID;
 		obj_id maxObjectID;
 		boolean showDeleted;


### PR DESCRIPTION
All incoming timestamps can be alternately supplied as Unix epochs.

Where possible (e.g. not tuples) epochs are provided as well as timestamps.

Also made kb-sdk compile targets.