### PR TITLE
Remove temporary files on fails + more

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -32,7 +32,7 @@
   <!-- Properties in ant are immutable, so the following assignment will only take place if jardir was not set above. -->
   <property name="jardir" location="${env.JENKINS_JARS_MODULE_PATH}/lib/jars"/>
 
-  <condition property="commonjar" value="kbase/common/kbase-common-0.0.15.jar">
+  <condition property="commonjar" value="kbase/common/kbase-common-0.0.17.jar">
     <or>
       <equals arg1="${env.JENKINS_JAVA_COMMON_JARFILE}" arg2=""/>
       <not>
@@ -172,6 +172,7 @@
   <target name="compile" depends="init" description="compile the source">
     <!-- Compile class files-->
     <javac destdir="${classes}" includeantruntime="false"
+      target="1.7" source="1.7"
       debug="true" classpathref="compile.classpath">
       <src path="${src}"/>
     </javac>

--- a/docsource/builddocs.rst
+++ b/docsource/builddocs.rst
@@ -10,7 +10,7 @@ Requirements
 
 The build requires:
 
-Java JDK 6+ (`install instructions <https://www.digitalocean.com/community/tutorials/how-to-install-java-on-ubuntu-with-apt-get>`_)
+Java JDK 7+ (`install instructions <https://www.digitalocean.com/community/tutorials/how-to-install-java-on-ubuntu-with-apt-get>`_)
 
 `Java ant <http://ant.apache.org/>`_::
 

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ assume that the KBase runtime or `dev_container` are installed.
 
 The build requires:
 
