### PR TITLE
Fix bug in getObjects wrt returned data size, temp files refactor

### DIFF
--- a/docsource/releasenotes.rst
+++ b/docsource/releasenotes.rst
@@ -38,6 +38,8 @@ UPDATED FEATURES / MAJOR BUG FIXES:
   anonymously would cause a null pointer error.
 * A temporary file is created and deleted at startup to ensure the temporary
   files directory is readable.
+* Fixed a bug where under certain circumstances more data than allowed could be
+  stored in memory or on disk and returned in a get_objects call.
 
 VERSION: 0.4.1 (Released 5/27/16)
 ---------------------------------

--- a/docsource/releasenotes.rst
+++ b/docsource/releasenotes.rst
@@ -32,7 +32,7 @@ UPDATED FEATURES / MAJOR BUG FIXES:
 * ``clone_workspace`` now prevents the new workspace from being accessed in any
   way while the clone is in progress.
 * ``clone_workspace`` can now exclude user specified objects from the clone.
-* Fixed two bugs where various failures on save would leave temporary files on
+* Fixed several bugs where various failures could leave temporary files on
   disk.
 * Fixed a bug where accessing an object with handles to shock nodes
   anonymously would cause a null pointer error.

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -67,7 +67,6 @@ import us.kbase.typedobj.db.FuncDetailedInfo;
 import us.kbase.typedobj.db.ModuleDefId;
 import us.kbase.typedobj.db.TypeChange;
 import us.kbase.typedobj.db.TypeDetailedInfo;
-import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
 import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.workspace.database.ListObjectsParameters;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
