### PR TITLE
Add useful status method

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -66,7 +66,7 @@
   </fileset>
 
   <fileset dir="${jardir}" id="shocklib">
-    <include name="kbase/shock/shock-client-0.0.10.jar"/>
+    <include name="kbase/shock/shock-client-0.0.11.jar"/>
     <include name="apache_commons/commons-logging-1.1.1.jar"/>
     <include name="apache_commons/http/httpclient-4.3.1.jar"/>
     <include name="apache_commons/http/httpcore-4.3.jar"/>
@@ -96,6 +96,7 @@
     <include name="apache_commons/commons-lang-2.4.jar"/>
     <include name="apache_commons/commons-collections-3.2.1.jar"/>
     <include name="mysql/mysql-connector-java-5.1.22-bin.jar"/>
+    <include name="jsemver/java-semver-0.9.0.jar"/>
   </fileset>
 	
   <union id="serverside">

--- a/docsource/releasenotes.rst
+++ b/docsource/releasenotes.rst
@@ -8,9 +8,19 @@ BACKWARDS INCOMPATIBILITIES:
 
 * The ``skip`` parameter of ``list_objects`` has been removed.
 
+NEW FEATURES:
+
+* The ``status`` method now returns JVM memory stats and the status of MongoDB
+  and Shock (if using). Currently this method is not available via client, but
+  can be invoked like so:
+
+``curl -X POST -d '{"id": '1', "method": "Workspace.status", "version": "1.1", "params": []}' [Workspace URL]``
+
 UPDATED FEATURES / MAJOR BUG FIXES:
 
 * ``clone_workspace`` can now exclude user specified objects from the clone.