-Java JDK 6+ ([install instructions](https://www.digitalocean.com/community/tutorials/how-to-install-java-on-ubuntu-with-apt-get))
+Java JDK 7+ ([install instructions](https://www.digitalocean.com/community/tutorials/how-to-install-java-on-ubuntu-with-apt-get))
 
 [Java ant](http://ant.apache.org):
 

--- a/src/us/kbase/common/test/TestCommon.java
+++ b/src/us/kbase/common/test/TestCommon.java
@@ -39,7 +39,7 @@ public class TestCommon {
 				System.getProperty("java.runtime.version"));
 	}
 	
-	private static String getProp(String prop) {
+	public static String getProp(String prop) {
 		if (System.getProperty(prop) == null || prop.isEmpty()) {
 			throw new TestException("Property " + prop +
 					" cannot be null or the empty string.");
@@ -118,7 +118,7 @@ public class TestCommon {
 	
 	//http://quirkygba.blogspot.com/2009/11/setting-environment-variables-in-java.html
 	@SuppressWarnings("unchecked")
-	protected static Map<String, String> getenv()
+	public static Map<String, String> getenv()
 			throws NoSuchFieldException, SecurityException,
 			IllegalArgumentException, IllegalAccessException {
 		Map<String, String> unmodifiable = System.getenv();

--- a/src/us/kbase/common/test/TestCommon.java
+++ b/src/us/kbase/common/test/TestCommon.java
@@ -1,0 +1,130 @@
+package us.kbase.common.test;
+
+import us.kbase.common.test.TestException;
+import us.kbase.typedobj.core.TempFilesManager;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DB;
+
+public class TestCommon {
+	
+	public static final String SHOCKEXE = "test.shock.exe";
+	public static final String SHOCKVER = "test.shock.version";
+	public static final String MONGOEXE = "test.mongo.exe";
+	public static final String MONGO_USE_WIRED_TIGER = "test.mongo.useWiredTiger";
+	public static final String MYSQLEXE = "test.mysql.exe";
+	public static final String MYSQL_INSTALL_EXE = "test.mysql.install.exe";
+	
+	public static final String TEST_TEMP_DIR = "test.temp.dir";
+	public static final String KEEP_TEMP_DIR = "test.temp.dir.keep";
+			
+	public static void stfuLoggers() {
+		((ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+				.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME))
+			.setLevel(ch.qos.logback.classic.Level.OFF);
+		java.util.logging.Logger.getLogger("com.mongodb")
+			.setLevel(java.util.logging.Level.OFF);
+	}
+	
+	public static void printJava() {
+		System.out.println("Java: " +
+				System.getProperty("java.runtime.version"));
+	}
+	
+	private static String getProp(String prop) {
+		if (System.getProperty(prop) == null || prop.isEmpty()) {
+			throw new TestException("Property " + prop +
+					" cannot be null or the empty string.");
+		}
+		return System.getProperty(prop);
+	}
+	
+	public static String getTempDir() {
+		return getProp(TEST_TEMP_DIR);
+	}
+	
+	public static String getMongoExe() {
+		return getProp(MONGOEXE);
+	}
+	
+	public static String getShockExe() {
+		return getProp(SHOCKEXE);
+	}
+	
+	public static String getShockVersion() {
+		return getProp(SHOCKVER);
+	}
+
+	public static String getMySQLExe() {
+		return getProp(MYSQLEXE);
+	}
+	
+	public static String getMySQLInstallExe() {
+		return getProp(MYSQL_INSTALL_EXE);
+	}
+	
+	public static boolean deleteTempFiles() {
+		return !"true".equals(System.getProperty(KEEP_TEMP_DIR));
+	}
+	
+	public static boolean useWiredTigerEngine() {
+		return "true".equals(System.getProperty(MONGO_USE_WIRED_TIGER));
+	}
+	
+	public static void destroyDB(DB db) {
+		for (String name: db.getCollectionNames()) {
+			if (!name.startsWith("system.")) {
+				// dropping collection also drops indexes
+				db.getCollection(name).remove(new BasicDBObject());
+			}
+		}
+	}
+	
+	public static void assertNoTempFilesExist(TempFilesManager tfm)
+			throws Exception {
+		assertNoTempFilesExist(Arrays.asList(tfm));
+	}
+	
+	
+	public static void assertNoTempFilesExist(List<TempFilesManager> tfms)
+			throws Exception {
+		int i = 0;
+		try {
+			for (TempFilesManager tfm: tfms) {
+				if (!tfm.isEmpty()) {
+					// Allow <=10 seconds to finish all activities
+					for (; i < 100; i++) {
+						Thread.sleep(100);
+						if (tfm.isEmpty())
+							break;
+					}
+				}
+				assertThat("There are tempfiles: " + tfm.getTempFileList(),
+						tfm.isEmpty(), is(true));
+			}
+		} finally {
+			for (TempFilesManager tfm: tfms)
+				tfm.cleanup();
+		}
+	}
+	
+	//http://quirkygba.blogspot.com/2009/11/setting-environment-variables-in-java.html
+	@SuppressWarnings("unchecked")
+	protected static Map<String, String> getenv()
+			throws NoSuchFieldException, SecurityException,
+			IllegalArgumentException, IllegalAccessException {
+		Map<String, String> unmodifiable = System.getenv();
+		Class<?> cu = unmodifiable.getClass();
+		Field m = cu.getDeclaredField("m");
+		m.setAccessible(true);
+		return (Map<String, String>) m.get(unmodifiable);
+	}
+}

--- a/src/us/kbase/common/utils/Counter.java
+++ b/src/us/kbase/common/utils/Counter.java
@@ -1,4 +1,4 @@
-package us.kbase.typedobj.util;
+package us.kbase.common.utils;
 
 /**
  * A simple counter class that can be initialized to

--- a/src/us/kbase/common/utils/SizeUtils.java
+++ b/src/us/kbase/common/utils/SizeUtils.java
@@ -1,4 +1,4 @@
-package us.kbase.typedobj.util;
+package us.kbase.common.utils;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;

--- a/src/us/kbase/typedobj/core/ExtractedMetadata.java
+++ b/src/us/kbase/typedobj/core/ExtractedMetadata.java
@@ -1,12 +1,8 @@
 package us.kbase.typedobj.core;
 
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * A thin container to return extracted Metadata (indicated by
@@ -17,35 +13,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class ExtractedMetadata {
 
-	private JsonNode metadata;
-	private static final ObjectMapper mapper = new ObjectMapper();
-	/**
-	 * The metadata JsonNode must be an object node with String type values for
-	 * all fields.  We assume that this has already been validated earlier.
-	 * @param wsSearchableSubset
-	 * @param metadata
-	 */
-	public ExtractedMetadata(JsonNode metadata) {
-		if(metadata == null) {
-			this.metadata = mapper.createObjectNode();
+	private final Map<String, String> metadata;
+
+	public ExtractedMetadata(final Map<String, String> metadata) {
+		if (metadata == null) {
+			this.metadata = Collections.unmodifiableMap(
+					new HashMap<String, String>());
 		} else {
-			this.metadata = metadata;
+			this.metadata = Collections.unmodifiableMap(
+					new HashMap<String, String>(metadata));;
 		}
 	}
 	
-	public JsonNode getMetadata() {
+	public Map<String, String> getMetadata() {
 		return metadata;
 	}
-	
-	/** converts the data stored in the metadata JsonNode to a map */
-	public Map<String,String> getMetadataAsMap() {
-		Map <String,String> data = new HashMap<String,String>(metadata.size());
-		Iterator<Entry<String, JsonNode>> ite = metadata.fields();
-		while (ite.hasNext()) {
-			Entry<String,JsonNode> next = ite.next();
-			data.put(next.getKey(),next.getValue().asText());
-		}
-		return data;
-	}
-	
 }

--- a/src/us/kbase/typedobj/core/ExtractedMetadata.java
+++ b/src/us/kbase/typedobj/core/ExtractedMetadata.java
@@ -21,7 +21,7 @@ public class ExtractedMetadata {
 					new HashMap<String, String>());
 		} else {
 			this.metadata = Collections.unmodifiableMap(
-					new HashMap<String, String>(metadata));;
+					new HashMap<String, String>(metadata));
 		}
 	}
 	

--- a/src/us/kbase/typedobj/core/MetadataExtractionHandler.java
+++ b/src/us/kbase/typedobj/core/MetadataExtractionHandler.java
@@ -62,8 +62,7 @@ public class MetadataExtractionHandler {
 	/**
 	 * selection indicates a mapping from metadata name to metadata selection
 	 * extraction (string to string) maxMetadataSize is the maximum size of the
-	 * metadata string when encoded into JSON UTF8 in bytes. IF set to a value
-	 * less than zero, then no size checks are performed.
+	 * metadata string when encoded into JSON UTF8 in bytes.
 	 */
 	public MetadataExtractionHandler(JsonNode selection, long maxMetadataSize) {
 

--- a/src/us/kbase/typedobj/core/TypeDefName.java
+++ b/src/us/kbase/typedobj/core/TypeDefName.java
@@ -1,7 +1,7 @@
 package us.kbase.typedobj.core;
 
+import static us.kbase.common.utils.SizeUtils.checkSizeInBytes;
 import static us.kbase.common.utils.StringUtils.checkString;
-import static us.kbase.typedobj.util.SizeUtils.checkSizeInBytes;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/src/us/kbase/typedobj/core/TypedObjectValidationReport.java
+++ b/src/us/kbase/typedobj/core/TypedObjectValidationReport.java
@@ -254,6 +254,7 @@ public class TypedObjectValidationReport {
 		nullifySortCacheFile();
 		cacheForSorting = null;
 		if (!sorted) {
+			//TODO NOW choose to use a file based on input size & max mem size. If no TFM & one is necessary, except. make sure tests catch left files.
 			if (tfm == null) {
 				ByteArrayOutputStream os = new ByteArrayOutputStream();
 				final JsonGenerator jgen = mapper.getFactory()
@@ -278,9 +279,15 @@ public class TypedObjectValidationReport {
 							"sortout", "json");
 					final FileOutputStream os = new FileOutputStream(
 							fileForSorting);
-					//TODO NOW if exception occurs here need to delete fileForSorting
-					fac.getSorter(f1).writeIntoStream(os);
-					os.close();
+					try {
+						fac.getSorter(f1).writeIntoStream(os);
+						os.close();
+					} catch (IOException | KeyDuplicationException |
+							TooManyKeysException | RuntimeException |
+							Error e) {
+						nullifySortCacheFile();
+						throw e;
+					}
 				} finally {
 					f1.delete();
 					if (jgen != null)

--- a/src/us/kbase/typedobj/core/TypedObjectValidationReport.java
+++ b/src/us/kbase/typedobj/core/TypedObjectValidationReport.java
@@ -50,7 +50,7 @@ public class TypedObjectValidationReport {
 	/**
 	 * The typedef author selection indicating in the JSON Schema what data should be extracted as metadata
 	 */
-	private MetadataExtractionHandler wsMetadataExtractionHandler;
+	private JsonNode wsMetadataSelection;
 	
 	/**
 	 * This is the ID of the type definition used in validation - it is an AbsoluteTypeDefId so you always have full version info
@@ -98,7 +98,7 @@ public class TypedObjectValidationReport {
 			final JsonTokenValidationSchema schema,
 			final IdReferenceHandlerSet<?> idHandler) {
 		this.errors = errors == null ? new LinkedList<String>() : errors;
-		this.wsMetadataExtractionHandler = new MetadataExtractionHandler(wsMetadataSelection,-1);
+		this.wsMetadataSelection = wsMetadataSelection;
 		this.validationTypeDefId=validationTypeDefId;
 		this.idHandler = idHandler;
 		this.tokenStreamProvider = tokenStreamProvider;
@@ -423,13 +423,15 @@ public class TypedObjectValidationReport {
 		if (!isInstanceValid()) {
 			return new ExtractedMetadata(null);
 		}
-		wsMetadataExtractionHandler.setMaxMetadataSize(maxMetadataSize);
+		final MetadataExtractionHandler handler =
+				new MetadataExtractionHandler(wsMetadataSelection,
+						maxMetadataSize);
 		// Identify what we need to extract
 		TokenSequenceProvider tsp = null;
 		try {
 			tsp = createTokenSequenceForMetaDataExtraction();
 			final ExtractedMetadata esam = MetadataExtractor
-					.extractFields(tsp, wsMetadataExtractionHandler);
+					.extractFields(tsp, handler);
 			tsp.close();
 			return esam;
 		} catch (IOException e) {

--- a/src/us/kbase/typedobj/core/TypedObjectValidationReport.java
+++ b/src/us/kbase/typedobj/core/TypedObjectValidationReport.java
@@ -278,6 +278,7 @@ public class TypedObjectValidationReport {
 							"sortout", "json");
 					final FileOutputStream os = new FileOutputStream(
 							fileForSorting);
+					//TODO NOW if exception occurs here need to delete fileForSorting
 					fac.getSorter(f1).writeIntoStream(os);
 					os.close();
 				} finally {

--- a/src/us/kbase/typedobj/core/TypedObjectValidationReport.java
+++ b/src/us/kbase/typedobj/core/TypedObjectValidationReport.java
@@ -158,7 +158,7 @@ public class TypedObjectValidationReport {
 			
 			@Override
 			public void releaseResources() throws IOException {
-				nullifySortCacheFile();
+				destroyCachedResources();
 			}
 		};
 	}	
@@ -251,10 +251,10 @@ public class TypedObjectValidationReport {
 		if (size < 0) {
 			getRelabeledSize();
 		}
-		nullifySortCacheFile();
+		destroyCachedResources();
 		cacheForSorting = null;
 		if (!sorted) {
-			//TODO NOW choose to use a file based on input size & max mem size. If no TFM & one is necessary, except. make sure tests catch left files.
+			//TODO PERFORMANCE choose to use a file based on input size & max mem size. If no TFM & one is necessary, except. make sure tests catch left files.
 			if (tfm == null) {
 				ByteArrayOutputStream os = new ByteArrayOutputStream();
 				final JsonGenerator jgen = mapper.getFactory()
@@ -285,7 +285,7 @@ public class TypedObjectValidationReport {
 					} catch (IOException | KeyDuplicationException |
 							TooManyKeysException | RuntimeException |
 							Error e) {
-						nullifySortCacheFile();
+						destroyCachedResources();
 						throw e;
 					}
 				} finally {
@@ -297,7 +297,7 @@ public class TypedObjectValidationReport {
 		}
 	}
 	
-	private void nullifySortCacheFile() {
+	public void destroyCachedResources() {
 		if (this.fileForSorting != null) {
 			this.fileForSorting.delete();
 			this.fileForSorting = null;

--- a/src/us/kbase/typedobj/db/test/TypeRegisteringTest.java
+++ b/src/us/kbase/typedobj/db/test/TypeRegisteringTest.java
@@ -37,6 +37,7 @@ import org.junit.runners.Parameterized.Parameters;
 import com.mongodb.DB;
 import com.mongodb.MongoClient;
 
+import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.typedobj.core.AbsoluteTypeDefId;
 import us.kbase.typedobj.core.MD5;
@@ -60,7 +61,6 @@ import us.kbase.typedobj.exceptions.NoSuchPrivilegeException;
 import us.kbase.typedobj.exceptions.NoSuchTypeException;
 import us.kbase.typedobj.exceptions.SpecParseException;
 import us.kbase.typedobj.exceptions.TypeStorageException;
-import us.kbase.workspace.test.WorkspaceTestCommon;
 
 @RunWith(Parameterized.class)
 public class TypeRegisteringTest {
@@ -123,7 +123,7 @@ public class TypeRegisteringTest {
 
 	public TypeRegisteringTest(boolean useMongoParam) throws Exception {
 		useMongo = useMongoParam;
-		Path d = Paths.get(WorkspaceTestCommon.getTempDir())
+		Path d = Paths.get(TestCommon.getTempDir())
 				.resolve("TypeRegisteringTest");
 		Files.createDirectories(d);
 		TypeStorage innerStorage;
@@ -138,15 +138,15 @@ public class TypeRegisteringTest {
 	
 	public static DB createMongoDbConnection() throws Exception {
 		if (mongo == null) {
-			mongo = new MongoController(WorkspaceTestCommon.getMongoExe(),
-					Paths.get(WorkspaceTestCommon.getTempDir()),
-					WorkspaceTestCommon.useWiredTigerEngine());
+			mongo = new MongoController(TestCommon.getMongoExe(),
+					Paths.get(TestCommon.getTempDir()),
+					TestCommon.useWiredTigerEngine());
 			System.out.println("Using mongo temp dir " + 
 					mongo.getTempDir());
 		}
 		DB mdb = new MongoClient("localhost:" + mongo.getServerPort())
 			.getDB("TypeRegisteringTest");
-		WorkspaceTestCommon.destroyDB(mdb);
+		TestCommon.destroyDB(mdb);
 		return mdb;
 	}
 	
@@ -172,7 +172,7 @@ public class TypeRegisteringTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		if (mongo != null) {
-			mongo.destroy(WorkspaceTestCommon.deleteTempFiles());
+			mongo.destroy(TestCommon.deleteTempFiles());
 		}
 	}
 	

--- a/src/us/kbase/typedobj/test/BasicValidationTest.java
+++ b/src/us/kbase/typedobj/test/BasicValidationTest.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.TestException;
 import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.TypeDefId;
@@ -42,7 +43,6 @@ import us.kbase.typedobj.db.FileTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
-import us.kbase.workspace.test.WorkspaceTestCommon;
 
 
 /**
@@ -72,7 +72,7 @@ public class BasicValidationTest {
 	private static final int INVALID_TEST_COUNT = 29;
 
 	private final static Path TEST_DB_LOCATION =
-			Paths.get(WorkspaceTestCommon.getTempDir())
+			Paths.get(TestCommon.getTempDir())
 			.resolve("BasicValidationTest");
 	
 	private final static String TEST_RESOURCE_LOCATION = "files/BasicValidation/";

--- a/src/us/kbase/typedobj/test/DetailedValidationTest.java
+++ b/src/us/kbase/typedobj/test/DetailedValidationTest.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.TestException;
 import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.TypeDefId;
@@ -46,7 +47,6 @@ import us.kbase.typedobj.db.FileTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
-import us.kbase.workspace.test.WorkspaceTestCommon;
 
 
 /**
@@ -66,7 +66,7 @@ public class DetailedValidationTest {
 	 * WARNING: THIS DIRECTORY WILL BE WIPED OUT AFTER TESTS!!!
 	 */
 	private final static Path TEST_DB_LOCATION =
-			Paths.get(WorkspaceTestCommon.getTempDir())
+			Paths.get(TestCommon.getTempDir())
 			.resolve("DetailedValidationTest");
 	
 	private final static String TEST_RESOURCE_LOCATION = "files/DetailedValidation/";

--- a/src/us/kbase/typedobj/test/DummyIdHandlerFactory.java
+++ b/src/us/kbase/typedobj/test/DummyIdHandlerFactory.java
@@ -7,6 +7,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import us.kbase.common.exceptions.UnimplementedException;
+import us.kbase.common.utils.Counter;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.HandlerLockedException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandler;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandlerException;
@@ -14,7 +15,6 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFa
 import us.kbase.typedobj.idref.DefaultRemappedId;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
-import us.kbase.typedobj.util.Counter;
 
 public class DummyIdHandlerFactory implements IdReferenceHandlerFactory {
 

--- a/src/us/kbase/typedobj/test/IdProcessingTest.java
+++ b/src/us/kbase/typedobj/test/IdProcessingTest.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
+import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.TestException;
 import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.TypeDefId;
@@ -51,7 +52,6 @@ import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
 import us.kbase.typedobj.idref.IdReferenceType;
-import us.kbase.workspace.test.WorkspaceTestCommon;
 
 /**
  * Tests that ensure IDs are properly extracted from typed object instances, and that IDs
@@ -84,7 +84,7 @@ public class IdProcessingTest {
 	private final static String TEST_RESOURCE_LOCATION = "files/IdProcessing/";
 	
 	private final static Path TEST_DB_LOCATION =
-			Paths.get(WorkspaceTestCommon.getTempDir())
+			Paths.get(TestCommon.getTempDir())
 			.resolve("IdProcessingTest");
 	
 	/**

--- a/src/us/kbase/typedobj/test/MetadataExtractionTest.java
+++ b/src/us/kbase/typedobj/test/MetadataExtractionTest.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -208,7 +209,7 @@ public class MetadataExtractionTest {
 		JsonNode exception = testdataJson.get("exception");
 		JsonNode maxMetadataSize = testdataJson.get("maxMetadataSize");
 		
-		long maxMetadataSizeLong = -1;
+		long maxMetadataSizeLong = 16000;
 		if(maxMetadataSize!=null)
 			maxMetadataSizeLong = maxMetadataSize.asLong();
 		
@@ -228,7 +229,7 @@ public class MetadataExtractionTest {
 				report.isInstanceValid());
 		try {
 			ExtractedMetadata extraction = report.extractMetadata(maxMetadataSizeLong);
-			JsonNode actualMetadata = extraction.getMetadata();
+			Map<String, String> actualMetadata = extraction.getMetadata();
 			if(exception!=null) {
 				fail("  -("+instance.resourceName+") should throw an exception when getting subdata, but does not");
 			}
@@ -246,9 +247,10 @@ public class MetadataExtractionTest {
 		System.out.println("       PASS");
 	}
 
-	public void compare(JsonNode expectedSubset, JsonNode actualSubset, String resourceName) throws IOException {
+	public void compare(JsonNode expectedSubset, Map<String, String> actualMetadata, String resourceName) throws IOException {
 		assertEquals("  -("+resourceName+") extracted subset/metadata does not match expected extracted subset/metadata",
-				sortJson(expectedSubset), sortJson(actualSubset));
+				sortJson(expectedSubset), sortJson(
+						new ObjectMapper().valueToTree(actualMetadata)));
 	}
 
 	private static JsonNode sortJson(JsonNode tree) throws IOException {

--- a/src/us/kbase/typedobj/test/MetadataExtractionTest.java
+++ b/src/us/kbase/typedobj/test/MetadataExtractionTest.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
+import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.TestException;
 import us.kbase.typedobj.core.ExtractedMetadata;
 import us.kbase.typedobj.core.LocalTypeProvider;
@@ -47,7 +48,6 @@ import us.kbase.typedobj.db.FileTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
-import us.kbase.workspace.test.WorkspaceTestCommon;
 
 /**
  * Tests that ensure the proper subset is extracted from a typed object instance
@@ -69,7 +69,7 @@ public class MetadataExtractionTest {
 	 * WARNING: THIS DIRECTORY WILL BE WIPED OUT AFTER TESTS!!!!
 	 */
 	private final static Path TEST_DB_LOCATION =
-			Paths.get(WorkspaceTestCommon.getTempDir())
+			Paths.get(TestCommon.getTempDir())
 			.resolve("WsSubsetExtractionTest");
 	
 	/**

--- a/src/us/kbase/typedobj/test/TypedObjectValidationReportTest.java
+++ b/src/us/kbase/typedobj/test/TypedObjectValidationReportTest.java
@@ -328,15 +328,19 @@ public class TypedObjectValidationReportTest {
 		TypedObjectValidationReport tovr = validator.validate(json,
 				new TypeDefId("TestIDMap.IDMap"), handlers);
 		handlers.processIDs();
+		TempFilesManager tfm = new TempFilesManager(
+				new File(TestCommon.getTempDir()));
+		UTF8JsonSorterFactory sfac = new UTF8JsonSorterFactory(225);
 		try {
-			tovr.sort(SORT_FAC);
+			tovr.sort(sfac, tfm);
 			fail("sorting didn't detect duplicate keys");
 		} catch (KeyDuplicationException kde){
 			assertThat("correct exception message", kde.getLocalizedMessage(),
 					is("Duplicated key 'b' was found at /m"));
 		}
+		assertThat("Temp files manager is empty", tfm.isEmpty(), is(true));
 	}
-
+	
 	@Test
 	public void relabelAndSortInMemAndFile() throws Exception {
 		String json = "{\"m\": {\"z\": \"a\", \"b\": \"d\"}}";
@@ -423,6 +427,7 @@ public class TypedObjectValidationReportTest {
 					is("Memory necessary for sorting map keys exceeds the limit " +
 					maxmem + " bytes at /"));
 		}
+		assertThat("Temp files manager is empty", tfm.isEmpty(), is(true));
 		
 		//test with json stored in memory
 		int filelength = json.getBytes("UTF-8").length;

--- a/src/us/kbase/typedobj/test/TypedObjectValidationReportTest.java
+++ b/src/us/kbase/typedobj/test/TypedObjectValidationReportTest.java
@@ -22,6 +22,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import us.kbase.common.test.TestCommon;
 import us.kbase.common.utils.sortjson.KeyDuplicationException;
 import us.kbase.common.utils.sortjson.TooManyKeysException;
 import us.kbase.common.utils.sortjson.UTF8JsonSorterFactory;
@@ -38,7 +39,6 @@ import us.kbase.typedobj.idref.IdReference;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
 import us.kbase.typedobj.idref.IdReferenceType;
-import us.kbase.workspace.test.WorkspaceTestCommon;
 
 public class TypedObjectValidationReportTest {
 	
@@ -57,7 +57,7 @@ public class TypedObjectValidationReportTest {
 	@BeforeClass
 	public static void setupTypeDB() throws Exception {
 		//ensure test location is available
-		final Path temppath = Paths.get(WorkspaceTestCommon.getTempDir());
+		final Path temppath = Paths.get(TestCommon.getTempDir());
 		Files.createDirectories(temppath);
 		tempdir = Files.createTempDirectory(temppath, "TypedObjectValReportTest");
 		System.out.println("setting up temporary typed obj database");
@@ -154,7 +154,7 @@ public class TypedObjectValidationReportTest {
 					is("Sorter factory cannot be null"));
 		}
 		TempFilesManager tfm = new TempFilesManager(
-				new File(WorkspaceTestCommon.getTempDir()));
+				new File(TestCommon.getTempDir()));
 		try {
 			tovr.sort(null, tfm);
 			fail("sorted with no factory");
@@ -381,7 +381,7 @@ public class TypedObjectValidationReportTest {
 		handlers.processIDs();
 
 		TempFilesManager tfm = new TempFilesManager(
-				new File(WorkspaceTestCommon.getTempDir()));
+				new File(TestCommon.getTempDir()));
 		tfm.cleanup();
 		assertThat("Temp files manager is empty", tfm.isEmpty(), is(true));
 		tovr.sort(SORT_FAC, tfm);
@@ -408,7 +408,7 @@ public class TypedObjectValidationReportTest {
 		
 		int maxmem = 8 + 64 + 8 + 64;
 		TempFilesManager tfm = new TempFilesManager(
-				new File(WorkspaceTestCommon.getTempDir()));
+				new File(TestCommon.getTempDir()));
 		UTF8JsonSorterFactory fac = new UTF8JsonSorterFactory(maxmem);
 		
 		//test with json stored in file

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -117,7 +117,7 @@ public class WorkspaceServer extends JsonServerServlet {
     //TODO check shock version
     //TODO shock client should ignore extra fields
     
-	private static final String VER = "0.5.0-dev";
+	private static final String VER = "0.5.0-dev2";
 	private static final String GIT =
 			"https://github.com/kbase/workspace_deluxe";
 

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -51,8 +51,6 @@ import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.AppenderBase;
 
 //import org.apache.commons.lang3.builder.ToStringBuilder;
 
@@ -179,31 +177,6 @@ public class WorkspaceServer extends JsonServerServlet {
 				org.slf4j.Logger.ROOT_LOGGER_NAME));
 		rootLogger.setLevel(Level.OFF);
 		rootLogger.detachAndStopAllAppenders();
-		final Logger kbaseRootLogger = (Logger) LoggerFactory.getLogger(
-				"us.kbase");
-		//would be better to also set the level here on calls to the server
-		//setLogLevel, but meh for now
-		kbaseRootLogger.setLevel(Level.ALL);
-		final AppenderBase<ILoggingEvent> kbaseAppender =
-				new AppenderBase<ILoggingEvent>() {
-
-			@Override
-			protected void append(final ILoggingEvent event) {
-				//for now only INFO is tested; test others as they're needed
-				final Level l = event.getLevel();
-				if (l.equals(Level.TRACE)) {
-					logDebug(event.getFormattedMessage(), 3);
-				} else if (l.equals(Level.DEBUG)) {
-					logDebug(event.getFormattedMessage());
-				} else if (l.equals(Level.INFO) || l.equals(Level.WARN)) {
-					logInfo(event.getFormattedMessage());
-				} else if (l.equals(Level.ERROR)) {
-					logErr(event.getFormattedMessage());
-				}
-			}
-		};
-		kbaseAppender.start();
-		kbaseRootLogger.addAppender(kbaseAppender);
 	}
 	
 	private class WorkspaceInitReporter extends InitReporter {

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -255,7 +255,7 @@ public class WorkspaceServer extends JsonServerServlet {
 		WorkspaceAdministration wsadmin = null;
 		URL handleManagerUrl = null;
 		RefreshingToken handleMgrToken = null;
-		
+		//TODO TEST add server startup tests
 		if (cfg.hasErrors()) {
 			logErr("Workspace server configuration has errors - all calls will fail");
 			System.out.println(

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -59,7 +59,6 @@ import com.fasterxml.jackson.core.JsonParseException;
 public class Workspace {
 	
 	//TODO limit all methods that return a set or list or map
-	//TODO generalize descent into DAG for all methods
 	
 	//TODO general unit tests
 	//TODO BIG GC garbage collection - see WOR-45

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -670,6 +670,7 @@ public class Workspace {
 		reports.clear();
 		
 		sortObjects(saveobjs, ttlObjSize);
+		//TODO NOW try finally & delete reps
 		return db.saveObjects(user, rwsi, saveobjs);
 	}
 

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -670,8 +670,17 @@ public class Workspace {
 		reports.clear();
 		
 		sortObjects(saveobjs, ttlObjSize);
-		//TODO NOW try finally & delete reps
-		return db.saveObjects(user, rwsi, saveobjs);
+		try {
+			return db.saveObjects(user, rwsi, saveobjs);
+		} finally {
+			for (final ResolvedSaveObject wo: saveobjs) {
+				try {
+					wo.getRep().destroyCachedResources();
+				} catch (RuntimeException | Error e) {
+					//damn the torpedoes full speed ahead
+				}
+			}
+		}
 	}
 
 	private void sortObjects(

--- a/src/us/kbase/workspace/database/WorkspaceUserMetadata.java
+++ b/src/us/kbase/workspace/database/WorkspaceUserMetadata.java
@@ -1,7 +1,7 @@
 package us.kbase.workspace.database;
 
-import static us.kbase.typedobj.util.SizeUtils.checkJSONSizeInBytes;
-import static us.kbase.typedobj.util.SizeUtils.checkSizeInBytes;
+import static us.kbase.common.utils.SizeUtils.checkJSONSizeInBytes;
+import static us.kbase.common.utils.SizeUtils.checkSizeInBytes;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -1516,7 +1516,7 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 				ExtractedMetadata extract = o.getRep()
 						.extractMetadata(
 								WorkspaceUserMetadata.MAX_METADATA_SIZE);
-				pkg.wo.addUserMeta(extract.getMetadataAsMap());
+				pkg.wo.addUserMeta(extract.getMetadata());
 			} catch (ExceededMaxMetadataSizeException e) {
 				throw new IllegalArgumentException(String.format(
 						"Object %s: %s",

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -24,6 +24,7 @@ import org.bson.types.ObjectId;
 import org.jongo.FindAndModify;
 import org.jongo.Jongo;
 
+import us.kbase.common.utils.Counter;
 import us.kbase.common.utils.CountingOutputStream;
 import us.kbase.typedobj.core.AbsoluteTypeDefId;
 import us.kbase.typedobj.core.ExtractedMetadata;
@@ -35,7 +36,6 @@ import us.kbase.typedobj.exceptions.ExceededMaxMetadataSizeException;
 import us.kbase.typedobj.exceptions.TypedObjectExtractionException;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
-import us.kbase.typedobj.util.Counter;
 import us.kbase.workspace.database.AllUsers;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
 import us.kbase.workspace.database.ObjectReferenceSet;

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -2079,7 +2079,8 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 
 	private void cleanUpTempObjectFiles(
 			final Map<String, ByteArrayFileCache> chksumToData,
-			final Map<ObjectIDResolvedWS, Map<ObjectPaths, WorkspaceObjectData>> ret) {
+			final Map<ObjectIDResolvedWS, Map<ObjectPaths,
+				WorkspaceObjectData>> ret) {
 		for (final ByteArrayFileCache f: chksumToData.values()) {
 			f.destroy();
 		}

--- a/src/us/kbase/workspace/docserver/DocServer.java
+++ b/src/us/kbase/workspace/docserver/DocServer.java
@@ -75,7 +75,7 @@ public class DocServer extends HttpServlet {
 		 */
 		JsonServerSyslog templogger = new JsonServerSyslog(
 				DEFAULT_COMPANION_SERVICE_NAME, JsonServerServlet.KB_DEP,
-				JsonServerSyslog.LOG_LEVEL_INFO);
+				JsonServerSyslog.LOG_LEVEL_INFO, false);
 		if (sysLogOut != null) {
 			templogger.changeOutput(sysLogOut);
 		}
@@ -98,7 +98,7 @@ public class DocServer extends HttpServlet {
 			}
 		}
 		logger = new JsonServerSyslog(serverName, JsonServerServlet.KB_DEP,
-				JsonServerSyslog.LOG_LEVEL_INFO);
+				JsonServerSyslog.LOG_LEVEL_INFO, false);
 		if (sysLogOut != null) {
 			logger.changeOutput(sysLogOut);
 		}

--- a/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
+++ b/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
@@ -13,6 +13,7 @@ import org.jongo.MongoCollection;
 import org.jongo.marshall.MarshallingException;
 
 import com.mongodb.DB;
+import com.mongodb.MongoException;
 import com.mongodb.MongoTimeoutException;
 
 import us.kbase.abstracthandle.AbstractHandleClient;
@@ -294,6 +295,10 @@ public class InitWorkspaceServer {
 		} catch (IOException | MongoTimeoutException e) {
 			throw new WorkspaceInitException("Couldn't connect to mongo host " 
 					+ host + ": " + e.getLocalizedMessage(), e);
+		} catch (MongoException e) {
+			throw new WorkspaceInitException(
+					"There was an error connecting to the mongo database: " +
+					e.getLocalizedMessage());
 		} catch (MongoAuthException ae) {
 			throw new WorkspaceInitException("Not authorized for mongo database "
 					+ dbs + ": " + ae.getLocalizedMessage(), ae);

--- a/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
+++ b/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
@@ -13,6 +13,7 @@ import org.jongo.MongoCollection;
 import org.jongo.marshall.MarshallingException;
 
 import com.mongodb.DB;
+import com.mongodb.MongoTimeoutException;
 
 import us.kbase.abstracthandle.AbstractHandleClient;
 import us.kbase.auth.AuthConfig;
@@ -290,9 +291,9 @@ public class InitWorkspaceServer {
 		} catch (UnknownHostException uhe) {
 			throw new WorkspaceInitException("Couldn't find mongo host "
 					+ host + ": " + uhe.getLocalizedMessage(), uhe);
-		} catch (IOException io) {
+		} catch (IOException | MongoTimeoutException e) {
 			throw new WorkspaceInitException("Couldn't connect to mongo host " 
-					+ host + ": " + io.getLocalizedMessage(), io);
+					+ host + ": " + e.getLocalizedMessage(), e);
 		} catch (MongoAuthException ae) {
 			throw new WorkspaceInitException("Not authorized for mongo database "
 					+ dbs + ": " + ae.getLocalizedMessage(), ae);

--- a/src/us/kbase/workspace/test/WorkspaceTestCommon.java
+++ b/src/us/kbase/workspace/test/WorkspaceTestCommon.java
@@ -1,5 +1,8 @@
 package us.kbase.workspace.test;
 
+import static us.kbase.common.test.TestCommon.getProp;
+import static us.kbase.common.test.TestCommon.destroyDB;
+
 import java.net.URL;
 
 import us.kbase.common.test.TestException;
@@ -10,65 +13,14 @@ import com.mongodb.DBObject;
 
 public class WorkspaceTestCommon {
 	
-	public static final String SHOCKEXE = "test.shock.exe";
-	public static final String SHOCKVER = "test.shock.version";
-	public static final String MONGOEXE = "test.mongo.exe";
-	public static final String MONGO_USE_WIRED_TIGER = "test.mongo.useWiredTiger";
-	public static final String MYSQLEXE = "test.mysql.exe";
-	public static final String MYSQL_INSTALL_EXE = "test.mysql.install.exe";
 	public static final String PLACKUPEXE = "test.plackup.exe";
 	public static final String HANDLE_SRV_PSGI = "test.handle.service.psgi";
 	public static final String HANDLE_MGR_PSGI = "test.handle.manager.psgi";
 	public static final String HANDLE_PERL5LIB = "test.handle.PERL5LIB";
 	
-	public static final String TEST_TEMP_DIR = "test.temp.dir";
-	public static final String KEEP_TEMP_DIR = "test.temp.dir.keep";
 	public static final String GRIDFS = "gridFS";
 	public static final String SHOCK = "shock";
 			
-	public static void stfuLoggers() {
-		((ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
-				.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME))
-			.setLevel(ch.qos.logback.classic.Level.OFF);
-		java.util.logging.Logger.getLogger("com.mongodb")
-			.setLevel(java.util.logging.Level.OFF);
-	}
-	
-	public static void printJava() {
-		System.out.println("Java: " + System.getProperty("java.runtime.version"));
-	}
-	
-	private static String getProp(String prop) {
-		if (System.getProperty(prop) == null || prop.isEmpty()) {
-			throw new TestException("Property " + prop + " cannot be null or the empty string.");
-		}
-		return System.getProperty(prop);
-	}
-	
-	public static String getTempDir() {
-		return getProp(TEST_TEMP_DIR);
-	}
-	
-	public static String getMongoExe() {
-		return getProp(MONGOEXE);
-	}
-	
-	public static String getShockExe() {
-		return getProp(SHOCKEXE);
-	}
-	
-	public static String getShockVersion() {
-		return getProp(SHOCKVER);
-	}
-
-	public static String getMySQLExe() {
-		return getProp(MYSQLEXE);
-	}
-	
-	public static String getMySQLInstallExe() {
-		return getProp(MYSQL_INSTALL_EXE);
-	}
-	
 	public static String getPlackupExe() {
 		return getProp(PLACKUPEXE);
 	}
@@ -85,14 +37,6 @@ public class WorkspaceTestCommon {
 		return getProp(HANDLE_PERL5LIB);
 	}
 	
-	public static boolean deleteTempFiles() {
-		return !"true".equals(System.getProperty(KEEP_TEMP_DIR));
-	}
-	
-	public static boolean useWiredTigerEngine() {
-		return "true".equals(System.getProperty(MONGO_USE_WIRED_TIGER));
-	}
-	
 	//useful for tests starting a server with GFS as the backend
 	public static void initializeGridFSWorkspaceDB(DB mdb, String typedb) {
 		destroyWSandTypeDBs(mdb, typedb);
@@ -106,15 +50,6 @@ public class WorkspaceTestCommon {
 	public static void destroyWSandTypeDBs(DB mdb, String typedb) {
 		destroyDB(mdb);
 		destroyDB(mdb.getSisterDB(typedb));
-	}
-	
-	public static void destroyDB(DB db) {
-		for (String name: db.getCollectionNames()) {
-			if (!name.startsWith("system.")) {
-				// dropping collection also drops indexes
-				db.getCollection(name).remove(new BasicDBObject());
-			}
-		}
 	}
 	
 	//useful for tests starting a server with shock as the backend

--- a/src/us/kbase/workspace/test/database/mongo/GridFSBlobStoreTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/GridFSBlobStoreTest.java
@@ -20,6 +20,7 @@ import com.mongodb.MongoClient;
 import com.mongodb.gridfs.GridFS;
 import com.mongodb.gridfs.GridFSInputFile;
 
+import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.typedobj.core.MD5;
 import us.kbase.typedobj.core.TempFilesManager;
@@ -28,7 +29,6 @@ import us.kbase.workspace.database.ByteArrayFileCacheManager;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
 import us.kbase.workspace.database.mongo.GridFSBlobStore;
 import us.kbase.workspace.database.mongo.exceptions.BlobStoreException;
-import us.kbase.workspace.test.WorkspaceTestCommon;
 
 public class GridFSBlobStoreTest {
 	
@@ -42,13 +42,13 @@ public class GridFSBlobStoreTest {
 	
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		tfm = new TempFilesManager(new File(WorkspaceTestCommon.getTempDir()));
-		mongo = new MongoController(WorkspaceTestCommon.getMongoExe(),
-				Paths.get(WorkspaceTestCommon.getTempDir()),
-				WorkspaceTestCommon.useWiredTigerEngine());
+		tfm = new TempFilesManager(new File(TestCommon.getTempDir()));
+		mongo = new MongoController(TestCommon.getMongoExe(),
+				Paths.get(TestCommon.getTempDir()),
+				TestCommon.useWiredTigerEngine());
 		System.out.println("Using Mongo temp dir " +
 				mongo.getTempDir());
-		WorkspaceTestCommon.stfuLoggers();
+		TestCommon.stfuLoggers();
 		MongoClient mongoClient = new MongoClient("localhost:" + mongo.getServerPort());
 		DB db = mongoClient.getDB("GridFSBackendTest");
 		gfs = new GridFS(db);
@@ -59,7 +59,7 @@ public class GridFSBlobStoreTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		if (mongo != null) {
-			mongo.destroy(WorkspaceTestCommon.deleteTempFiles());
+			mongo.destroy(TestCommon.deleteTempFiles());
 		}
 	}
 	

--- a/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import us.kbase.common.mongo.GetMongoDB;
 import us.kbase.common.service.UObject;
+import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.typedobj.core.AbsoluteTypeDefId;
 import us.kbase.typedobj.core.LocalTypeProvider;
@@ -94,12 +95,12 @@ public class MongoInternalsTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		mongo = new MongoController(WorkspaceTestCommon.getMongoExe(),
-				Paths.get(WorkspaceTestCommon.getTempDir()),
-				WorkspaceTestCommon.useWiredTigerEngine());
+		mongo = new MongoController(TestCommon.getMongoExe(),
+				Paths.get(TestCommon.getTempDir()),
+				TestCommon.useWiredTigerEngine());
 		System.out.println("Using mongo temp dir " +
 				mongo.getTempDir());
-		WorkspaceTestCommon.stfuLoggers();
+		TestCommon.stfuLoggers();
 		String mongohost = "localhost:" + mongo.getServerPort();
 		mongoClient = new MongoClient(mongohost);
 		final DB db = mongoClient.getDB("MongoInternalsTest");
@@ -108,7 +109,7 @@ public class MongoInternalsTest {
 		jdb = new Jongo(db);
 		
 		TempFilesManager tfm = new TempFilesManager(
-				new File(WorkspaceTestCommon.getTempDir()));
+				new File(TestCommon.getTempDir()));
 		final TypeDefinitionDB typeDefDB = new TypeDefinitionDB(
 				new MongoTypeStorage(GetMongoDB.getDB(mongohost, typedb)));
 		TypedObjectValidator val = new TypedObjectValidator(
@@ -135,7 +136,7 @@ public class MongoInternalsTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		if (mongo != null) {
-			mongo.destroy(WorkspaceTestCommon.deleteTempFiles());
+			mongo.destroy(TestCommon.deleteTempFiles());
 		}
 	}
 	
@@ -143,7 +144,7 @@ public class MongoInternalsTest {
 	public void startUpAndCheckConfigDoc() throws Exception {
 		final DB db = mongoClient.getDB("startUpAndCheckConfigDoc");
 		TempFilesManager tfm = new TempFilesManager(
-				new File(WorkspaceTestCommon.getTempDir()));
+				new File(TestCommon.getTempDir()));
 		new MongoWorkspaceDB(db, new GridFSBlobStore(db), tfm);
 		
 		DBCursor c = db.getCollection("config").find();
@@ -213,7 +214,7 @@ public class MongoInternalsTest {
 	private void failMongoWSStart(final DB db, final Exception exp)
 			throws Exception {
 		TempFilesManager tfm = new TempFilesManager(
-				new File(WorkspaceTestCommon.getTempDir()));
+				new File(TestCommon.getTempDir()));
 		try {
 			new MongoWorkspaceDB(db, new GridFSBlobStore(db), tfm);
 			fail("started mongo with bad config");

--- a/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreTest.java
@@ -25,6 +25,7 @@ import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 
 import us.kbase.auth.AuthService;
+import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.TestException;
 import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.common.test.controllers.shock.ShockController;
@@ -40,7 +41,6 @@ import us.kbase.workspace.database.mongo.Fields;
 import us.kbase.workspace.database.mongo.ShockBlobStore;
 import us.kbase.workspace.database.mongo.exceptions.BlobStoreAuthorizationException;
 import us.kbase.workspace.database.mongo.exceptions.NoSuchBlobException;
-import us.kbase.workspace.test.WorkspaceTestCommon;
 
 public class ShockBlobStoreTest {
 	
@@ -61,11 +61,11 @@ public class ShockBlobStoreTest {
 		String u1 = System.getProperty("test.user1");
 		String p1 = System.getProperty("test.pwd1");
 		
-		tfm = new TempFilesManager(new File(WorkspaceTestCommon.getTempDir()));
-		WorkspaceTestCommon.stfuLoggers();
-		mongoCon = new MongoController(WorkspaceTestCommon.getMongoExe(),
-				Paths.get(WorkspaceTestCommon.getTempDir()),
-				WorkspaceTestCommon.useWiredTigerEngine());
+		tfm = new TempFilesManager(new File(TestCommon.getTempDir()));
+		TestCommon.stfuLoggers();
+		mongoCon = new MongoController(TestCommon.getMongoExe(),
+				Paths.get(TestCommon.getTempDir()),
+				TestCommon.useWiredTigerEngine());
 		System.out.println("Using Mongo temp dir " + mongoCon.getTempDir());
 		
 		String mongohost = "localhost:" + mongoCon.getServerPort();
@@ -73,9 +73,9 @@ public class ShockBlobStoreTest {
 		mongo = mongoClient.getDB("ShockBackendTest");
 		
 		shock = new ShockController(
-				WorkspaceTestCommon.getShockExe(),
-				WorkspaceTestCommon.getShockVersion(),
-				Paths.get(WorkspaceTestCommon.getTempDir()),
+				TestCommon.getShockExe(),
+				TestCommon.getShockVersion(),
+				Paths.get(TestCommon.getTempDir()),
 				"***---fakeuser---***",
 				mongohost,
 				"ShockBackendTest_ShockDB",
@@ -101,10 +101,10 @@ public class ShockBlobStoreTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		if (shock != null) {
-			shock.destroy(WorkspaceTestCommon.deleteTempFiles());
+			shock.destroy(TestCommon.deleteTempFiles());
 		}
 		if (mongoCon != null) {
-			mongoCon.destroy(WorkspaceTestCommon.deleteTempFiles());
+			mongoCon.destroy(TestCommon.deleteTempFiles());
 		}
 	}
 	

--- a/src/us/kbase/workspace/test/docserver/DocServerTest.java
+++ b/src/us/kbase/workspace/test/docserver/DocServerTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -37,8 +36,8 @@ import org.productivity.java.syslog4j.SyslogIF;
 
 import us.kbase.common.service.JsonServerSyslog;
 import us.kbase.common.service.JsonServerSyslog.SyslogOutput;
+import us.kbase.common.test.TestCommon;
 import us.kbase.workspace.docserver.DocServer;
-import us.kbase.workspace.test.WorkspaceTestCommon;
 
 public class DocServerTest {
 	
@@ -65,15 +64,15 @@ public class DocServerTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		WorkspaceTestCommon.stfuLoggers();
+		TestCommon.stfuLoggers();
 		logout = new SysLogOutputMock();
 		DocServer.setLoggerOutput(logout);
-		Files.createDirectories(Paths.get(WorkspaceTestCommon.getTempDir())
+		Files.createDirectories(Paths.get(TestCommon.getTempDir())
 				.toAbsolutePath());
 		
 		server = createServer("TestDocServer",
 				"/us/kbase/workspace/test/docserver");
-		iniFile = new File(getenv().get("KB_DEPLOYMENT_CONFIG"));
+		iniFile = new File(TestCommon.getenv().get("KB_DEPLOYMENT_CONFIG"));
 		docURL = getServerURL(server);
 		System.out.println("Started doc server at " + docURL);
 	}
@@ -88,7 +87,7 @@ public class DocServerTest {
 			throws IOException, NoSuchFieldException, IllegalAccessException,
 			InterruptedException {
 		File iniFile = File.createTempFile("test", ".cfg",
-				new File(WorkspaceTestCommon.getTempDir()));
+				new File(TestCommon.getTempDir()));
 		Ini ini = new Ini();
 		Section ws = ini.add("Workspace");
 		if (serverName != null) {
@@ -103,7 +102,7 @@ public class DocServerTest {
 				iniFile.getAbsolutePath());
 		
 		//set up env
-		Map<String, String> env = getenv();
+		Map<String, String> env = TestCommon.getenv();
 		env.put("KB_DEPLOYMENT_CONFIG", iniFile.getAbsolutePath());
 		env.put("KB_SERVICE_NAME", "Workspace");
 		
@@ -116,7 +115,7 @@ public class DocServerTest {
 	}
 	
 	private void restoreEnv() throws Exception {
-		Map<String, String> env = getenv();
+		Map<String, String> env = TestCommon.getenv();
 		env.put("KB_DEPLOYMENT_CONFIG", iniFile.getAbsolutePath());
 		env.put("KB_SERVICE_NAME", "Workspace");
 		DocServer.setDefaultDocsLocation(DocServer.DEFAULT_DOCS_LOC);
@@ -127,18 +126,6 @@ public class DocServerTest {
 		if (server != null) {
 			server.stopServer();
 		}
-	}
-	
-	//TODO put this in test utils in common, used all over
-	//http://quirkygba.blogspot.com/2009/11/setting-environment-variables-in-java.html
-	@SuppressWarnings("unchecked")
-	protected static Map<String, String> getenv() throws NoSuchFieldException,
-	SecurityException, IllegalArgumentException, IllegalAccessException {
-		Map<String, String> unmodifiable = System.getenv();
-		Class<?> cu = unmodifiable.getClass();
-		Field m = cu.getDeclaredField("m");
-		m.setAccessible(true);
-		return (Map<String, String>) m.get(unmodifiable);
 	}
 	
 	protected static class ServerThread extends Thread {

--- a/src/us/kbase/workspace/test/kbase/HandleTest.java
+++ b/src/us/kbase/workspace/test/kbase/HandleTest.java
@@ -34,6 +34,7 @@ import us.kbase.common.mongo.exceptions.InvalidHostException;
 import us.kbase.common.service.ServerException;
 import us.kbase.common.service.UObject;
 import us.kbase.common.service.UnauthorizedException;
+import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.TestException;
 import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.common.test.controllers.mysql.MySQLController;
@@ -113,19 +114,19 @@ public class HandleTest {
 			throw new TestException("Could not log in test user test.user3: " + u3, e);
 		}
 		
-		WorkspaceTestCommon.stfuLoggers();
+		TestCommon.stfuLoggers();
 		
-		MONGO = new MongoController(WorkspaceTestCommon.getMongoExe(),
-				Paths.get(WorkspaceTestCommon.getTempDir()),
-				WorkspaceTestCommon.useWiredTigerEngine());
+		MONGO = new MongoController(TestCommon.getMongoExe(),
+				Paths.get(TestCommon.getTempDir()),
+				TestCommon.useWiredTigerEngine());
 		System.out.println("Using Mongo temp dir " + MONGO.getTempDir());
 		final String mongohost = "localhost:" + MONGO.getServerPort();
 		MongoClient mongoClient = new MongoClient(mongohost);
 
 		SHOCK = new ShockController(
-				WorkspaceTestCommon.getShockExe(),
-				WorkspaceTestCommon.getShockVersion(),
-				Paths.get(WorkspaceTestCommon.getTempDir()),
+				TestCommon.getShockExe(),
+				TestCommon.getShockVersion(),
+				Paths.get(TestCommon.getTempDir()),
 				u3,
 				mongohost,
 				"JSONRPCLayerHandleTest_ShockDB",
@@ -139,9 +140,9 @@ public class HandleTest {
 		System.out.println("Using Shock temp dir " + SHOCK.getTempDir());
 
 		MYSQL = new MySQLController(
-				WorkspaceTestCommon.getMySQLExe(),
-				WorkspaceTestCommon.getMySQLInstallExe(),
-				Paths.get(WorkspaceTestCommon.getTempDir()));
+				TestCommon.getMySQLExe(),
+				TestCommon.getMySQLInstallExe(),
+				Paths.get(TestCommon.getTempDir()));
 		System.out.println("Using MySQL temp dir " + MYSQL.getTempDir());
 		
 		HANDLE = new HandleServiceController(
@@ -154,7 +155,7 @@ public class HandleTest {
 				u3,
 				p3,
 				WorkspaceTestCommon.getHandlePERL5LIB(),
-				Paths.get(WorkspaceTestCommon.getTempDir()));
+				Paths.get(TestCommon.getTempDir()));
 		System.out.println("Using Handle Service temp dir " +
 				HANDLE.getTempDir());
 		
@@ -229,7 +230,7 @@ public class HandleTest {
 
 		//write the server config file:
 		File iniFile = File.createTempFile("test", ".cfg",
-				new File(WorkspaceTestCommon.getTempDir()));
+				new File(TestCommon.getTempDir()));
 		if (iniFile.exists()) {
 			iniFile.delete();
 		}
@@ -249,13 +250,13 @@ public class HandleTest {
 		ws.add("ws-admin", USER2);
 		ws.add("kbase-admin-user", handleUser);
 		ws.add("kbase-admin-pwd", handlePwd);
-		ws.add("temp-dir", Paths.get(WorkspaceTestCommon.getTempDir())
+		ws.add("temp-dir", Paths.get(TestCommon.getTempDir())
 				.resolve("tempForJSONRPCLayerTester"));
 		ini.store(iniFile);
 		iniFile.deleteOnExit();
 
 		//set up env
-		Map<String, String> env = JSONRPCLayerTester.getenv();
+		Map<String, String> env = TestCommon.getenv();
 		env.put("KB_DEPLOYMENT_CONFIG", iniFile.getAbsolutePath());
 		env.put("KB_SERVICE_NAME", "Workspace");
 
@@ -277,16 +278,16 @@ public class HandleTest {
 			System.out.println("Done");
 		}
 		if (HANDLE != null) {
-			HANDLE.destroy(WorkspaceTestCommon.deleteTempFiles());
+			HANDLE.destroy(TestCommon.deleteTempFiles());
 		}
 		if (SHOCK != null) {
-			SHOCK.destroy(WorkspaceTestCommon.deleteTempFiles());
+			SHOCK.destroy(TestCommon.deleteTempFiles());
 		}
 		if (MONGO != null) {
-			MONGO.destroy(WorkspaceTestCommon.deleteTempFiles());
+			MONGO.destroy(TestCommon.deleteTempFiles());
 		}
 		if (MYSQL != null) {
-			MYSQL.destroy(WorkspaceTestCommon.deleteTempFiles());
+			MYSQL.destroy(TestCommon.deleteTempFiles());
 		}
 	}
 

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
@@ -1505,7 +1505,7 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 	}
 	
 	@Test
-	public void saveBigMeta() throws Exception {
+	public void metadataBig() throws Exception {
 		CLIENT1.createWorkspace(new CreateWorkspaceParams().withWorkspace("bigmeta"));
 
 		Map<String, Object> moredata = new HashMap<String, Object>();

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
@@ -85,7 +85,7 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 	
 	@Test
 	public void ver() throws Exception {
-		assertThat("got correct version", CLIENT_NO_AUTH.ver(), is("0.5.0-dev"));
+		assertThat("got correct version", CLIENT_NO_AUTH.ver(), is("0.5.0-dev2"));
 	}
 	
 	@Test

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
@@ -151,8 +151,8 @@ public class JSONRPCLayerTester {
 	public static final Map<String, String> MT_META =
 			new HashMap<String, String>();
 	
-	private static List<TempFilesManager> tfms =
-			new LinkedList<TempFilesManager>();;
+	private static List<TempFilesManager> TFMS =
+			new LinkedList<TempFilesManager>();
 	
 	protected static class ServerThread extends Thread {
 		private WorkspaceServer server;
@@ -356,7 +356,7 @@ public class JSONRPCLayerTester {
 						server.getWorkspaceResourceUsageConfig())
 				.withMaxIncomingDataMemoryUsage(24)
 				.withMaxReturnedDataMemoryUsage(24).build());
-		tfms.add(server.getTempFilesManager());
+		TFMS.add(server.getTempFilesManager());
 		new ServerThread(server).start();
 		System.out.println("Main thread waiting for server to start up");
 		while (server.getServerPort() == null) {
@@ -422,7 +422,7 @@ public class JSONRPCLayerTester {
 	
 	@After
 	public void cleanupTempFilesAfterTest() throws Exception {
-		assertNoTempFilesExist(tfms);
+		assertNoTempFilesExist(TFMS);
 	}
 	
 	protected void checkWS(Tuple9<Long, String, String, String, Long, String, String, String, Map<String, String>> info,

--- a/src/us/kbase/workspace/test/kbase/LoggingTest.java
+++ b/src/us/kbase/workspace/test/kbase/LoggingTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.lang.reflect.Field;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -32,6 +31,7 @@ import us.kbase.common.service.JsonServerSyslog;
 import us.kbase.common.service.UObject;
 import us.kbase.common.service.UnauthorizedException;
 import us.kbase.common.service.JsonServerSyslog.SyslogOutput;
+import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.TestException;
 import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.workspace.CopyObjectParams;
@@ -64,7 +64,7 @@ import com.mongodb.MongoClient;
  */
 public class LoggingTest {
 	
-	//TODO it'd be nice if JsonServerServlet integrated with slf4j
+	//TODO NOW it'd be nice if JsonServerServlet integrated with slf4j
 
 	private static final String DB_WS_NAME = "LoggingTest";
 	private static final String DB_TYPE_NAME = "LoggingTest_Types";
@@ -98,9 +98,9 @@ public class LoggingTest {
 		String p2 = System.getProperty("test.pwd2");
 		
 //		WorkspaceTestCommon.stfuLoggers();
-		mongo = new MongoController(WorkspaceTestCommon.getMongoExe(),
-				Paths.get(WorkspaceTestCommon.getTempDir()),
-				WorkspaceTestCommon.useWiredTigerEngine());
+		mongo = new MongoController(TestCommon.getMongoExe(),
+				Paths.get(TestCommon.getTempDir()),
+				TestCommon.useWiredTigerEngine());
 		System.out.println("Using mongo temp dir " + mongo.getTempDir());
 		
 		final String mongohost = "localhost:" + mongo.getServerPort();
@@ -156,19 +156,6 @@ public class LoggingTest {
 		CLIENT1.releaseModule("SomeModule");
 	}
 	
-	//TODO move to common, used everywhere
-	//http://quirkygba.blogspot.com/2009/11/setting-environment-variables-in-java.html
-	@SuppressWarnings("unchecked")
-	protected static Map<String, String> getenv() throws NoSuchFieldException,
-			SecurityException, IllegalArgumentException,
-			IllegalAccessException {
-		Map<String, String> unmodifiable = System.getenv();
-		Class<?> cu = unmodifiable.getClass();
-		Field m = cu.getDeclaredField("m");
-		m.setAccessible(true);
-		return (Map<String, String>) m.get(unmodifiable);
-	}
-
 	public static void administerCommand(WorkspaceClient client,
 			String command, String... params)
 			throws IOException, JsonClientException {
@@ -186,7 +173,7 @@ public class LoggingTest {
 		
 		//write the server config file:
 		File iniFile = File.createTempFile("test", ".cfg",
-				new File(WorkspaceTestCommon.getTempDir()));
+				new File(TestCommon.getTempDir()));
 		if (iniFile.exists()) {
 			iniFile.delete();
 		}
@@ -200,14 +187,14 @@ public class LoggingTest {
 		ws.add("ws-admin", USER2);
 		ws.add("kbase-admin-user", USER1);
 		ws.add("kbase-admin-pwd", user1Password);
-		ws.add("temp-dir", Paths.get(WorkspaceTestCommon.getTempDir())
+		ws.add("temp-dir", Paths.get(TestCommon.getTempDir())
 				.resolve("tempForLoggingTest"));
 		ws.add("ignore-handle-service", "true");
 		ini.store(iniFile);
 		iniFile.deleteOnExit();
 		
 		//set up env
-		Map<String, String> env = getenv();
+		Map<String, String> env = TestCommon.getenv();
 		env.put("KB_DEPLOYMENT_CONFIG", iniFile.getAbsolutePath());
 		env.put("KB_SERVICE_NAME", "Workspace");
 
@@ -230,7 +217,7 @@ public class LoggingTest {
 		}
 		if (mongo != null) {
 			System.out.println("destroying mongo temp files");
-			mongo.destroy(WorkspaceTestCommon.deleteTempFiles());
+			mongo.destroy(TestCommon.deleteTempFiles());
 		}
 	}
 
@@ -239,7 +226,7 @@ public class LoggingTest {
 		logout.reset();
 		DB wsdb1 = GetMongoDB.getDB("localhost:" + mongo.getServerPort(),
 				DB_WS_NAME);
-		WorkspaceTestCommon.destroyDB(wsdb1);
+		TestCommon.destroyDB(wsdb1);
 	}
 	
 	private static class LogEvent {

--- a/src/us/kbase/workspace/test/scripts/ScriptTestRunner.java
+++ b/src/us/kbase/workspace/test/scripts/ScriptTestRunner.java
@@ -6,7 +6,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.file.Paths;
@@ -28,6 +27,7 @@ import us.kbase.auth.AuthService;
 import us.kbase.auth.AuthUser;
 import us.kbase.common.mongo.exceptions.InvalidHostException;
 import us.kbase.common.service.UnauthorizedException;
+import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.TestException;
 import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.common.test.controllers.mysql.MySQLController;
@@ -89,17 +89,6 @@ public class ScriptTestRunner {
 				e.printStackTrace();
 			}
 		}
-	}
-	
-	//http://quirkygba.blogspot.com/2009/11/setting-environment-variables-in-java.html
-	@SuppressWarnings("unchecked")
-	private static Map<String, String> getenv() throws NoSuchFieldException,
-			SecurityException, IllegalArgumentException, IllegalAccessException {
-		Map<String, String> unmodifiable = System.getenv();
-		Class<?> cu = unmodifiable.getClass();
-		Field m = cu.getDeclaredField("m");
-		m.setAccessible(true);
-		return (Map<String, String>) m.get(unmodifiable);
 	}
 	
 	@Test
@@ -201,20 +190,20 @@ public class ScriptTestRunner {
 			throw new TestException("Could not log in test user test.user3: " + u3, e);
 		}
 		
-		WorkspaceTestCommon.stfuLoggers();
+		TestCommon.stfuLoggers();
 		
-		String tempDir = Paths.get(WorkspaceTestCommon.getTempDir())
+		String tempDir = Paths.get(TestCommon.getTempDir())
 							.resolve(TMP_FILE_SUBDIR).toString();
 		
-		MONGO = new MongoController(WorkspaceTestCommon.getMongoExe(),
-				Paths.get(tempDir), WorkspaceTestCommon.useWiredTigerEngine());
+		MONGO = new MongoController(TestCommon.getMongoExe(),
+				Paths.get(tempDir), TestCommon.useWiredTigerEngine());
 		System.out.println("Using Mongo temp dir " + MONGO.getTempDir());
 		final String mongohost = "localhost:" + MONGO.getServerPort();
 		MongoClient mongoClient = new MongoClient(mongohost);
 
 		SHOCK = new ShockController(
-				WorkspaceTestCommon.getShockExe(),
-				WorkspaceTestCommon.getShockVersion(),
+				TestCommon.getShockExe(),
+				TestCommon.getShockVersion(),
 				Paths.get(tempDir),
 				u3,
 				mongohost,
@@ -229,8 +218,8 @@ public class ScriptTestRunner {
 		System.out.println("Using Shock temp dir " + SHOCK.getTempDir());
 
 		MYSQL = new MySQLController(
-				WorkspaceTestCommon.getMySQLExe(),
-				WorkspaceTestCommon.getMySQLInstallExe(),
+				TestCommon.getMySQLExe(),
+				TestCommon.getMySQLInstallExe(),
 				Paths.get(tempDir));
 		System.out.println("Using MySQL temp dir " + MYSQL.getTempDir());
 		
@@ -290,7 +279,7 @@ public class ScriptTestRunner {
 
 		//write the server config file:
 		File iniFile = File.createTempFile("test", ".cfg",
-				new File(WorkspaceTestCommon.getTempDir()));
+				new File(TestCommon.getTempDir()));
 		if (iniFile.exists()) {
 			iniFile.delete();
 		}
@@ -308,13 +297,13 @@ public class ScriptTestRunner {
 		ws.add("handle-manager-user", handleUser);
 		ws.add("handle-manager-pwd", handlePwd);
 		ws.add("ws-admin", USER2);
-		ws.add("temp-dir", Paths.get(WorkspaceTestCommon.getTempDir())
+		ws.add("temp-dir", Paths.get(TestCommon.getTempDir())
 				.resolve(TMP_FILE_SUBDIR));
 		ini.store(iniFile);
 		iniFile.deleteOnExit();
 
 		//set up env
-		Map<String, String> env = getenv();
+		Map<String, String> env = TestCommon.getenv();
 		env.put("KB_DEPLOYMENT_CONFIG", iniFile.getAbsolutePath());
 		env.put("KB_SERVICE_NAME", "Workspace");
 
@@ -338,22 +327,22 @@ public class ScriptTestRunner {
 		}
 		if (HANDLE != null) {
 			System.out.print("Destroying handle service... ");
-			HANDLE.destroy(WorkspaceTestCommon.deleteTempFiles());
+			HANDLE.destroy(TestCommon.deleteTempFiles());
 			System.out.println("Done");
 		}
 		if (SHOCK != null) {
 			System.out.print("Destroying shock service... ");
-			SHOCK.destroy(WorkspaceTestCommon.deleteTempFiles());
+			SHOCK.destroy(TestCommon.deleteTempFiles());
 			System.out.println("Done");
 		}
 		if (MONGO != null) {
 			System.out.print("Destroying mongo test service... ");
-			MONGO.destroy(WorkspaceTestCommon.deleteTempFiles());
+			MONGO.destroy(TestCommon.deleteTempFiles());
 			System.out.println("Done");
 		}
 		if (MYSQL != null) {
 			System.out.print("Destroying mysql test service... ");
-			MYSQL.destroy(WorkspaceTestCommon.deleteTempFiles());
+			MYSQL.destroy(TestCommon.deleteTempFiles());
 			System.out.println("Done");
 		}
 	}

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import us.kbase.common.service.JsonTokenStream;
+import us.kbase.common.test.TestCommon;
 import us.kbase.typedobj.core.AbsoluteTypeDefId;
 import us.kbase.typedobj.core.ObjectPaths;
 import us.kbase.typedobj.core.TempFileListener;
@@ -80,7 +81,6 @@ import us.kbase.workspace.database.exceptions.NoSuchReferenceException;
 import us.kbase.workspace.database.exceptions.NoSuchWorkspaceException;
 import us.kbase.workspace.database.exceptions.PreExistingWorkspaceException;
 import us.kbase.workspace.exceptions.WorkspaceAuthorizationException;
-import us.kbase.workspace.test.kbase.JSONRPCLayerTester;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -1367,7 +1367,7 @@ public class WorkspaceTest extends WorkspaceTester {
 						"Object #1, whooop: The user-provided metadata, when updated with object-extracted metadata, exceeds the allowed maximum of 16000B"));
 	
 		ws.setResourceConfig(oldcfg);
-		assertNoTempFilesExist(tfm);
+		TestCommon.assertNoTempFilesExist(tfm);
 	}
 	
 	@Test
@@ -6729,35 +6729,35 @@ public class WorkspaceTest extends WorkspaceTester {
 				new ObjIDWithChainAndSubset(oi, null,
 				new ObjectPaths(Arrays.asList("z")))))).get(0).getSerializedData().destroy();
 		assertThat("created 1 temp file on get subdata", filesCreated[0], is(1));
-		JSONRPCLayerTester.assertNoTempFilesExist(ws.getTempFilesManager());
+		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());
 		
 		//files go to disk except for small subdata
 		filesCreated[0] = 0;
 		ws.setResourceConfig(build.withMaxIncomingDataMemoryUsage(12).build());
 		ws.saveObjects(user, wsi, objs, getIdFactory());
 		assertThat("created temp files on save", filesCreated[0], is(2));
-		JSONRPCLayerTester.assertNoTempFilesExist(ws.getTempFilesManager());
+		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());
 		
 		filesCreated[0] = 0;
 		ws.setResourceConfig(build.withMaxReturnedDataMemoryUsage(12).build());
 		oi = new ObjectIdentifier(wsi, 2);
 		ws.getObjects(user, Arrays.asList(oi)).get(0).getSerializedData().destroy();
 		assertThat("created 1 temp files on get", filesCreated[0], is(1));
-		JSONRPCLayerTester.assertNoTempFilesExist(ws.getTempFilesManager());
+		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());
 		
 		filesCreated[0] = 0;
 		ws.getObjects(user, new ArrayList<ObjectIdentifier>(Arrays.asList(
 				new ObjIDWithChainAndSubset(oi, null,
 				new ObjectPaths(Arrays.asList("z")))))).get(0).getSerializedData().destroy();
 		assertThat("created 1 temp files on get subdata part object", filesCreated[0], is(1));
-		JSONRPCLayerTester.assertNoTempFilesExist(ws.getTempFilesManager());
+		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());
 		
 		filesCreated[0] = 0;
 		ws.getObjects(user, new ArrayList<ObjectIdentifier>(Arrays.asList(
 				new ObjIDWithChainAndSubset(oi, null,
 				new ObjectPaths(Arrays.asList("z", "y")))))).get(0).getSerializedData().destroy();
 		assertThat("created 2 temp files on get subdata full object", filesCreated[0], is(2));
-		JSONRPCLayerTester.assertNoTempFilesExist(ws.getTempFilesManager());
+		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());
 		
 		// test with multiple objects
 		Map<String, Object> data2 = new LinkedHashMap<String, Object>();
@@ -6783,7 +6783,7 @@ public class WorkspaceTest extends WorkspaceTester {
 			wod.getSerializedData().destroy();
 		}
 		assertThat("created no temp files on get", filesCreated[0], is(0));
-		JSONRPCLayerTester.assertNoTempFilesExist(ws.getTempFilesManager());
+		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());
 		
 		//multiple objects to file
 		ws.setResourceConfig(build.withMaxIncomingDataMemoryUsage(38).build());
@@ -6791,7 +6791,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		ws.saveObjects(user, wsi, objs, getIdFactory());
 		//two files per data - 1 for relabeling, 1 for sort
 		assertThat("created temp files on save", filesCreated[0], is(4));
-		JSONRPCLayerTester.assertNoTempFilesExist(ws.getTempFilesManager());
+		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());
 		
 		filesCreated[0] = 0;
 		ws.setResourceConfig(build.withMaxReturnedDataMemoryUsage(38).build());
@@ -6799,7 +6799,7 @@ public class WorkspaceTest extends WorkspaceTester {
 			wod.getSerializedData().destroy();
 		}
 		assertThat("created 1 temp files on get", filesCreated[0], is(1));
-		JSONRPCLayerTester.assertNoTempFilesExist(ws.getTempFilesManager());
+		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());
 		
 		filesCreated[0] = 0;
 		ws.setResourceConfig(build.withMaxReturnedDataMemoryUsage(25).build());
@@ -6807,7 +6807,7 @@ public class WorkspaceTest extends WorkspaceTester {
 			wod.getSerializedData().destroy();
 		}
 		assertThat("created 2 temp files on get", filesCreated[0], is(2));
-		JSONRPCLayerTester.assertNoTempFilesExist(ws.getTempFilesManager());
+		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());
 		
 		ws.getTempFilesManager().removeListener(listener);
 		ws.setResourceConfig(oldcfg);

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -1228,6 +1228,14 @@ public class WorkspaceTest extends WorkspaceTester {
 	
 	@Test
 	public void metadataExtractedLargeTest() throws Exception {
+		//make sure all temporary files are deleted when errors occur here
+		//TODO NOW should have 5 temp files when tests is over before fix. NOw have one. Maybe because only 1 needs sorting?
+		ResourceUsageConfiguration oldcfg = ws.getResourceConfig();
+		ResourceUsageConfigurationBuilder build =
+				new ResourceUsageConfigurationBuilder(oldcfg);
+		ws.setResourceConfig(build.withMaxIncomingDataMemoryUsage(1).build());
+		tfm.cleanup();
+		
 		String module = "TestLargeMetadata";
 		String typeName = "BigMeta";
 		String nestmeta = "." + TEXT100.substring(16) + "." +
@@ -1357,6 +1365,9 @@ public class WorkspaceTest extends WorkspaceTester {
 				new WorkspaceUserMetadata(meta), mtprov, false)),
 				new IllegalArgumentException(
 						"Object #1, whooop: The user-provided metadata, when updated with object-extracted metadata, exceeds the allowed maximum of 16000B"));
+	
+		ws.setResourceConfig(oldcfg);
+		assertNoTempFilesExist(tfm);
 	}
 	
 	@Test

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -1231,9 +1231,9 @@ public class WorkspaceTest extends WorkspaceTester {
 		//make sure all temporary files are deleted when errors occur here
 		//TODO NOW should have 5 temp files when tests is over before fix. NOw have one. Maybe because only 1 needs sorting?
 		ResourceUsageConfiguration oldcfg = ws.getResourceConfig();
-		ResourceUsageConfigurationBuilder build =
-				new ResourceUsageConfigurationBuilder(oldcfg);
-		ws.setResourceConfig(build.withMaxIncomingDataMemoryUsage(1).build());
+//		ResourceUsageConfigurationBuilder build =
+//				new ResourceUsageConfigurationBuilder(oldcfg);
+//		ws.setResourceConfig(build.withMaxIncomingDataMemoryUsage(1).build());
 		tfm.cleanup();
 		
 		String module = "TestLargeMetadata";

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -1229,11 +1229,10 @@ public class WorkspaceTest extends WorkspaceTester {
 	@Test
 	public void metadataExtractedLargeTest() throws Exception {
 		//make sure all temporary files are deleted when errors occur here
-		//TODO NOW should have 5 temp files when tests is over before fix. NOw have one. Maybe because only 1 needs sorting?
-		ResourceUsageConfiguration oldcfg = ws.getResourceConfig();
-//		ResourceUsageConfigurationBuilder build =
-//				new ResourceUsageConfigurationBuilder(oldcfg);
-//		ws.setResourceConfig(build.withMaxIncomingDataMemoryUsage(1).build());
+		final ResourceUsageConfiguration oldcfg = ws.getResourceConfig();
+		final ResourceUsageConfigurationBuilder build =
+				new ResourceUsageConfigurationBuilder(oldcfg);
+		ws.setResourceConfig(build.withMaxIncomingDataMemoryUsage(1).build());
 		tfm.cleanup();
 		
 		String module = "TestLargeMetadata";
@@ -1274,6 +1273,7 @@ public class WorkspaceTest extends WorkspaceTester {
 					"@optional val3\n" +
 					"*/" +
 					"typedef structure {" +
+						"string a;" + 
 						"string val;" +
 						"string val2;" +
 						"string val3;" +
@@ -1296,6 +1296,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		Map<String, Object> dBig = new LinkedHashMap<String, Object>();
 		dBig.put("l", Arrays.asList(1,2,3,4,5,6,7,8));
+		dBig.put("a", "a"); //force sort
 
 		//test fail on large extracted values
 		dBig.put("val", TEXT1000.substring(103));

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -637,6 +637,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		failGetPermissions(AUSER, wsis, new NoSuchWorkspaceException(
 				"No workspace with name permmass-doesntexist exists", wiow));
 		
+		wsis.remove(wsis.size() - 1);
 		wsis.add(new WorkspaceIdentifier(100000000));
 		failGetPermissions(AUSER, wsis, new NoSuchWorkspaceException(
 				"No workspace with id 100000000 exists", wiow));
@@ -4891,7 +4892,7 @@ public class WorkspaceTest extends WorkspaceTester {
 	
 		failListObjects(user2, Arrays.asList(wsi, writeable), null,
 				new WorkspaceAuthorizationException("User listObjUser2 may not read workspace listObj1"));
-		failListObjects(null, Arrays.asList(wsi, writeable), null,
+		failListObjects(null, Arrays.asList(wsi), null,
 				new WorkspaceAuthorizationException("Anonymous users may not read workspace listObj1"));
 		failListObjects(user, Arrays.asList(writeable, new WorkspaceIdentifier("listfake")), null,
 				new NoSuchWorkspaceException("No workspace with name listfake exists", wsi));

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -127,7 +127,7 @@ public class WorkspaceTester {
 	
 	private static MongoController mongo = null;
 	private static ShockController shock = null;
-	private static TempFilesManager tfm;
+	protected static TempFilesManager tfm;
 	
 	protected static final WorkspaceUser SOMEUSER = new WorkspaceUser("auser");
 	protected static final WorkspaceUser AUSER = new WorkspaceUser("a");
@@ -196,6 +196,34 @@ public class WorkspaceTester {
 		DB wsdb = GetMongoDB.getDB("localhost:" + mongo.getServerPort(),
 				DB_WS_NAME);
 		WorkspaceTestCommon.destroyDB(wsdb);
+	}
+	
+	public static void assertNoTempFilesExist(TempFilesManager tfm)
+			throws Exception {
+		assertNoTempFilesExist(Arrays.asList(tfm));
+	}
+	
+	
+	public static void assertNoTempFilesExist(List<TempFilesManager> tfms)
+			throws Exception {
+		int i = 0;
+		try {
+			for (TempFilesManager tfm: tfms) {
+				if (!tfm.isEmpty()) {
+					// Allow <=10 seconds to finish all activities
+					for (; i < 100; i++) {
+						Thread.sleep(100);
+						if (tfm.isEmpty())
+							break;
+					}
+				}
+				assertThat("There are tempfiles: " + tfm.getTempFileList(),
+						tfm.isEmpty(), is(true));
+			}
+		} finally {
+			for (TempFilesManager tfm: tfms)
+				tfm.cleanup();
+		}
 	}
 	
 	private static final Map<String, WSandTypes> CONFIGS =

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -31,6 +31,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.slf4j.LoggerFactory;
 
 import us.kbase.common.mongo.GetMongoDB;
+import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.TestException;
 import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.common.test.controllers.shock.ShockController;
@@ -181,10 +182,10 @@ public class WorkspaceTester {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		if (shock != null) {
-			shock.destroy(WorkspaceTestCommon.deleteTempFiles());
+			shock.destroy(TestCommon.deleteTempFiles());
 		}
 		if (mongo != null) {
-			mongo.destroy(WorkspaceTestCommon.deleteTempFiles());
+			mongo.destroy(TestCommon.deleteTempFiles());
 		}
 		System.out.println("deleting temporary files");
 		tfm.cleanup();
@@ -195,35 +196,7 @@ public class WorkspaceTester {
 	public void clearDB() throws Exception {
 		DB wsdb = GetMongoDB.getDB("localhost:" + mongo.getServerPort(),
 				DB_WS_NAME);
-		WorkspaceTestCommon.destroyDB(wsdb);
-	}
-	
-	public static void assertNoTempFilesExist(TempFilesManager tfm)
-			throws Exception {
-		assertNoTempFilesExist(Arrays.asList(tfm));
-	}
-	
-	
-	public static void assertNoTempFilesExist(List<TempFilesManager> tfms)
-			throws Exception {
-		int i = 0;
-		try {
-			for (TempFilesManager tfm: tfms) {
-				if (!tfm.isEmpty()) {
-					// Allow <=10 seconds to finish all activities
-					for (; i < 100; i++) {
-						Thread.sleep(100);
-						if (tfm.isEmpty())
-							break;
-					}
-				}
-				assertThat("There are tempfiles: " + tfm.getTempFileList(),
-						tfm.isEmpty(), is(true));
-			}
-		} finally {
-			for (TempFilesManager tfm: tfms)
-				tfm.cleanup();
-		}
+		TestCommon.destroyDB(wsdb);
 	}
 	
 	private static final Map<String, WSandTypes> CONFIGS =
@@ -235,9 +208,9 @@ public class WorkspaceTester {
 			Integer maxMemoryUsePerCall)
 			throws Exception {
 		if (mongo == null) {
-			mongo = new MongoController(WorkspaceTestCommon.getMongoExe(),
-					Paths.get(WorkspaceTestCommon.getTempDir()),
-					WorkspaceTestCommon.useWiredTigerEngine());
+			mongo = new MongoController(TestCommon.getMongoExe(),
+					Paths.get(TestCommon.getTempDir()),
+					TestCommon.useWiredTigerEngine());
 			System.out.println("Using Mongo temp dir " + mongo.getTempDir());
 			System.out.println("Started test mongo instance at localhost:" +
 					mongo.getServerPort());
@@ -285,9 +258,9 @@ public class WorkspaceTester {
 		String shockpwd = System.getProperty("test.pwd1");
 		if (shock == null) {
 			shock = new ShockController(
-					WorkspaceTestCommon.getShockExe(),
-					WorkspaceTestCommon.getShockVersion(),
-					Paths.get(WorkspaceTestCommon.getTempDir()),
+					TestCommon.getShockExe(),
+					TestCommon.getShockVersion(),
+					Paths.get(TestCommon.getTempDir()),
 					"***---fakeuser---***",
 					"localhost:" + mongo.getServerPort(),
 					"WorkspaceTester_ShockDB",
@@ -314,7 +287,7 @@ public class WorkspaceTester {
 					throws Exception {
 		
 		tfm = new TempFilesManager(
-				new File(WorkspaceTestCommon.getTempDir()));
+				new File(TestCommon.getTempDir()));
 		tfm.cleanup();
 		
 		final TypeDefinitionDB typeDefDB = new TypeDefinitionDB(

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -1239,9 +1239,6 @@ public class WorkspaceTester {
 					got.getSerializedData());
 		} else {
 			assertThat("returned data same", got.getData(), is((Object)data));
-			assertThat("returned data jsonnode same",
-					got.getSerializedData().getAsJsonNode(),
-					is(new ObjectMapper().valueToTree(data)));
 		}
 		assertThat("returned refs same", new HashSet<String>(got.getReferences()),
 				is(new HashSet<String>(refs)));

--- a/test/performance/ConfigurationsAndThreads.java
+++ b/test/performance/ConfigurationsAndThreads.java
@@ -30,6 +30,7 @@ import us.kbase.auth.AuthToken;
 import us.kbase.common.mongo.GetMongoDB;
 import us.kbase.common.service.ServerException;
 import us.kbase.common.service.UObject;
+import us.kbase.common.test.TestCommon;
 import us.kbase.shock.client.BasicShockClient;
 import us.kbase.shock.client.ShockNode;
 import us.kbase.typedobj.core.LocalTypeProvider;
@@ -61,7 +62,6 @@ import us.kbase.workspace.database.mongo.GridFSBlobStore;
 import us.kbase.workspace.database.mongo.MongoWorkspaceDB;
 import us.kbase.workspace.database.mongo.ShockBlobStore;
 import us.kbase.workspace.kbase.KBaseReferenceParser;
-import us.kbase.workspace.test.WorkspaceTestCommon;
 
 /* DO NOT run these tests on production workspaces.
  * WARNING: extensive changes have been made to the workspace initialization
@@ -165,7 +165,7 @@ public class ConfigurationsAndThreads {
 		System.setProperty("test.mongo.host", MONGO_HOST);
 		System.setProperty("test.shock.url", shockurl);
 		tfm = new TempFilesManager(
-				new File(WorkspaceTestCommon.getTempDir()));
+				new File(TestCommon.getTempDir()));
 		//need to redo set up if this is used again
 //		us.kbase.workspace.test.WorkspaceTestCommonDeprecated.destroyAndSetupDB(
 //				1, WorkspaceTestCommon.SHOCK, user, null);

--- a/test/performance/GetObjectsLibSpeedTest.java
+++ b/test/performance/GetObjectsLibSpeedTest.java
@@ -23,6 +23,7 @@ import com.mongodb.DB;
 
 import us.kbase.common.mongo.GetMongoDB;
 import us.kbase.common.service.JsonTokenStream;
+import us.kbase.common.test.TestCommon;
 import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.TypeDefId;
@@ -43,7 +44,6 @@ import us.kbase.workspace.database.WorkspaceUser;
 import us.kbase.workspace.database.mongo.MongoWorkspaceDB;
 import us.kbase.workspace.database.mongo.ShockBlobStore;
 import us.kbase.workspace.kbase.KBaseReferenceParser;
-import us.kbase.workspace.test.WorkspaceTestCommon;
 
 public class GetObjectsLibSpeedTest {
 	
@@ -77,7 +77,7 @@ public class GetObjectsLibSpeedTest {
 //		us.kbase.workspace.test.WorkspaceTestCommonDeprecated.destroyAndSetupDB(
 //				1, WorkspaceTestCommon.SHOCK, shockuser, null);
 		TempFilesManager tfm = new TempFilesManager(
-				new File(WorkspaceTestCommon.getTempDir()));
+				new File(TestCommon.getTempDir()));
 		
 		DB db = GetMongoDB.getDB(mongohost, wsDB);
 		final TypeDefinitionDB typeDefDB = new TypeDefinitionDB(new MongoTypeStorage(


### PR DESCRIPTION
Fixes:
https://atlassian.kbase.us/browse/KBASE-4224
Certain failures (metadata key and total size, sort memory size, duplicate keys on sort) could leave temporary files sitting around.
https://atlassian.kbase.us/browse/WOR-234
Tests fail when run with Java 8.

Also:
Update java-common and use the built in SLF4J logging mechanism rather than the current hack.
Refactor the metadata handler to simplify the API & internals.
Some other minor things.

Bumped version to 0.5.0-dev2.