@@ -638,9 +637,8 @@ public class WorkspaceServer extends JsonServerServlet {
 		final WorkspaceObjectData ret = ws.getObjects(
 				getUser(params.getAuth(), authPart), Arrays.asList(oi)).get(0);
 		resourcesToDelete.set(Arrays.asList(ret));
-		final ByteArrayFileCache resource = ret.getSerializedData();
 		returnVal = new GetObjectOutput()
-			.withData(resource.getUObject())
+			.withData(ret.getSerializedData().getUObject())
 			.withMetadata(objInfoToMetaTuple(ret.getObjectInfo(), true));
         //END get_object
         return returnVal;

--- a/src/us/kbase/workspace/database/ByteArrayFileCacheManager.java
+++ b/src/us/kbase/workspace/database/ByteArrayFileCacheManager.java
@@ -34,7 +34,10 @@ public class ByteArrayFileCacheManager {
 	private final long maxSizeOnDisk;
 	private final TempFilesManager tfm;
 	
-	public ByteArrayFileCacheManager(int maxSizeInMem, long maxSizeOnDisk, TempFilesManager tfm) {
+	public ByteArrayFileCacheManager(
+			final int maxSizeInMem,
+			final long maxSizeOnDisk,
+			final TempFilesManager tfm) {
 		this.maxSizeInMem = maxSizeInMem;
 		this.maxSizeOnDisk = maxSizeOnDisk;
 		this.tfm = tfm;
@@ -116,7 +119,7 @@ public class ByteArrayFileCacheManager {
 				sizeOnDisk += size;
 				return new ByteArrayFileCache(null, tempFile,
 						new JsonTokenStream(tempFile)
-							.setTrustedWholeJson(trustedJson), sorted);
+							.setTrustedWholeJson(trustedJson), sorted, size);
 			} catch (IOException ioe) {
 				cleanUp(tempFile, os);
 				throw new FileCacheIOException(ioe.getLocalizedMessage(), ioe);
@@ -129,7 +132,7 @@ public class ByteArrayFileCacheManager {
 			try {
 				return new ByteArrayFileCache(null, null,
 						new JsonTokenStream(bufOs.toByteArray())
-							.setTrustedWholeJson(trustedJson), sorted);
+							.setTrustedWholeJson(trustedJson), sorted, size);
 			} catch (IOException ioe) {
 				throw new FileCacheIOException(
 						ioe.getLocalizedMessage(), ioe);
@@ -193,14 +196,14 @@ public class ByteArrayFileCacheManager {
 				return new ByteArrayFileCache(parent, tempFile[0],
 						new JsonTokenStream(tempFile[0])
 						.setTrustedWholeJson(parent.containsTrustedJson()),
-						parent.isSorted()); 
+						parent.isSorted(), size[0]); 
 			} else {
 				sizeInMem += (int)size[0];
 				byte[] arr = ((ByteArrayOutputStream)origin[0]).toByteArray();
 				return new ByteArrayFileCache(parent, null,
 						new JsonTokenStream(arr)
 						.setTrustedWholeJson(parent.containsTrustedJson()),
-						parent.isSorted());
+						parent.isSorted(), size[0]);
 			}
 		} catch (Throwable e) {
 			try {
@@ -239,11 +242,15 @@ public class ByteArrayFileCacheManager {
 		private ByteArrayFileCache parent = null;
 		private boolean destroyed = false;
 		private final boolean sorted;
+		private final long size;
 		
 		// sorted is ignored if a parent is present
-		private ByteArrayFileCache(final ByteArrayFileCache parent,
-				final File tempFile, final JsonTokenStream jts,
-				final boolean sorted) {
+		private ByteArrayFileCache(
+				final ByteArrayFileCache parent,
+				final File tempFile,
+				final JsonTokenStream jts,
+				final boolean sorted,
+				final long size) {
 			this.parent = parent;
 			this.tempFile = tempFile;
 			this.jts = jts;
@@ -252,10 +259,15 @@ public class ByteArrayFileCacheManager {
 			} else {
 				this.sorted = sorted;
 			}
+			this.size = size;
 		}
 		
 		public boolean isSorted() {
 			return sorted;
+		}
+		
+		public long getSize() {
+			return size;
 		}
 		
 		public UObject getUObject() throws JsonParseException, IOException {

--- a/src/us/kbase/workspace/database/ByteArrayFileCacheManager.java
+++ b/src/us/kbase/workspace/database/ByteArrayFileCacheManager.java
@@ -323,6 +323,10 @@ public class ByteArrayFileCacheManager {
 			}
 		}
 		
+		/** Destroys any data associated with this cache and calls destroy()
+		 * on this cache's parent. Only subdata objects have a parent, but
+		 * multiple subdata objects can share the same parent.
+		 */
 		public void destroy() {
 			if (destroyed) {
 				return;

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -976,7 +976,6 @@ public class Workspace {
 					//object cannot be missing at this stage
 					false, true, true);
 			
-			
 			chainpaths.clear();
 			stdpaths.clear();
 			
@@ -1009,7 +1008,7 @@ public class Workspace {
 			return ret;
 		} catch (RuntimeException | Error | CorruptWorkspaceDBException |
 				WorkspaceCommunicationException | InaccessibleObjectException |
-				TypedObjectExtractionException e){
+				TypedObjectExtractionException e) {
 			destroyGetObjectsResources(stddata);
 			destroyGetObjectsResources(chaindata);
 			throw e;
@@ -1023,7 +1022,7 @@ public class Workspace {
 			return;
 		}
 		for (final Map<ObjectPaths, WorkspaceObjectData> paths:
-			data.values()) {
+				data.values()) {
 			for (final WorkspaceObjectData d: paths.values()) {
 				try {
 					d.destroy();

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -675,8 +675,8 @@ public class Workspace {
 		objects = null;
 		reports.clear();
 		
-		sortObjects(saveobjs, ttlObjSize);
 		try {
+			sortObjects(saveobjs, ttlObjSize);
 			return db.saveObjects(user, rwsi, saveobjs);
 		} finally {
 			for (final ResolvedSaveObject wo: saveobjs) {

--- a/src/us/kbase/workspace/database/WorkspaceDatabase.java
+++ b/src/us/kbase/workspace/database/WorkspaceDatabase.java
@@ -212,7 +212,13 @@ public interface WorkspaceDatabase {
 	
 	/** Get object data and provenance information from the workspace database.
 	 * @param objects the objects for which to retrieve data.
-	 * @param noData return provenance only if true.
+	 * @param dataManager the data manager. Reuse the same data manager over
+	 * multiple getObjects() calls to enforce limits on the combined returned
+	 * data. If null, only provenance information is returned.
+	 * @param usedDataAllocation the amount of data already pulled from prior
+	 * getObjects() calls. This amount will be added to the data amount pulled
+	 * this call and if the total exceeds the limit, an exception will be
+	 * thrown.
 	 * @param exceptIfDeleted throw an exception if deleted.
 	 * @param includeDeleted include information from deleted objects. Has no
 	 * effect if exceptIfDeleted is set.
@@ -229,7 +235,8 @@ public interface WorkspaceDatabase {
 	public Map<ObjectIDResolvedWS, Map<ObjectPaths, WorkspaceObjectData>>
 			getObjects(
 					Map<ObjectIDResolvedWS, Set<ObjectPaths>> objects,
-					boolean noData,
+					ByteArrayFileCacheManager dataManager,
+					long usedDataAllocation,
 					boolean exceptIfDeleted,
 					boolean includeDeleted,
 					boolean exceptIfMissing)

--- a/src/us/kbase/workspace/database/WorkspaceObjectData.java
+++ b/src/us/kbase/workspace/database/WorkspaceObjectData.java
@@ -96,6 +96,17 @@ public class WorkspaceObjectData {
 		return isCopySourceInaccessible;
 	}
 	
+	/** Destroys any resources used to store the objects. In the case of
+	 * object subsets, also destroys the parent objects. This method should be
+	 * called on a set of objects when further processing is no longer
+	 * required.
+	 */
+	public void destroy() {
+		if (data != null) {
+			data.destroy();
+		}
+	}
+	
 	/**
 	 * @return Maps/lists/scalars
 	 * @throws IOException 

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -2179,12 +2179,20 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 			final Map<ObjectIDResolvedWS, Map<ObjectPaths,
 				WorkspaceObjectData>> ret) {
 		for (final ByteArrayFileCache f: chksumToData.values()) {
-			f.destroy();
+			try {
+				f.destroy();
+			} catch (RuntimeException | Error e) {
+				//continue
+			}
 		}
 		for (final Map<ObjectPaths, WorkspaceObjectData> m:
 			ret.values()) {
 			for (final WorkspaceObjectData wod: m.values()) {
-				wod.getSerializedData().destroy();
+				try {
+					wod.destroy();
+				} catch (RuntimeException | Error e) {
+					//continue
+				}
 			}
 		}
 	}

--- a/src/us/kbase/workspace/kbase/ArgUtils.java
+++ b/src/us/kbase/workspace/kbase/ArgUtils.java
@@ -272,7 +272,7 @@ public class ArgUtils {
 	}
 
 	public static List<List<Tuple11<Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>>>>
-			translateObjectDataList(
+			translateObjectInfoList(
 					final List<Set<ObjectInformation>> lsoi,
 					final boolean logObjects) {
 		final List<List<Tuple11<Long, String, String, String, Long, String,
@@ -418,7 +418,6 @@ public class ArgUtils {
 	public static List<ObjectData> translateObjectData(
 			final List<WorkspaceObjectData> objects, 
 			final WorkspaceUser user,
-			final Set<ByteArrayFileCache> resourcesToDestroy,
 			final URL handleManagerURl,
 			final RefreshingToken handleManagertoken,
 			final boolean logObjects)
@@ -450,7 +449,6 @@ public class ArgUtils {
 					.withExtractedIds(o.getExtractedIds())
 					.withHandleError(error.error)
 					.withHandleStacktrace(error.stackTrace));
-			resourcesToDestroy.add(resource);
 		}
 		return ret;
 	}

--- a/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
@@ -47,6 +47,7 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
 import us.kbase.typedobj.test.DummyValidatedTypedObject;
+import us.kbase.workspace.database.ByteArrayFileCacheManager;
 import us.kbase.workspace.database.DefaultReferenceParser;
 import us.kbase.workspace.database.ListObjectsParameters;
 import us.kbase.workspace.database.ObjIDWithChainAndSubset;
@@ -862,8 +863,10 @@ public class MongoInternalsTest {
 		for (final ObjectIDResolvedWS o: oidsetver) {
 			paths.put(o, null);
 		}
+		final ByteArrayFileCacheManager man = new ByteArrayFileCacheManager(
+				10000, 10000, mwdb.getTempFilesManager());
 		try {
-			mwdb.getObjects(paths, false, true, false, true);
+			mwdb.getObjects(paths, man, 0, true, false, true);
 			fail("operated on object with no version");
 		} catch (NoSuchObjectException nsoe) {
 			assertThat("correct exception message", nsoe.getMessage(),

--- a/src/us/kbase/workspace/test/workspace/WorkspaceLongTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceLongTest.java
@@ -180,17 +180,20 @@ public class WorkspaceLongTest extends WorkspaceTester {
 		WorkspaceObjectData wod = ws.getObjects(userfoo,
 				Arrays.asList(new ObjectIdentifier(wspace, "auto10001")))
 				.get(0);
-		
-		@SuppressWarnings("unchecked")
-		Map<String, Object> ret = (Map<String, Object>) wod.getData();
-		@SuppressWarnings("unchecked")
-		Map<String, String> retrefs = (Map<String, String>) ret.get("map");
-		for (Entry<String, String> es: retrefs.entrySet()) {
-			long expected = Long.parseLong(es.getValue().split(" ")[1]);
-			ObjectIdentifier oi = ObjectIdentifier.parseObjectReference(es.getKey());
-			assertThat("reference ws is correct", oi.getWorkspaceIdentifier().getId(), is(wsid));
-			assertThat("reference id is correct", oi.getId(), is(expected));
-			assertThat("reference ver is correct", oi.getVersion(), is(1));
+		try {
+			@SuppressWarnings("unchecked")
+			Map<String, Object> ret = (Map<String, Object>) wod.getData();
+			@SuppressWarnings("unchecked")
+			Map<String, String> retrefs = (Map<String, String>) ret.get("map");
+			for (Entry<String, String> es: retrefs.entrySet()) {
+				long expected = Long.parseLong(es.getValue().split(" ")[1]);
+				ObjectIdentifier oi = ObjectIdentifier.parseObjectReference(es.getKey());
+				assertThat("reference ws is correct", oi.getWorkspaceIdentifier().getId(), is(wsid));
+				assertThat("reference id is correct", oi.getId(), is(expected));
+				assertThat("reference ver is correct", oi.getVersion(), is(1));
+			}
+		} finally {
+			destroyGetObjectsResources(Arrays.asList(wod));
 		}
 		assertThat("returned refs correct", new HashSet<String>(wod.getReferences()),
 				is(expectedRefs));
@@ -224,9 +227,17 @@ public class WorkspaceLongTest extends WorkspaceTester {
 		ws.saveObjects(userfoo, unicode, Arrays.asList(
 				new WorkspaceSaveObject(data, SAFE_TYPE1, null, new Provenance(userfoo), false)),
 				getIdFactory());
-		@SuppressWarnings("unchecked")
-		Map<String, Object> newdata = (Map<String, Object>) ws.getObjects(
-				userfoo, Arrays.asList(new ObjectIdentifier(unicode, 1))).get(0).getData();
+		final List<WorkspaceObjectData> objects = ws.getObjects(
+				userfoo, Arrays.asList(new ObjectIdentifier(unicode, 1)));
+		final Map<String, Object> newdata;
+		try {
+			@SuppressWarnings("unchecked")
+			Map<String, Object> newdatatmp =
+					(Map<String, Object>) objects.get(0).getData();
+			newdata = newdatatmp;
+		} finally {
+			destroyGetObjectsResources(objects);
+		}
 		assertThat("correct obj keys", newdata.keySet(),
 				is((Set<String>) new HashSet<String>(Arrays.asList("subset"))));
 		@SuppressWarnings("unchecked")
@@ -241,12 +252,17 @@ public class WorkspaceLongTest extends WorkspaceTester {
 		ws.saveObjects(userfoo, unicode, Arrays.asList(
 				new WorkspaceSaveObject(data, SAFE_TYPE1, null, new Provenance(userfoo), false)),
 				getIdFactory());
-		@SuppressWarnings("unchecked")
-		Map<String, Object> newdata2 = (Map<String, Object>) ws.getObjects(
-				userfoo, Arrays.asList(new ObjectIdentifier(unicode, 2))).get(0).getData();
-		assertThat("unicode key correct", newdata2.keySet(),
-				is((Set<String>) new HashSet<String>(Arrays.asList(test))));
-		assertThat("value correct", (String) newdata2.get(test), is("foo"));
+		final List<WorkspaceObjectData> objects2 = ws.getObjects(
+				userfoo, Arrays.asList(new ObjectIdentifier(unicode, 2)));
+		try {
+			@SuppressWarnings("unchecked")
+			Map<String, Object> newdata2 = (Map<String, Object>) objects2.get(0).getData();
+			assertThat("unicode key correct", newdata2.keySet(),
+					is((Set<String>) new HashSet<String>(Arrays.asList(test))));
+			assertThat("value correct", (String) newdata2.get(test), is("foo"));
+		} finally {
+			destroyGetObjectsResources(objects2);
+		}
 	}
 	
 	@Test

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -1449,10 +1449,13 @@ public class WorkspaceTest extends WorkspaceTester {
 				new ObjectIdentifier(wspace, 3),
 				new ObjectIdentifier(wspace, 4),
 				new ObjectIdentifier(wspace, 5)));
-		
-		for (WorkspaceObjectData wod: ret) {
-			assertThat("got correct object input in various encodings",
-					wod.getData(), is((Object) craycraymap));
+		try {
+			for (WorkspaceObjectData wod: ret) {
+				assertThat("got correct object input in various encodings",
+						wod.getData(), is((Object) craycraymap));
+		}
+		} finally {
+			destroyGetObjectsResources(ret);
 		}
 	}
 
@@ -1575,8 +1578,14 @@ public class WorkspaceTest extends WorkspaceTester {
 		long data1id = ws.saveObjects(userfoo, wspace, Arrays.asList(
 				new WorkspaceSaveObject(data1, abstype1, null, emptyprov, false)),
 				getIdFactory()).get(0).getObjectId();
-		Map<String, Object> data1copy = (Map<String, Object>)ws.getObjects(userfoo, Arrays.asList(
-				new ObjectIdentifier(wspace, data1id))).get(0).getData();
+		final List<WorkspaceObjectData> objects = ws.getObjects(
+				userfoo, Arrays.asList(new ObjectIdentifier(wspace, data1id)));
+		final Map<String, Object> data1copy;
+		try {
+				data1copy = (Map<String, Object>)objects.get(0).getData();
+		} finally {
+			destroyGetObjectsResources(objects);
+		}
 		Assert.assertEquals(keys, new TreeSet<String>(data1copy.keySet()));
 		
 		Map<String, Object> data2 = new LinkedHashMap<String, Object>();
@@ -1647,11 +1656,16 @@ public class WorkspaceTest extends WorkspaceTester {
 				new WorkspaceSaveObject(data, SAFE_TYPE1, null, mtprov,
 						false)
 				), getIdFactory());
-		@SuppressWarnings("unchecked")
-		Map<String, Object> dataObj = (Map<String, Object>)
-				ws.getObjects(user, Arrays.asList(
-				new ObjectIdentifier(wspace, 1))).get(0).getData();
-		assertThat("data saved correctly", dataObj, is(data));
+		final List<WorkspaceObjectData> objects = ws.getObjects(
+				user, Arrays.asList(new ObjectIdentifier(wspace, 1)));
+		try {
+			@SuppressWarnings("unchecked")
+			Map<String, Object> dataObj = (Map<String, Object>)
+					objects.get(0).getData();
+			assertThat("data saved correctly", dataObj, is(data));
+		} finally {
+			destroyGetObjectsResources(objects);
+		}
 	}
 	
 	@Test
@@ -2116,10 +2130,14 @@ public class WorkspaceTest extends WorkspaceTester {
 		for (int i = 3; i < 11; i++) {
 			WorkspaceObjectData wod = ws.getObjects(userfoo, Arrays.asList(
 					new ObjectIdentifier(reftypecheck, i))).get(0);
-			@SuppressWarnings("unchecked")
-			Map<String, Object> obj = (Map<String, Object>) wod.getData();
-			assertThat("reference rewritten correctly", (String) obj.get("ref"),
-					is(reftypewsid + "/2/1"));
+			try {
+				@SuppressWarnings("unchecked")
+				Map<String, Object> obj = (Map<String, Object>) wod.getData();
+				assertThat("reference rewritten correctly",
+						(String) obj.get("ref"), is(reftypewsid + "/2/1"));
+			} finally {
+				destroyGetObjectsResources(Arrays.asList(wod));
+			}
 			assertThat("reference included correctly", wod.getReferences(),
 					is(Arrays.asList(reftypewsid + "/2/1")));
 			
@@ -2175,7 +2193,11 @@ public class WorkspaceTest extends WorkspaceTester {
 		ws.saveObjects(user, wsi, objs, new IdReferenceHandlerSetFactory(0));
 		WorkspaceObjectData d =  ws.getObjects(user, Arrays.asList(
 				new ObjectIdentifier(wsi, "auto5-2"))).get(0);
-		assertThat("auto named correctly", d.getData(), is((Object) d2));
+		try {
+			assertThat("auto named correctly", d.getData(), is((Object) d2));
+		} finally {
+			destroyGetObjectsResources(Arrays.asList(d));
+		}
 	}
 
 	@Test
@@ -2769,7 +2791,10 @@ public class WorkspaceTest extends WorkspaceTester {
 				getIdFactory());
 		List<Date> dates = checkProvenanceCorrect(foo, p2, new ObjectIdentifier(provid, 5),
 				new HashMap<String, String>());
-		Provenance got2 = ws.getObjects(foo, Arrays.asList(new ObjectIdentifier(prov, 5))).get(0).getProvenance();
+		final List<WorkspaceObjectData> objects = ws.getObjects(
+				foo, Arrays.asList(new ObjectIdentifier(prov, 5)));
+		destroyGetObjectsResources(objects); // don't need the data
+		Provenance got2 = objects.get(0).getProvenance();
 		assertThat("Prov date constant", got2.getDate(), is(dates.get(0)));
 		Provenance gotProv2 = ws.getObjects(foo, Arrays.asList(
 				new ObjectIdentifier(prov, 5)), true).get(0).getProvenance();
@@ -3351,6 +3376,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		ObjectInformation save13 = objs.get(2);
 		
 		WorkspaceObjectData wod = ws.getObjects(user1, Arrays.asList(oihide)).get(0);
+		destroyGetObjectsResources(Arrays.asList(wod));
 		WorkspaceObjectData woi = ws.getObjects(user1, Arrays.asList(oihide), true).get(0);
 		assertThat("copy ref for obj is null", wod.getCopyReference(), is((Reference) null));
 		assertThat("copy ref for prov is null", woi.getCopyReference(), is((Reference) null));
@@ -3684,8 +3710,14 @@ public class WorkspaceTest extends WorkspaceTester {
 				new LinkedList<List<WorkspaceObjectData>>();
 		
 		infos.add(ws.getObjects(user, testobjs, true));
-		infos.add(ws.getObjects(user, testobjs));
-		infos.add(ws.getObjects(user, testocs));
+		final List<WorkspaceObjectData> objects =
+				ws.getObjects(user, testobjs);
+		destroyGetObjectsResources(objects); // don't need the data
+		infos.add(objects);
+		final List<WorkspaceObjectData> objects2 =
+				ws.getObjects(user, testocs);
+		destroyGetObjectsResources(objects2); // ditto
+		infos.add(objects2);
 		
 		for (List<WorkspaceObjectData> info: infos) {
 			for (int i = 0; i < info.size(); i++) {
@@ -5688,10 +5720,14 @@ public class WorkspaceTest extends WorkspaceTester {
 				"			  ]" +
 				"}"
 				);
-		compareObjectAndInfo(got.get(0), o1, p1, expdata1, refs1, refmap1);
-		compareObjectAndInfo(got.get(1), o1, p1, expdata2, refs1, refmap1);
-		compareObjectAndInfo(got.get(2), o2, p2, expdata3, refs2, refmap2);
-		compareObjectAndInfo(got.get(3), o3, p2, expdata4, refs2, refmap2);
+		try {
+			compareObjectAndInfo(got.get(0), o1, p1, expdata1, refs1, refmap1);
+			compareObjectAndInfo(got.get(1), o1, p1, expdata2, refs1, refmap1);
+			compareObjectAndInfo(got.get(2), o2, p2, expdata3, refs2, refmap2);
+			compareObjectAndInfo(got.get(3), o3, p2, expdata4, refs2, refmap2);
+		} finally {
+			destroyGetObjectsResources(got);
+		}
 		
 		// new test for extractor that fails on an array OOB
 		failGetSubset(user, Arrays.asList(
@@ -5720,8 +5756,12 @@ public class WorkspaceTest extends WorkspaceTester {
 				"			  ]" +
 				"}"
 				);
-		compareObjectAndInfo(got.get(0), o1, p1, expdata1, refs1, refmap1);
-		compareObjectAndInfo(got.get(1), o2, p2, expdata2, refs2, refmap2);
+		try {
+			compareObjectAndInfo(got.get(0), o1, p1, expdata1, refs1, refmap1);
+			compareObjectAndInfo(got.get(1), o2, p2, expdata2, refs2, refmap2);
+		} finally {
+			destroyGetObjectsResources(got);
+		}
 		
 		failGetSubset(user, Arrays.asList(
 				new ObjIDWithChainAndSubset(oident1, null, new ObjectPaths(
@@ -6224,18 +6264,21 @@ public class WorkspaceTest extends WorkspaceTester {
 						Arrays.asList(leaf1oi),
 						new ObjectPaths(Arrays.asList("/map/id3")))
 				));
-		assertThat("correct list size", lwod.size(), is(8));
 		List<String> mtlist = new LinkedList<String>();
 		Map<String, String> mtmap = new HashMap<String, String>();
-		compareObjectAndInfo(lwod.get(0), leaf2, pU1_1, data2, mtlist, mtmap);
-		compareObjectAndInfo(lwod.get(1), simpleref, pU2_2, data2resolved, refs, refmap);
-		compareObjectAndInfo(lwod.get(2), leaf1, pU2_1, data1, mtlist, mtmap);
-		compareObjectAndInfo(lwod.get(3), leaf2, pU1_1, data2id22, mtlist, mtmap);
-		compareObjectAndInfo(lwod.get(4), leaf2, pU1_1, data2map, mtlist, mtmap);
-		compareObjectAndInfo(lwod.get(5), simpleref, pU2_2, data2id23, refs, refmap);
-		compareObjectAndInfo(lwod.get(6), leaf1, pU2_1, data1id1, mtlist, mtmap);
-		compareObjectAndInfo(lwod.get(7), leaf1, pU2_1, data1id3, mtlist, mtmap);
-		
+		try {
+			assertThat("correct list size", lwod.size(), is(8));
+			compareObjectAndInfo(lwod.get(0), leaf2, pU1_1, data2, mtlist, mtmap);
+			compareObjectAndInfo(lwod.get(1), simpleref, pU2_2, data2resolved, refs, refmap);
+			compareObjectAndInfo(lwod.get(2), leaf1, pU2_1, data1, mtlist, mtmap);
+			compareObjectAndInfo(lwod.get(3), leaf2, pU1_1, data2id22, mtlist, mtmap);
+			compareObjectAndInfo(lwod.get(4), leaf2, pU1_1, data2map, mtlist, mtmap);
+			compareObjectAndInfo(lwod.get(5), simpleref, pU2_2, data2id23, refs, refmap);
+			compareObjectAndInfo(lwod.get(6), leaf1, pU2_1, data1id1, mtlist, mtmap);
+			compareObjectAndInfo(lwod.get(7), leaf1, pU2_1, data1id3, mtlist, mtmap);
+		} finally {
+			destroyGetObjectsResources(lwod);
+		}
 		// test getting provenance only
 		lwod = ws.getObjects(user1, Arrays.asList(
 				leaf2oi,
@@ -6243,10 +6286,13 @@ public class WorkspaceTest extends WorkspaceTester {
 				(ObjectIdentifier) new ObjectIDWithRefChain(
 						simplerefoi, Arrays.asList(leaf1oi))
 				), true);
-		compareObjectAndInfo(lwod.get(0), leaf2, pU1_1, null, mtlist, mtmap);
-		compareObjectAndInfo(lwod.get(1), simpleref, pU2_2, null, refs, refmap);
-		compareObjectAndInfo(lwod.get(2), leaf1, pU2_1, null, mtlist, mtmap);
-		
+		try {
+			compareObjectAndInfo(lwod.get(0), leaf2, pU1_1, null, mtlist, mtmap);
+			compareObjectAndInfo(lwod.get(1), simpleref, pU2_2, null, refs, refmap);
+			compareObjectAndInfo(lwod.get(2), leaf1, pU2_1, null, mtlist, mtmap);
+		} finally {
+			destroyGetObjectsResources(lwod);
+		}
 		// test getting info only
 		List<ObjectInformation> loi = ws.getObjectInformation(user1,
 				Arrays.asList(
@@ -6461,14 +6507,18 @@ public class WorkspaceTest extends WorkspaceTester {
 		a.add(new ObjectIDWithRefChain(delptr2oi, Arrays.asList(del2oi, leaf1oi1)));
 		a.add(new ObjectIDWithRefChain(delptr2oi, Arrays.asList(del2oi, leaf2oi)));
 		List<WorkspaceObjectData> lwod = ws.getObjects(user1, a);
-		assertThat("correct list size", lwod.size(), is(7));
-		compareObjectAndInfo(lwod.get(0), leaf1_1, new Provenance(user2), data1, mtlist, mtmap);
-		compareObjectAndInfo(lwod.get(1), leaf2, new Provenance(user2), data2, mtlist, mtmap);
-		compareObjectAndInfo(lwod.get(2), leaf1_1, new Provenance(user2), data1, mtlist, mtmap);
-		compareObjectAndInfo(lwod.get(3), leaf2, new Provenance(user2), data2, mtlist, mtmap);
-		compareObjectAndInfo(lwod.get(4), leaf2, new Provenance(user2), data2, mtlist, mtmap);
-		compareObjectAndInfo(lwod.get(5), leaf1_1, new Provenance(user2), data1, mtlist, mtmap);
-		compareObjectAndInfo(lwod.get(6), leaf2, new Provenance(user2), data2, mtlist, mtmap);
+		try {
+			assertThat("correct list size", lwod.size(), is(7));
+			compareObjectAndInfo(lwod.get(0), leaf1_1, new Provenance(user2), data1, mtlist, mtmap);
+			compareObjectAndInfo(lwod.get(1), leaf2, new Provenance(user2), data2, mtlist, mtmap);
+			compareObjectAndInfo(lwod.get(2), leaf1_1, new Provenance(user2), data1, mtlist, mtmap);
+			compareObjectAndInfo(lwod.get(3), leaf2, new Provenance(user2), data2, mtlist, mtmap);
+			compareObjectAndInfo(lwod.get(4), leaf2, new Provenance(user2), data2, mtlist, mtmap);
+			compareObjectAndInfo(lwod.get(5), leaf1_1, new Provenance(user2), data1, mtlist, mtmap);
+			compareObjectAndInfo(lwod.get(6), leaf2, new Provenance(user2), data2, mtlist, mtmap);
+		} finally {
+			destroyGetObjectsResources(lwod);
+		}
 		List<ObjectInformation> loi = ws.getObjectInformation(user1, a, true, false);
 		assertThat("object info not same", loi, is(Arrays.asList(
 				leaf1_1, leaf2, leaf1_1, leaf2, leaf2, leaf1_1, leaf2)));
@@ -6491,9 +6541,13 @@ public class WorkspaceTest extends WorkspaceTester {
 		a.add(new ObjectIDWithRefChain(delptr12oi, Arrays.asList(del1oi, leaf2tempID)));
 		a.add(new ObjectIDWithRefChain(delptr12oi, Arrays.asList(del2oi, leaf2nover)));
 		lwod = ws.getObjects(user1, a);
-		compareObjectAndInfo(lwod.get(0), leaf2, new Provenance(user2), data2, mtlist, mtmap);
-		compareObjectAndInfo(lwod.get(1), leaf2, new Provenance(user2), data2, mtlist, mtmap);
-		compareObjectAndInfo(lwod.get(2), leaf2, new Provenance(user2), data2, mtlist, mtmap);
+		try {
+			compareObjectAndInfo(lwod.get(0), leaf2, new Provenance(user2), data2, mtlist, mtmap);
+			compareObjectAndInfo(lwod.get(1), leaf2, new Provenance(user2), data2, mtlist, mtmap);
+			compareObjectAndInfo(lwod.get(2), leaf2, new Provenance(user2), data2, mtlist, mtmap);
+		} finally {
+			destroyGetObjectsResources(lwod);
+		}
 		loi = ws.getObjectInformation(user1, a, true, false);
 		assertThat("object info not same", loi, is(Arrays.asList(
 				leaf2, leaf2, leaf2)));
@@ -6790,6 +6844,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		List<ObjectIDWithRefChain> refchain2 = 
 				Arrays.asList(new ObjectIDWithRefChain(ref, oi1l),
 				new ObjectIDWithRefChain(ref2, oi2l));
+		TestCommon.assertNoTempFilesExist(tfm);
 		
 		ResourceUsageConfiguration oldcfg = ws.getResourceConfig();
 		try {
@@ -6805,18 +6860,23 @@ public class WorkspaceTest extends WorkspaceTester {
 					Arrays.asList(new ObjIDWithChainAndSubset(oi1, null,
 					new ObjectPaths(new ArrayList<String>()))));
 			successGetObjects(user, oi1l);
-			ws.getObjects(user, ois1l);
-			ws.getObjects(user, ois1lmt);
-			ws.getObjects(user, refchain);
+			destroyGetObjectsResources(ws.getObjects(user, ois1l));
+			destroyGetObjectsResources(ws.getObjects(user, ois1lmt));
+			destroyGetObjectsResources(ws.getObjects(user, refchain));
+			TestCommon.assertNoTempFilesExist(tfm);
 			ws.setResourceConfig(build.withMaxReturnedDataSize(19).build());
 			String errstr = "Too much data requested from the workspace at once; data requested " + 
 					"including potential subsets is %sB which exceeds maximum of %s.";
 			IllegalArgumentException err = new IllegalArgumentException(String.format(errstr, 20, 19));
 			failGetObjects(user, oi1l, err, true);
+			TestCommon.assertNoTempFilesExist(tfm);
 			failGetSubset(user, (List<ObjIDWithChainAndSubset>)(List<?>) ois1l, err);
+			TestCommon.assertNoTempFilesExist(tfm);
 			failGetSubset(user, (List<ObjIDWithChainAndSubset>)(List<?>) ois1lmt, err);
+			TestCommon.assertNoTempFilesExist(tfm);
 			failGetReferencedObjects(user,
 					(List<ObjectIDWithRefChain>)(List<?>) refchain, err, true);
+			TestCommon.assertNoTempFilesExist(tfm);
 			
 			ws.setResourceConfig(build.withMaxReturnedDataSize(40).build());
 			List<ObjectIdentifier> two = Arrays.asList(oi1, oi2);
@@ -6830,25 +6890,35 @@ public class WorkspaceTest extends WorkspaceTester {
 					new ObjIDWithChainAndSubset(oi2, null, new ObjectPaths(Arrays.asList("/ba"))));
 			successGetObjects(user, two);
 			successGetObjects(user, mixed);
-			ws.getObjects(user, (List<ObjectIdentifier>)(List<?>) ois1l2);
-			ws.getObjects(user, (List<ObjectIdentifier>)(List<?>) bothoi);
-			ws.getObjects(user, (List<ObjectIdentifier>)(List<?>) refchain2);
+			destroyGetObjectsResources(ws.getObjects(user,
+					(List<ObjectIdentifier>)(List<?>) ois1l2));
+			destroyGetObjectsResources(ws.getObjects(user,
+					(List<ObjectIdentifier>)(List<?>) bothoi));
+			destroyGetObjectsResources(ws.getObjects(user,
+					(List<ObjectIdentifier>)(List<?>) refchain2));
+			TestCommon.assertNoTempFilesExist(tfm);
 			ws.setResourceConfig(build.withMaxReturnedDataSize(39).build());
 			err = new IllegalArgumentException(String.format(errstr, 40, 39));
 			failGetObjects(user, two, err, true);
+			TestCommon.assertNoTempFilesExist(tfm);
 			failGetObjects(user, mixed, err, true);
+			TestCommon.assertNoTempFilesExist(tfm);
 			failGetSubset(user, ois1l2, err);
+			TestCommon.assertNoTempFilesExist(tfm);
 			failGetSubset(user, bothoi, err);
+			TestCommon.assertNoTempFilesExist(tfm);
 			failGetReferencedObjects(user, refchain2, err, true);
+			TestCommon.assertNoTempFilesExist(tfm);
 			
 			List<ObjectIdentifier> all = new LinkedList<ObjectIdentifier>();
 			all.addAll(ois1l2);
 			all.addAll(bothoi);
 			ws.setResourceConfig(build.withMaxReturnedDataSize(60).build());
-			ws.getObjects(user, all);
+			destroyGetObjectsResources(ws.getObjects(user, all));
 			ws.setResourceConfig(build.withMaxReturnedDataSize(59).build());
 			err = new IllegalArgumentException(String.format(errstr, 60, 59));
 			failGetSubset(user, (List<ObjIDWithChainAndSubset>)(List<?>) all, err);
+			TestCommon.assertNoTempFilesExist(tfm);
 		} finally {
 			ws.setResourceConfig(oldcfg);
 		}
@@ -7033,8 +7103,12 @@ public class WorkspaceTest extends WorkspaceTester {
 		ws.saveObjects(user, wsi, objs, getIdFactory());
 		WorkspaceObjectData o = ws.getObjects(
 				user, Arrays.asList(new ObjectIdentifier(wsi, 1))).get(0);
-		String data = IOUtils.toString(o.getSerializedData().getJSON());
-		assertThat("data is sorted", data, is(expected));
+		try {
+			String data = IOUtils.toString(o.getSerializedData().getJSON());
+			assertThat("data is sorted", data, is(expected));
+		} finally {
+			destroyGetObjectsResources(Arrays.asList(o));
+		}
 		assertThat("data marked as sorted", o.getSerializedData().isSorted(),
 				is(true));
 	}


### PR DESCRIPTION
Since 0.4.1 there are two calls to MongoWorkspaceDB.getObjects in each
Workspace.getObjects call - one for standard objects and one for object
reference paths. Each MWDB.GO call checked data limits independently,
which meant that twice the allowed data limit could be stored on disk,
in memory, and returned. 

Altered the MWDB.getObjects calls so that the set of two calls shares
the same limits.

Went down the temp files rabbit hole and reworked temp files management
in a number of places.

* Made all workspace level tests check for temp files.
* Fixed a bug where sort errors could leave temp files on disk.
* Made the server level tempfiles cleanup easier to understand and less
prone to failure.
* Fixed a bug where getObjects() errors could leave temp files on disk for similar
reasons to the data limit bug decribed above.