+* Fixed two bugs where various failures on save would leave temporary files on
+  disk.
 
 VERSION: 0.4.1 (Released 5/27/16)
 ---------------------------------

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -1773,7 +1773,10 @@ public class WorkspaceServer extends JsonServerServlet {
     public Map<String, Object> status() {
         Map<String, Object> returnVal = null;
         //BEGIN_STATUS
+		//note failures are tested manually for now, if you make changes test
+		//things still work
 		//TODO TEST when the client supports this method
+		//TODO TEST add tests exercising failures
 		returnVal = new LinkedHashMap<String, Object>();
 		final List<DependencyStatus> deps = ws.status();
 		boolean ok = true;

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -66,6 +66,7 @@ import us.kbase.typedobj.db.ModuleDefId;
 import us.kbase.typedobj.db.TypeChange;
 import us.kbase.typedobj.db.TypeDetailedInfo;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
+import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.workspace.database.ListObjectsParameters;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
@@ -1772,18 +1773,36 @@ public class WorkspaceServer extends JsonServerServlet {
     public Map<String, Object> status() {
         Map<String, Object> returnVal = null;
         //BEGIN_STATUS
-        returnVal = new LinkedHashMap<String, Object>();
-        //TODO check mongo and shock?
-        returnVal.put("state", "OK");
-        returnVal.put("message", "");
-        returnVal.put("version", VER);
-        returnVal.put("git_url", GIT);
-        @SuppressWarnings("unused")
-        String v = version;
-        @SuppressWarnings("unused")
-        String h = gitCommitHash;
-        @SuppressWarnings("unused")
-        String u = gitUrl;
+		//TODO TEST when the client supports this method
+		returnVal = new LinkedHashMap<String, Object>();
+		final List<DependencyStatus> deps = ws.status();
+		boolean ok = true;
+		final List<Map<String, String>> dstate = new LinkedList<>();
+		for (final DependencyStatus ds: deps) {
+			if (!ds.isOk()) {
+				ok = false;
+			}
+			final Map<String, String> d = new HashMap<String, String>();
+			d.put("state", ds.isOk() ? "OK" : "Fail");
+			d.put("name", ds.getName());
+			d.put("message", ds.getStatus());
+			d.put("version", ds.getVersion());
+			dstate.add(d);
+		}
+		returnVal.put("state", ok ? "OK" : "Fail");
+		returnVal.put("message", ok ? "OK" : "Dependency failure");
+		returnVal.put("dependencies", dstate);
+		returnVal.put("version", VER);
+		returnVal.put("git_url", GIT);
+		returnVal.put("freemem", Runtime.getRuntime().freeMemory());
+		returnVal.put("totalmem", Runtime.getRuntime().totalMemory());
+		returnVal.put("maxmem", Runtime.getRuntime().maxMemory());
+		@SuppressWarnings("unused")
+		final String v = version;
+		@SuppressWarnings("unused")
+		final String h = gitCommitHash;
+		@SuppressWarnings("unused")
+		final String u = gitUrl;
         //END_STATUS
         return returnVal;
     }

--- a/src/us/kbase/workspace/database/DependencyStatus.java
+++ b/src/us/kbase/workspace/database/DependencyStatus.java
@@ -1,0 +1,41 @@
+package us.kbase.workspace.database;
+
+/** Provides the status of a Workspace dependency.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class DependencyStatus {
+
+	private final boolean ok;
+	private final String status;
+	private final String name;
+	private final String version;
+	
+	public DependencyStatus(
+			final boolean ok,
+			final String status,
+			final String name,
+			final String version) {
+		super();
+		this.ok = ok;
+		this.status = status;
+		this.name = name;
+		this.version = version;
+	}
+
+	public boolean isOk() {
+		return ok;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+}

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -298,6 +298,10 @@ public class Workspace {
 		return ret;
 	}
 	
+	public List<DependencyStatus> status() {
+		return db.status();
+	}
+	
 	public WorkspaceInformation createWorkspace(final WorkspaceUser user, 
 			final String wsname, boolean globalread, final String description,
 			final WorkspaceUserMetadata meta)

--- a/src/us/kbase/workspace/database/WorkspaceDatabase.java
+++ b/src/us/kbase/workspace/database/WorkspaceDatabase.java
@@ -377,4 +377,9 @@ public interface WorkspaceDatabase {
 
 	public void setResourceUsageConfiguration(
 			ResourceUsageConfiguration rescfg);
+	
+	/** Returns the status of the databases' dependencies.
+	 * @return the dependency status.
+	 */
+	public List<DependencyStatus> status();
 }

--- a/src/us/kbase/workspace/database/mongo/BlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/BlobStore.java
@@ -1,9 +1,12 @@
 package us.kbase.workspace.database.mongo;
 
+import java.util.List;
+
 import us.kbase.typedobj.core.MD5;
 import us.kbase.typedobj.core.Writable;
 import us.kbase.workspace.database.ByteArrayFileCacheManager;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
+import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.workspace.database.exceptions.FileCacheIOException;
 import us.kbase.workspace.database.exceptions.FileCacheLimitExceededException;
 import us.kbase.workspace.database.mongo.exceptions.BlobStoreAuthorizationException;
@@ -48,4 +51,9 @@ public interface BlobStore {
 		BlobStoreCommunicationException, NoSuchBlobException;
 	
 	public String getStoreType();
+
+	/** Returns the status of the blob store's dependencies.
+	 * @return the dependency status.
+	 */
+	public List<DependencyStatus> status();
 }

--- a/src/us/kbase/workspace/database/mongo/GridFSBlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/GridFSBlobStore.java
@@ -150,6 +150,7 @@ public class GridFSBlobStore implements BlobStore {
 	public List<DependencyStatus> status() {
 		//note failures are tested manually for now, if you make changes test
 		//things still work
+		//TODO TEST add tests exercising failures
 		final String version;
 		try {
 			final CommandResult bi = gfs.getDB().command("buildInfo");

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -214,6 +214,9 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 	}
 	
 	public List<DependencyStatus> status() {
+		//note failures are tested manually for now, if you make changes test
+		//things still work
+		//TODO TEST add tests exercising failures
 		final List<DependencyStatus> deps = new LinkedList<>(blob.status());
 		final String version;
 		try {

--- a/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
@@ -91,6 +91,7 @@ public class ShockBlobStore implements BlobStore {
 	public List<DependencyStatus> status() {
 		//note failures are tested manually for now, if you make changes test
 		//things still work
+		//TODO TEST add tests exercising failures
 		final String version;
 		try {
 			version = client.getRemoteVersion();

--- a/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
@@ -3,7 +3,11 @@ package us.kbase.workspace.database.mongo;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
+
+import org.slf4j.LoggerFactory;
 
 import us.kbase.auth.AuthException;
 import us.kbase.auth.AuthService;
@@ -19,6 +23,7 @@ import us.kbase.typedobj.core.MD5;
 import us.kbase.typedobj.core.Writable;
 import us.kbase.workspace.database.ByteArrayFileCacheManager;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
+import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.workspace.database.exceptions.FileCacheIOException;
 import us.kbase.workspace.database.exceptions.FileCacheLimitExceededException;
 import us.kbase.workspace.database.mongo.exceptions.BlobStoreAuthorizationException;
@@ -80,6 +85,30 @@ public class ShockBlobStore implements BlobStore {
 					ioe.getLocalizedMessage(), ioe);
 		}
 		//TODO check that a few nodes exist to ensure we're pointing at the right Shock instance
+	}
+	
+	@Override
+	public List<DependencyStatus> status() {
+		//note failures are tested manually for now, if you make changes test
+		//things still work
+		final String version;
+		try {
+			version = client.getRemoteVersion();
+		} catch (IOException e) {
+			LoggerFactory.getLogger(getClass())
+				.error("Failed to connect to Shock", e);
+			return Arrays.asList(new DependencyStatus(
+					false, "Cannot connect to Shock: " +
+					e.getMessage(), "Shock", "Unknown"));
+		} catch (InvalidShockUrlException e) {
+			LoggerFactory.getLogger(getClass())
+				.error("Invalid Shock URL", e);
+			return Arrays.asList(new DependencyStatus(
+					false, "Invalid Shock URL: " +
+					e.getMessage(), "Shock", "Unknown"));
+		}
+		return Arrays.asList(new DependencyStatus(
+				true, "OK", "Shock", version));
 	}
 	
 	private RefreshingToken getToken(final String user, final String pwd)

--- a/src/us/kbase/workspace/test/database/mongo/GridFSBlobStoreTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/GridFSBlobStoreTest.java
@@ -9,12 +9,14 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Paths;
+import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.github.zafarkhaja.semver.Version;
 import com.mongodb.DB;
 import com.mongodb.MongoClient;
 import com.mongodb.gridfs.GridFS;
@@ -27,6 +29,7 @@ import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.Writable;
 import us.kbase.workspace.database.ByteArrayFileCacheManager;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
+import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.workspace.database.mongo.GridFSBlobStore;
 import us.kbase.workspace.database.mongo.exceptions.BlobStoreException;
 
@@ -159,5 +162,17 @@ public class GridFSBlobStoreTest {
 			public void releaseResources() throws IOException {
 			}
 		};
+	}
+	
+	@Test
+	public void status() throws Exception {
+		List<DependencyStatus> deps = gfsb.status();
+		assertThat("incorrect number of deps", deps.size(), is(1));
+		DependencyStatus dep = deps.get(0);
+		assertThat("incorrect fail", dep.isOk(), is(true));
+		assertThat("incorrect name", dep.getName(), is("GridFS"));
+		assertThat("incorrect status", dep.getStatus(), is("OK"));
+		//should throw an error if not a semantic version
+		Version.valueOf(dep.getVersion());
 	}
 }

--- a/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
@@ -18,6 +19,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.github.zafarkhaja.semver.Version;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
@@ -36,6 +38,7 @@ import us.kbase.typedobj.core.MD5;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.Writable;
 import us.kbase.workspace.database.ByteArrayFileCacheManager;
+import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
 import us.kbase.workspace.database.mongo.Fields;
 import us.kbase.workspace.database.mongo.ShockBlobStore;
@@ -248,5 +251,17 @@ public class ShockBlobStoreTest {
 			public void releaseResources() throws IOException {
 			}
 		};
+	}
+	
+	@Test
+	public void status() throws Exception {
+		List<DependencyStatus> deps = sb.status();
+		assertThat("incorrect number of deps", deps.size(), is(1));
+		DependencyStatus dep = deps.get(0);
+		assertThat("incorrect fail", dep.isOk(), is(true));
+		assertThat("incorrect name", dep.getName(), is("Shock"));
+		assertThat("incorrect status", dep.getStatus(), is("OK"));
+		//should throw an error if not a semantic version
+		Version.valueOf(dep.getVersion());
 	}
 }

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -49,6 +49,7 @@ import us.kbase.typedobj.exceptions.TypedObjectValidationException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.workspace.database.AllUsers;
+import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.workspace.database.ListObjectsParameters;
 import us.kbase.workspace.database.ModuleInfo;
 import us.kbase.workspace.database.ObjIDWithChainAndSubset;
@@ -84,6 +85,7 @@ import us.kbase.workspace.exceptions.WorkspaceAuthorizationException;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.zafarkhaja.semver.Version;
 import com.google.common.collect.Sets;
 
 public class WorkspaceTest extends WorkspaceTester {
@@ -94,6 +96,28 @@ public class WorkspaceTest extends WorkspaceTester {
 		super(config, backend, maxMemoryUsePerCall);
 	}
 
+	@Test
+	public void status() throws Exception {
+		List<DependencyStatus> deps = ws.status();
+		assertThat("incorrect number of dependencies", deps.size(), is(2));
+		DependencyStatus mwdb = deps.get(0);
+		assertThat("incorrect fail", mwdb.isOk(), is(true));
+		assertThat("incorrect name", mwdb.getName(), is("MongoDB"));
+		assertThat("incorrect status", mwdb.getStatus(), is("OK"));
+		//should throw an error if not a semantic version
+		Version.valueOf(mwdb.getVersion());
+		
+		DependencyStatus blob = deps.get(1);
+		assertThat("incorrect fail", blob.isOk(), is(true));
+		String n = blob.getName();
+		assertThat("incorrect name", n.equals("Shock") || n.equals("GridFS"),
+				is(true));
+		assertThat("incorrect status", blob.getStatus(), is("OK"));
+		//should throw an error if not a semantic version
+		Version.valueOf(blob.getVersion());
+		
+	}
+	
 	@Test
 	public void workspaceDescription() throws Exception {
 		WorkspaceInformation ltinfo = ws.createWorkspace(SOMEUSER, "lt", false, LONG_TEXT, null);


### PR DESCRIPTION
As opposed to a non-useful method.

Checks status of dependencies.

```
~$ curl -X POST -d '{"id": '1', "method": "Workspace.status", "version": "1.1", "params": []}' http://localhost:41670
{"version":"1.1","result":[{"state":"OK","message":"OK","dependencies":[{"name":"MongoDB","state":"OK","message":"OK","version":"2.4.14"},{"name":"GridFS","state":"OK","message":"OK","version":"2.4.14"}],"version":"0.5.0-dev2","git_url":"https://github.com/kbase/workspace_deluxe"}]}

~$ curl -X POST -d '{"id": '1', "method": "Workspace.status", "version": "1.1", "params": []}' http://localhost:41670
{"version":"1.1","result":[{"state":"Fail","message":"Dependency failure","dependencies":[{"name":"MongoDB","state":"Fail","message":"Couldn't connect to MongoDB: Timed out after 10000 ms while waiting to connect. Client view of cluster state is {type=Unknown, servers=[{address=localhost:33805, type=Unknown, state=Connecting, exception={com.mongodb.MongoException$Network: Exception opening the socket}, caused by {java.net.ConnectException: Connection refused}}]","version":"Unknown"},{"name":"GridFS","state":"Fail","message":"Couldn't connect to MongoDB: Timed out after 10000 ms while waiting to connect. Client view of cluster state is {type=Unknown, servers=[{address=localhost:33805, type=Unknown, state=Connecting, exception={com.mongodb.MongoException$Network: Exception opening the socket}, caused by {java.net.ConnectException: Connection refused}}]","version":"Unknown"}],"version":"0.5.0-dev2","git_url":"https://github.com/kbase/workspace_deluxe"}]}

~$ curl -X POST -d '{"id": '1', "method": "Workspace.status", "version": "1.1", "params": []}' http://localhost:20000
{"version":"1.1","result":[{"state":"OK","message":"OK","dependencies":[{"name":"MongoDB","state":"OK","message":"OK","version":"2.6.11"},{"name":"Shock","state":"OK","message":"OK","version":"0.9.6"}],"version":"0.5.0-dev2","git_url":"https://github.com/kbase/workspace_deluxe"}]}

~$ curl -X POST -d '{"id": '1', "method": "Workspace.status", "version": "1.1", "params": []}' http://localhost:20000
{"version":"1.1","result":[{"state":"Fail","message":"Dependency failure","dependencies":[{"name":"MongoDB","state":"OK","message":"OK","version":"2.6.11"},{"name":"Shock","state":"Fail","message":"Cannot connect to Shock: Connect to localhost:7044 [localhost/127.0.0.1] failed: Connection refused","version":"Unknown"}],"version":"0.5.0-dev2","git_url":"https://github.com/kbase/workspace_deluxe"}]}

~$ curl -X POST -d '{"id": '1', "method": "Workspace.status", "version": "1.1", "params": []}' http://localhost:33178
{"version":"1.1","result":[{"state":"OK","message":"OK","dependencies":[{"name":"MongoDB","state":"OK","message":"OK","version":"2.4.14"},{"name":"GridFS","state":"OK","message":"OK","version":"2.4.14"}],"version":"0.5.0-dev2","git_url":"https://github.com/kbase/workspace_deluxe","freemem":5755906848,"totalmem":6029312000,"maxmem":6029312000}]}
```