### PR TITLE
Clean up ValidatedTypedObject, remove EasyStream

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -66,7 +66,7 @@
   </fileset>
 
   <fileset dir="${jardir}" id="shocklib">
-    <include name="kbase/shock/shock-client-0.0.11.jar"/>
+    <include name="kbase/shock/shock-client-0.0.12.jar"/>
     <include name="apache_commons/commons-logging-1.1.1.jar"/>
     <include name="apache_commons/http/httpclient-4.3.1.jar"/>
     <include name="apache_commons/http/httpcore-4.3.jar"/>
@@ -81,7 +81,6 @@
     <include name="mongo/mongo-java-driver-2.13.3.jar"/>
     <include name="jongo/jongo-0.5-early-20130912-1506.jar"/>
     <include name="bson4jackson/bson4jackson-2.2.0-2.2.0.jar"/>
-    <include name="easystream/easystream-1.2.13.jar"/>
     <include name="slf4j/slf4j-api-1.7.7.jar"/>
     <include name="logback/logback-core-1.1.2.jar"/>
     <include name="logback/logback-classic-1.1.2.jar"/>

--- a/src/us/kbase/typedobj/core/TypedObjectValidator.java
+++ b/src/us/kbase/typedobj/core/TypedObjectValidator.java
@@ -110,7 +110,7 @@ public final class TypedObjectValidator {
 	 * @throws IOException 
 	 * @throws JsonParseException 
 	 */
-	public TypedObjectValidationReport validate(final String instance,
+	public ValidatedTypedObject validate(final String instance,
 			final TypeDefId type, final IdReferenceHandlerSet<?> handlers)
 			throws NoSuchTypeException, NoSuchModuleException,
 			TypeStorageException, TypedObjectValidationException,
@@ -148,7 +148,7 @@ public final class TypedObjectValidator {
 	 * @throws IOException 
 	 * @throws JsonParseException 
 	 */
-	public TypedObjectValidationReport validate(final JsonNode instanceRootNode,
+	public ValidatedTypedObject validate(final JsonNode instanceRootNode,
 			final TypeDefId typeDefId, final IdReferenceHandlerSet<?> handlers)
 			throws NoSuchTypeException, NoSuchModuleException,
 			TypeStorageException, TypedObjectSchemaException,
@@ -167,7 +167,7 @@ public final class TypedObjectValidator {
 		return validate(obj, typeDefId, handlers);
 	}
 	
-	public TypedObjectValidationReport validate(final UObject obj,
+	public ValidatedTypedObject validate(final UObject obj,
 			final TypeDefId typeDefId, final IdReferenceHandlerSet<?> handlers)
 			throws NoSuchTypeException, NoSuchModuleException,
 			TypeStorageException, TypedObjectSchemaException,
@@ -268,7 +268,7 @@ public final class TypedObjectValidator {
 			}
 		}
 
-		return new TypedObjectValidationReport(
+		return new ValidatedTypedObject(
 									obj,
 									absoluteTypeDefId,
 									errors, 

--- a/src/us/kbase/typedobj/core/ValidatedTypedObject.java
+++ b/src/us/kbase/typedobj/core/ValidatedTypedObject.java
@@ -1,5 +1,6 @@
 package us.kbase.typedobj.core;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -146,7 +147,8 @@ public class ValidatedTypedObject {
 	}
 	
 	/** Get an input stream containing the relabeled, sorted object. sort()
-	 * must be called before calling this method.
+	 * must be called before calling this method. The stream is buffered
+	 * when appropriate.
 	 * 
 	 * The caller of this method is responsible for closing the stream.
 	 * @return an object input stream.
@@ -160,7 +162,7 @@ public class ValidatedTypedObject {
 			return new ByteArrayInputStream(byteCache);
 		} else {
 			try {
-				return new FileInputStream(fileCache);
+				return new BufferedInputStream(new FileInputStream(fileCache));
 			} catch (FileNotFoundException e) {
 				throw new RuntimeException("A programming error occured and " +
 						"the file cache could not be found.", e);

--- a/src/us/kbase/typedobj/core/ValidatedTypedObject.java
+++ b/src/us/kbase/typedobj/core/ValidatedTypedObject.java
@@ -277,22 +277,16 @@ public class ValidatedTypedObject {
 		if (tfm == null) {
 			if (naturallySorted) {
 				final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-				try (final OutputStream os = new BufferedOutputStream(baos)) {
-					relabelWsIdReferencesIntoWriter(new DigestOutputStream(
-							os, digest));
-				}
+				relabelWsIdReferencesIntoWriter(new DigestOutputStream(
+						baos, digest));
 				byteCache = baos.toByteArray();
 			} else {
 				ByteArrayOutputStream baos = new ByteArrayOutputStream();
-				try (final OutputStream os = new BufferedOutputStream(baos)) {
-					relabelWsIdReferencesIntoWriter(os);
-				}
+				relabelWsIdReferencesIntoWriter(baos);
 				byteCache = baos.toByteArray();
 				baos = new ByteArrayOutputStream();
-				try (final OutputStream os = new BufferedOutputStream(baos)) {
-					fac.getSorter(byteCache).writeIntoStream(
-							new DigestOutputStream(os, digest));
-				}
+				fac.getSorter(byteCache).writeIntoStream(
+						new DigestOutputStream(baos, digest));
 				byteCache = baos.toByteArray();
 			}
 		} else {

--- a/src/us/kbase/typedobj/core/ValidatedTypedObject.java
+++ b/src/us/kbase/typedobj/core/ValidatedTypedObject.java
@@ -43,7 +43,7 @@ import com.fasterxml.jackson.databind.JsonNode;
  * @author rsutormin
  * @author gaprice@lbl.gov
  */
-public class TypedObjectValidationReport {
+public class ValidatedTypedObject {
 
 	//TODO JAVADOC
 	
@@ -95,7 +95,7 @@ public class TypedObjectValidationReport {
 	 * metadata extraction selection.
 	 * 
 	 */
-	protected TypedObjectValidationReport(
+	protected ValidatedTypedObject(
 			final UObject tokenStreamProvider,
 			final AbsoluteTypeDefId validationTypeDefId, 
 			final List<String> errors,

--- a/src/us/kbase/typedobj/core/ValidatedTypedObject.java
+++ b/src/us/kbase/typedobj/core/ValidatedTypedObject.java
@@ -35,9 +35,9 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
- * The report generated when a typed object instance is validated.  If the type
+ * A typed object that has been validated  If the type
  * definition indicates that fields are ID references, those ID references can
- * be extracted from this report.
+ * be extracted from this object.
  *
  * @author msneddon
  * @author rsutormin
@@ -45,8 +45,6 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 public class ValidatedTypedObject {
 
-	//TODO JAVADOC
-	
 	/**
 	 * The list of errors found during validation.  If the object is not valid, this must be non-empty, (although
 	 * note that not all validations errors found may be added, for instance, if there are many errors only the
@@ -90,9 +88,9 @@ public class ValidatedTypedObject {
 	private final JsonTokenValidationSchema schema;
 	
 	/**
-	 * After validation, assemble the validation result into a report for later use. The report contains
-	 * information on validation errors (if any), the IDs found in the object, and information about the
-	 * metadata extraction selection.
+	 * Created a validated object. The object contains
+	 * information on validation errors (if any), the IDs found in the object,
+	 * and information about the metadata extraction selection.
 	 * 
 	 */
 	protected ValidatedTypedObject(
@@ -127,23 +125,23 @@ public class ValidatedTypedObject {
 	}
 	
 	/**
-	 * Get the absolute ID of the typedef that was used to validate the instance
-	 * @return
+	 * Get the absolute ID of the typedef that was used to validate the object.
+	 * @return the type ID.
 	 */
 	public AbsoluteTypeDefId getValidationTypeDefId() {
 		return validationTypeDefId;
 	}
 	
-	/**
-	 * @return boolean true if the instance is valid, false otherwise
+	/** Get whether this object is valid according to the validator.
+	 * @return boolean true if the object is valid, false otherwise
 	 */
 	public boolean isInstanceValid() {
 		return errors.isEmpty();
 	}
 	
 	/**
-	 * Iterate over all items in the report and return the error messages.
-	 * @return errors
+	 * Return any validation errors for this object.
+	 * @return errors the validation errors.
 	 */
 	public List<String> getErrorMessages() {
 		return errors;
@@ -209,6 +207,10 @@ public class ValidatedTypedObject {
 		return size;
 	}
 
+	/** Get the MD5 of the sorted, relabeled object.
+	 * sort() must have been called previously.
+	 * @return the object's MD5
+	 */
 	public MD5 getMD5() {
 		if (md5 == null) {
 			throw new IllegalStateException(
@@ -236,11 +238,9 @@ public class ValidatedTypedObject {
 	}
 
 	/** Relabel ids, sort the object if necessary and keep a copy.
-	 * You must call this method prior to calling createJsonWritable().
+	 * You must call this method prior to calling getInputStream().
 	 * Equivalent of sort(null). All data is kept in memory.
 	 * @param fac the sorter factory to use when generating a sorter.
-	 * @throws RelabelIdReferenceException if there are duplicate keys after
-	 * relabeling the ids or if sorting the map keys takes too much memory.
 	 * @throws IOException if an IO exception occurs.
 	 * @throws TooManyKeysException if the memory required to sort the map is
 	 * too high.
@@ -253,7 +253,7 @@ public class ValidatedTypedObject {
 	}
 	
 	/** Relabel ids, sort the object if necessary and keep a copy.
-	 * You must call this method prior to calling createJsonWritable().
+	 * You must call this method prior to calling getInputStream().
 	 * @param fac the sorter factory to use when generating a sorter.
 	 * @param tfm the temporary file manager to use for managing temporary
 	 * files. All data is kept in memory if tfm is null.
@@ -332,6 +332,12 @@ public class ValidatedTypedObject {
 		md5 = getMD5fromDigest(digest);
 	}
 	
+	/** Destroy any cached resources created by this class and allow garbage
+	 * collection of in-memory caches. This method must be called before
+	 * program exit or temporary files may be left on disk. The caches will be
+	 * recreated as necessary. 
+	 * 
+	 */
 	public void destroyCachedResources() {
 		this.byteCache = null;
 		if (this.fileCache != null) {
@@ -391,6 +397,11 @@ public class ValidatedTypedObject {
 		}
 	}
 	
+	/** Get the path to an ID in the object.
+	 * @param ref the ID to search for.
+	 * @return the location of the ID in the object.
+	 * @throws IOException if an IO error occurs.
+	 */
 	public JsonDocumentLocation getIdReferenceLocation (
 			final IdReference<?> ref)
 					throws IOException {
@@ -447,13 +458,11 @@ public class ValidatedTypedObject {
 	
 	
 	/**
-	 * If metadata ws was defined in the Json Schema, then you can use this method
-	 * to extract out the contents.  Note that this method does not perform a deep copy of the data,
-	 * so if you extract metadata, then modify the original instance that was validated, it can
-	 * (in some but not all cases) modify this metadata as well.  So you should always perform a
-	 * deep copy of the original instance if you intend to modify it and  metadata has already
-	 * been extracted.
-	 * @throws ExceededMaxMetadataSizeException 
+	 * If metadata ws was defined in the Json Schema, then you can use this
+	 * method to extract out the contents.
+	 * @param maxMetadataSize the maximum allowable size for the metadata.
+	 * @throws ExceededMaxMetadataSizeException if the metadata exceeds the
+	 * maximum allowed size.
 	 */
 	public ExtractedMetadata extractMetadata(
 			final long maxMetadataSize) 

--- a/src/us/kbase/typedobj/test/BasicValidationTest.java
+++ b/src/us/kbase/typedobj/test/BasicValidationTest.java
@@ -37,7 +37,7 @@ import us.kbase.common.test.TestException;
 import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.typedobj.core.TypeDefName;
-import us.kbase.typedobj.core.TypedObjectValidationReport;
+import us.kbase.typedobj.core.ValidatedTypedObject;
 import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.db.FileTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
@@ -234,7 +234,7 @@ public class BasicValidationTest {
 			String instanceJson = loadResourceFile(TEST_RESOURCE_LOCATION+instance.resourceName);
 			
 			try {
-				TypedObjectValidationReport report = 
+				ValidatedTypedObject report = 
 					validator.validate(
 						instanceJson,
 						new TypeDefId(new TypeDefName(instance.moduleName,instance.typeName)),
@@ -263,7 +263,7 @@ public class BasicValidationTest {
 			String instanceJson = loadResourceFile(TEST_RESOURCE_LOCATION+instance.resourceName);
 			
 			try {
-				TypedObjectValidationReport report = 
+				ValidatedTypedObject report = 
 					validator.validate(
 						instanceJson,
 						new TypeDefId(new TypeDefName(instance.moduleName,instance.typeName)),

--- a/src/us/kbase/typedobj/test/DetailedValidationTest.java
+++ b/src/us/kbase/typedobj/test/DetailedValidationTest.java
@@ -41,7 +41,7 @@ import us.kbase.common.test.TestException;
 import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.typedobj.core.TypeDefName;
-import us.kbase.typedobj.core.TypedObjectValidationReport;
+import us.kbase.typedobj.core.ValidatedTypedObject;
 import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.db.FileTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
@@ -235,7 +235,7 @@ public class DetailedValidationTest {
 		handler.associateObject("foo");
 		
 		try {
-			TypedObjectValidationReport report = 
+			ValidatedTypedObject report = 
 				validator.validate(
 					instance,
 					new TypeDefId(new TypeDefName(typeTokens[0],typeTokens[1])),

--- a/src/us/kbase/typedobj/test/DummyValidatedTypedObject.java
+++ b/src/us/kbase/typedobj/test/DummyValidatedTypedObject.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import us.kbase.common.service.UObject;
 import us.kbase.typedobj.core.AbsoluteTypeDefId;
 import us.kbase.typedobj.core.JsonTokenValidationSchema;
-import us.kbase.typedobj.core.TypedObjectValidationReport;
+import us.kbase.typedobj.core.ValidatedTypedObject;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
 
 /**
@@ -20,12 +20,12 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
  * @author msneddon
  *
  */
-public class DummyTypedObjectValidationReport extends
-		TypedObjectValidationReport {
+public class DummyValidatedTypedObject extends
+		ValidatedTypedObject {
 	
 	final UObject data;
 	
-	public DummyTypedObjectValidationReport(final AbsoluteTypeDefId type, 
+	public DummyValidatedTypedObject(final AbsoluteTypeDefId type, 
 			final UObject data) throws Exception {
 		
 		super(data, type, Collections.<String>emptyList(), null,

--- a/src/us/kbase/typedobj/test/IdProcessingTest.java
+++ b/src/us/kbase/typedobj/test/IdProcessingTest.java
@@ -46,7 +46,7 @@ import us.kbase.common.utils.sortjson.UTF8JsonSorterFactory;
 import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.typedobj.core.TypeDefName;
-import us.kbase.typedobj.core.TypedObjectValidationReport;
+import us.kbase.typedobj.core.ValidatedTypedObject;
 import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.db.FileTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
@@ -251,7 +251,7 @@ public class IdProcessingTest {
 		idhandlers.associateObject("foo");
 		
 		// perform the initial validation, which must validate!
-		TypedObjectValidationReport report = 
+		ValidatedTypedObject report = 
 			validator.validate(
 					instanceRootNode,
 					new TypeDefId(new TypeDefName(instance.moduleName,instance.typeName)),
@@ -272,7 +272,7 @@ public class IdProcessingTest {
 		
 		// now we revalidate the instance, and ensure that the labels have been renamed
 		IdReferenceHandlerSetFactory dummyfac = new IdReferenceHandlerSetFactory(0);
-		TypedObjectValidationReport report2 = validator.validate(relabeledInstance, new TypeDefId(new TypeDefName(instance.moduleName,instance.typeName)),
+		ValidatedTypedObject report2 = validator.validate(relabeledInstance, new TypeDefId(new TypeDefName(instance.moduleName,instance.typeName)),
 				dummyfac.createHandlers(String.class).associateObject("foo"));
 		List <String> mssgs2 = report2.getErrorMessages();
 		for(int i=0; i<mssgs2.size(); i++) {

--- a/src/us/kbase/typedobj/test/JsonTokenValidatorTester.java
+++ b/src/us/kbase/typedobj/test/JsonTokenValidatorTester.java
@@ -18,7 +18,7 @@ import us.kbase.common.service.UObject;
 import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.typedobj.core.TypeDefName;
-import us.kbase.typedobj.core.TypedObjectValidationReport;
+import us.kbase.typedobj.core.ValidatedTypedObject;
 import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.db.MongoTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
@@ -68,7 +68,7 @@ public class JsonTokenValidatorTester {
 					new IdReferenceHandlerSetFactory(6);
 			IdReferenceHandlerSet<String> han = fac.createHandlers(String.class);
 			han.associateObject("foo");
-			TypedObjectValidationReport report = new TypedObjectValidator(
+			ValidatedTypedObject report = new TypedObjectValidator(
 					new LocalTypeProvider(db)).validate(new UObject(jp, null), 
 					new TypeDefId(new TypeDefName(moduleName, typeName)), han);
 			Assert.assertTrue(report.isInstanceValid());

--- a/src/us/kbase/typedobj/test/MetadataExtractionTest.java
+++ b/src/us/kbase/typedobj/test/MetadataExtractionTest.java
@@ -43,7 +43,7 @@ import us.kbase.typedobj.core.ExtractedMetadata;
 import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.typedobj.core.TypeDefName;
-import us.kbase.typedobj.core.TypedObjectValidationReport;
+import us.kbase.typedobj.core.ValidatedTypedObject;
 import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.db.FileTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
@@ -216,7 +216,7 @@ public class MetadataExtractionTest {
 		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(6);
 		IdReferenceHandlerSet<String> han =
 				fac.createHandlers(String.class).associateObject("foo");
-		TypedObjectValidationReport report = 
+		ValidatedTypedObject report = 
 			validator.validate(
 				instanceRootNode,
 				new TypeDefId(new TypeDefName(instance.moduleName,instance.typeName)),

--- a/src/us/kbase/typedobj/test/ProfileBasicValidation.java
+++ b/src/us/kbase/typedobj/test/ProfileBasicValidation.java
@@ -28,7 +28,7 @@ import org.apache.commons.io.FileUtils;
 import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.typedobj.core.TypeDefName;
-import us.kbase.typedobj.core.TypedObjectValidationReport;
+import us.kbase.typedobj.core.ValidatedTypedObject;
 import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.db.MongoTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
@@ -187,7 +187,7 @@ public class ProfileBasicValidation {
 		if(instance.isValid) {
 
 			try {
-				TypedObjectValidationReport report = 
+				ValidatedTypedObject report = 
 					validator.validate(
 						instance.instanceJson,
 						new TypeDefId(new TypeDefName(instance.moduleName,instance.typeName)),
@@ -205,7 +205,7 @@ public class ProfileBasicValidation {
 		} else {
 
 			try {
-				TypedObjectValidationReport report = 
+				ValidatedTypedObject report = 
 					validator.validate(
 						instance.instanceJson,
 						new TypeDefId(new TypeDefName(instance.moduleName,instance.typeName)),

--- a/src/us/kbase/typedobj/test/TypedObjectValidationReportTest.java
+++ b/src/us/kbase/typedobj/test/TypedObjectValidationReportTest.java
@@ -33,7 +33,7 @@ import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.MD5;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.TypeDefId;
-import us.kbase.typedobj.core.TypedObjectValidationReport;
+import us.kbase.typedobj.core.ValidatedTypedObject;
 import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.db.FileTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
@@ -111,7 +111,7 @@ public class TypedObjectValidationReportTest {
 		String json = "{\"m\": {\"z\": 1, \"b\": []}}";
 		
 		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(100);
-		TypedObjectValidationReport tovr = validator.validate(json,
+		ValidatedTypedObject tovr = validator.validate(json,
 				new TypeDefId("TestIDMap.IDMap"),
 				fac.createHandlers(String.class).associateObject("foo"));
 		List<String> errors = Arrays.asList(
@@ -145,7 +145,7 @@ public class TypedObjectValidationReportTest {
 						new HashMap<String, String>()));
 		IdReferenceHandlerSet<String> handlers =
 				fac.createHandlers(String.class).associateObject("foo");
-		TypedObjectValidationReport tovr = validator.validate(json,
+		ValidatedTypedObject tovr = validator.validate(json,
 				new TypeDefId("TestIDMap.IDMap"), handlers);
 		handlers.processIDs();
 		
@@ -173,7 +173,7 @@ public class TypedObjectValidationReportTest {
 		String json = "{\"m\": {\"c\": \"a\", \"z\": \"d\"}," +
 						"\"att\":[\"a1\", 3, \"a1\", \"a2\", \"a1\"]," +
 						"\"att2\":[\"b1\", 3, \"b2\", \"b3\", \"b4\"]}";
-		TypedObjectValidationReport tovr = validator.validate(json,
+		ValidatedTypedObject tovr = validator.validate(json,
 				new TypeDefId("TestIDMap.IDMap"), 
 				new IdReferenceHandlerSetFactory(1).createHandlers(String.class));
 		
@@ -212,7 +212,7 @@ public class TypedObjectValidationReportTest {
 		checkIDLocation(tovr, foo2Type, "b4", attrib1, null);
 	}
 
-	private void checkIDLocation(TypedObjectValidationReport tovr,
+	private void checkIDLocation(ValidatedTypedObject tovr,
 			IdReferenceType wsType, final String id, List<String> mtAttribs,
 			String expectedLoc) throws IOException {
 		JsonDocumentLocation loc = tovr.getIdReferenceLocation(
@@ -253,7 +253,7 @@ public class TypedObjectValidationReportTest {
 				new File(TestCommon.getTempDir()));
 		tfm.cleanup();
 		// in memory
-		TypedObjectValidationReport tovr = validator.validate(json,
+		ValidatedTypedObject tovr = validator.validate(json,
 				new TypeDefId("TestIDMap.IDMap"), handlers);
 		handlers.processIDs();
 		failGetRelabeledSize(tovr);
@@ -288,7 +288,7 @@ public class TypedObjectValidationReportTest {
 		assertThat("Temp files manager is empty", tfm.isEmpty(), is(true));
 	}
 
-	private void failGetMD5(TypedObjectValidationReport tovr) {
+	private void failGetMD5(ValidatedTypedObject tovr) {
 		try {
 			tovr.getMD5();
 			fail("got md5 for unsorted data");
@@ -308,7 +308,7 @@ public class TypedObjectValidationReportTest {
 		IdReferenceHandlerSet<String> handlers =
 				fac.createHandlers(String.class).associateObject("foo");
 
-		TypedObjectValidationReport tovr = validator.validate(json,
+		ValidatedTypedObject tovr = validator.validate(json,
 				new TypeDefId("TestIDMap.IDMap"), handlers);
 		handlers.processIDs();
 		failGetMD5(tovr);
@@ -338,7 +338,7 @@ public class TypedObjectValidationReportTest {
 		IdReferenceHandlerSet<String> handlers =
 				fac.createHandlers(String.class).associateObject("foo");
 		
-		TypedObjectValidationReport tovr = validator.validate(json,
+		ValidatedTypedObject tovr = validator.validate(json,
 				new TypeDefId("TestIDMap.IDMap"), handlers);
 		//sort via sort() method in memory
 		handlers.processIDs();
@@ -366,7 +366,7 @@ public class TypedObjectValidationReportTest {
 		IdReferenceHandlerSet<String> handlers =
 				fac.createHandlers(String.class).associateObject("foo");
 		
-		TypedObjectValidationReport tovr = validator.validate(json,
+		ValidatedTypedObject tovr = validator.validate(json,
 				new TypeDefId("TestIDMap.IDMap"), handlers);
 		handlers.processIDs();
 		TempFilesManager tfm = new TempFilesManager(
@@ -399,7 +399,7 @@ public class TypedObjectValidationReportTest {
 		IdReferenceHandlerSet<String> handlers =
 				fac.createHandlers(String.class).associateObject("foo");
 		
-		TypedObjectValidationReport tovr = validator.validate(json,
+		ValidatedTypedObject tovr = validator.validate(json,
 				new TypeDefId("TestIDMap.IDMap"), handlers);
 		assertThat("incorrect typedef", tovr.getValidationTypeDefId(),
 				is(AbsoluteTypeDefId.fromAbsoluteTypeString(
@@ -463,7 +463,7 @@ public class TypedObjectValidationReportTest {
 		assertThat("Temp files manager is empty", tfm.isEmpty(), is(true));
 	}
 
-	private void failGetRelabeledSize(TypedObjectValidationReport tovr) {
+	private void failGetRelabeledSize(ValidatedTypedObject tovr) {
 		try {
 			tovr.getRelabeledSize();
 			fail("got relabled size before calculation");
@@ -481,7 +481,7 @@ public class TypedObjectValidationReportTest {
 				new IdReferenceHandlerSetFactory(100);
 		IdReferenceHandlerSet<String> handlers =
 				hfac.createHandlers(String.class).associateObject("foo");
-		TypedObjectValidationReport tovr = validator.validate(json,
+		ValidatedTypedObject tovr = validator.validate(json,
 				new TypeDefId("TestIDMap.IDMap"), handlers);
 		handlers.processIDs();
 		

--- a/src/us/kbase/workspace/database/ResolvedSaveObject.java
+++ b/src/us/kbase/workspace/database/ResolvedSaveObject.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import us.kbase.typedobj.core.TypedObjectValidationReport;
+import us.kbase.typedobj.core.ValidatedTypedObject;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
 import us.kbase.workspace.database.WorkspaceUserMetadata.MetadataException;
@@ -15,7 +15,7 @@ public class ResolvedSaveObject {
 	private final WorkspaceUserMetadata userMeta;
 	private final Provenance provenance;
 	private final boolean hidden;
-	private final TypedObjectValidationReport rep;
+	private final ValidatedTypedObject rep;
 	private final Set<Reference> refs;
 	private final List<Reference> provrefs;
 	final Map<IdReferenceType, Set<RemappedId>> extractedIDs;
@@ -25,7 +25,7 @@ public class ResolvedSaveObject {
 			final WorkspaceUserMetadata userMeta,
 			final Provenance provenance,
 			final boolean hidden,
-			final TypedObjectValidationReport rep,
+			final ValidatedTypedObject rep,
 			final Set<Reference> refs,
 			final List<Reference> provenancerefs,
 			final Map<IdReferenceType, Set<RemappedId>> extractedIDs) {
@@ -49,7 +49,7 @@ public class ResolvedSaveObject {
 			final WorkspaceUserMetadata userMeta,
 			final Provenance provenance,
 			final boolean hidden,
-			final TypedObjectValidationReport rep,
+			final ValidatedTypedObject rep,
 			final Set<Reference> refs,
 			final List<Reference> provenancerefs,
 			final Map<IdReferenceType, Set<RemappedId>> extractedIDs) {
@@ -97,7 +97,7 @@ public class ResolvedSaveObject {
 		return hidden;
 	}
 
-	public TypedObjectValidationReport getRep() {
+	public ValidatedTypedObject getRep() {
 		return rep;
 	}
 

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -23,7 +23,7 @@ import us.kbase.typedobj.core.JsonDocumentLocation;
 import us.kbase.typedobj.core.ObjectPaths;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.TypeDefName;
-import us.kbase.typedobj.core.TypedObjectValidationReport;
+import us.kbase.typedobj.core.ValidatedTypedObject;
 import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.exceptions.NoSuchModuleException;
 import us.kbase.typedobj.exceptions.NoSuchTypeException;
@@ -621,7 +621,7 @@ public class Workspace {
 		final IdReferenceHandlerSet<IDAssociation> idhandler =
 				idHandlerFac.createHandlers(IDAssociation.class);
 		
-		final Map<WorkspaceSaveObject, TypedObjectValidationReport> reports = 
+		final Map<WorkspaceSaveObject, ValidatedTypedObject> reports = 
 				validateObjectsAndExtractReferences(objects, idhandler);
 		
 		processIds(objects, idhandler, reports);
@@ -660,7 +660,7 @@ public class Workspace {
 				refs.add((Reference) id);
 			}
 			
-			final TypedObjectValidationReport rep = reports.get(wo);
+			final ValidatedTypedObject rep = reports.get(wo);
 			saveobjs.add(wo.resolve(rep, refs, provrefs, extractedIDs));
 			ttlObjSize += rep.calculateRelabeledSize();
 			if (rep.getRelabeledSize() > rescfg.getMaxObjectSize()) {
@@ -724,18 +724,18 @@ public class Workspace {
 		}
 	}
 
-	private Map<WorkspaceSaveObject, TypedObjectValidationReport>
+	private Map<WorkspaceSaveObject, ValidatedTypedObject>
 			validateObjectsAndExtractReferences(
 			final List<WorkspaceSaveObject> objects,
 			final IdReferenceHandlerSet<IDAssociation> idhandler)
 			throws TypeStorageException, TypedObjectSchemaException,
 			TypedObjectValidationException {
-		final Map<WorkspaceSaveObject, TypedObjectValidationReport> reports = 
-				new HashMap<WorkspaceSaveObject, TypedObjectValidationReport>();
+		final Map<WorkspaceSaveObject, ValidatedTypedObject> reports = 
+				new HashMap<WorkspaceSaveObject, ValidatedTypedObject>();
 		int objcount = 1;
 		for (final WorkspaceSaveObject wo: objects) {
 			idhandler.associateObject(new IDAssociation(objcount, false));
-			final TypedObjectValidationReport rep = validate(wo, idhandler,
+			final ValidatedTypedObject rep = validate(wo, idhandler,
 					objcount);
 			reports.put(wo, rep);
 			idhandler.associateObject(new IDAssociation(objcount, true));
@@ -769,7 +769,7 @@ public class Workspace {
 	private void processIds(
 			final List<WorkspaceSaveObject> objects,
 			final IdReferenceHandlerSet<IDAssociation> idhandler,
-			final Map<WorkspaceSaveObject, TypedObjectValidationReport> reports)
+			final Map<WorkspaceSaveObject, ValidatedTypedObject> reports)
 			throws TypedObjectValidationException,
 			WorkspaceCommunicationException, CorruptWorkspaceDBException {
 		try {
@@ -812,7 +812,7 @@ public class Workspace {
 		}
 	}
 
-	private String getIDPath(TypedObjectValidationReport r,
+	private String getIDPath(ValidatedTypedObject r,
 			IdReference<String> idReference) {
 		try {
 			final JsonDocumentLocation loc = r.getIdReferenceLocation(
@@ -829,13 +829,13 @@ public class Workspace {
 		}
 	}
 
-	private TypedObjectValidationReport validate(
+	private ValidatedTypedObject validate(
 			final WorkspaceSaveObject wo,
 			final IdReferenceHandlerSet<IDAssociation> idhandler,
 			final int objcount)
 			throws TypeStorageException, TypedObjectSchemaException,
 			TypedObjectValidationException {
-		final TypedObjectValidationReport rep;
+		final ValidatedTypedObject rep;
 		try {
 			rep = validator.validate(wo.getData(), wo.getType(), idhandler);
 		} catch (NoSuchTypeException nste) {

--- a/src/us/kbase/workspace/database/WorkspaceSaveObject.java
+++ b/src/us/kbase/workspace/database/WorkspaceSaveObject.java
@@ -6,7 +6,7 @@ import java.util.Set;
 
 import us.kbase.common.service.UObject;
 import us.kbase.typedobj.core.TypeDefId;
-import us.kbase.typedobj.core.TypedObjectValidationReport;
+import us.kbase.typedobj.core.ValidatedTypedObject;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
 
@@ -80,7 +80,7 @@ public class WorkspaceSaveObject {
 		return hidden;
 	}
 
-	public ResolvedSaveObject resolve(final TypedObjectValidationReport rep,
+	public ResolvedSaveObject resolve(final ValidatedTypedObject rep,
 			final Set<Reference> references,
 			final List<Reference> provenancerefs,
 			final Map<IdReferenceType, Set<RemappedId>> extractedIDs) {

--- a/src/us/kbase/workspace/database/mongo/GridFSBlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/GridFSBlobStore.java
@@ -1,6 +1,5 @@
 package us.kbase.workspace.database.mongo;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -45,8 +44,7 @@ public class GridFSBlobStore implements BlobStore {
 		if (getFile(md5) != null) {
 			return; //already exists
 		}
-		final GridFSInputFile gif = gfs.createFile(
-				new BufferedInputStream(data), true);
+		final GridFSInputFile gif = gfs.createFile(data, true);
 		gif.setId(md5.getMD5());
 		gif.setFilename(md5.getMD5());
 		gif.put(Fields.GFS_SORTED, sorted);

--- a/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
@@ -1,6 +1,5 @@
 package us.kbase.workspace.database.mongo;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -171,8 +170,7 @@ public class ShockBlobStore implements BlobStore {
 		updateAuth();
 		final ShockNode sn;
 		try {
-			sn = client.addNode(new BufferedInputStream(data),
-					"workspace_" + md5.getMD5(), "JSON");
+			sn = client.addNode(data, "workspace_" + md5.getMD5(), "JSON");
 		} catch (TokenExpiredException ete) {
 			//this should be impossible
 			throw new RuntimeException("Token magically expired: "

--- a/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import org.slf4j.LoggerFactory;
 
@@ -31,9 +30,6 @@ import us.kbase.workspace.database.mongo.exceptions.BlobStoreException;
 import us.kbase.workspace.database.mongo.exceptions.NoSuchBlobException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.gc.iotools.stream.base.ExecutionModel;
-import com.gc.iotools.stream.base.ExecutorServiceFactory;
-import com.gc.iotools.stream.os.OutputStreamToInputStream;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
@@ -243,19 +239,9 @@ public class ShockBlobStore implements BlobStore {
 		} else {
 			sorted = (Boolean)entry.get(Fields.SHOCK_SORTED);
 		}
-		//TODO CODE, PERFORMANCE make the shock client return an inputstream
-		final OutputStreamToInputStream<ByteArrayFileCache> osis =
-				new OutputStreamToInputStream<ByteArrayFileCache>(true,
-						ExecutorServiceFactory.getExecutor(
-								ExecutionModel.THREAD_PER_INSTANCE), 10000000) { //speeds up by 2-3x
-					
-			@Override
-			protected ByteArrayFileCache doRead(InputStream is) throws Exception {
-				return bafcMan.createBAFC(is, true, sorted);
-			}
-		};
 		try {
-			client.getFile(new ShockNodeId(node), osis);
+			return bafcMan.createBAFC(client.getFile(new ShockNodeId(node)),
+					true, sorted);
 		} catch (TokenExpiredException ete) {
 			//this should be impossible
 			throw new RuntimeException("Things are broke", ete);
@@ -273,18 +259,6 @@ public class ShockBlobStore implements BlobStore {
 			throw new BlobStoreCommunicationException(
 					"Failed to retrieve shock node: " +
 					she.getLocalizedMessage(), she);
-		}
-		try {
-			osis.close();
-		} catch (IOException ioe) {
-			throw new RuntimeException("Something is broken", ioe);
-		}
-		try {
-			return osis.getResult();
-		} catch (InterruptedException ie) {
-			throw new RuntimeException("Something is broken", ie);
-		} catch (ExecutionException ee) {
-			throw new RuntimeException("Something is broken", ee);
 		}
 	}
 

--- a/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
@@ -46,7 +46,7 @@ import us.kbase.typedobj.exceptions.TypedObjectExtractionException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
-import us.kbase.typedobj.test.DummyTypedObjectValidationReport;
+import us.kbase.typedobj.test.DummyValidatedTypedObject;
 import us.kbase.workspace.database.DefaultReferenceParser;
 import us.kbase.workspace.database.ListObjectsParameters;
 import us.kbase.workspace.database.ObjIDWithChainAndSubset;
@@ -662,8 +662,8 @@ public class MongoInternalsTest {
 		WorkspaceSaveObject wso = new WorkspaceSaveObject(
 				new ObjectIDNoWSNoVer("testobj"), new UObject(data), t,
 				new WorkspaceUserMetadata(meta), p, false);
-		final DummyTypedObjectValidationReport dummy =
-				new DummyTypedObjectValidationReport(at, wso.getData());
+		final DummyValidatedTypedObject dummy =
+				new DummyValidatedTypedObject(at, wso.getData());
 		dummy.calculateRelabeledSize();
 		dummy.sort(new UTF8JsonSorterFactory(100000));
 		ResolvedSaveObject rso = wso.resolve(
@@ -877,8 +877,8 @@ public class MongoInternalsTest {
 		WorkspaceSaveObject wso = new WorkspaceSaveObject(
 				new ObjectIDNoWSNoVer(objname),
 				new UObject(data), t, null, p, false);
-		final DummyTypedObjectValidationReport dummy =
-				new DummyTypedObjectValidationReport(at, wso.getData());
+		final DummyValidatedTypedObject dummy =
+				new DummyValidatedTypedObject(at, wso.getData());
 		dummy.calculateRelabeledSize();
 		dummy.sort(new UTF8JsonSorterFactory(100000));
 		ResolvedSaveObject rso = wso.resolve(


### PR DESCRIPTION
Requires https://github.com/kbase/jars/pull/41.

Renamed TypedObjectValidationReport -> ValidatedTypedObject

Removed a number of unnecessary stream buffers. JsonTokenStream, Jackson, and the JSON sorters all do their own buffering.

Add a buffer when necessary when calling ValidatedTypedObject.getInputStream().

Simplifies pulling data from Shock and as such removes the now unnecessary EasyStream library.