### PR TITLE
Refactoring class names

### DIFF
--- a/src/us/kbase/typedobj/core/SubdataExtractor.java
+++ b/src/us/kbase/typedobj/core/SubdataExtractor.java
@@ -31,7 +31,7 @@ public class SubdataExtractor {
 	 * stored in memory as a tree rather than as token stream that could be processed
 	 * directly from a file.
 	 */
-	public static JsonNode extract(ObjectPaths objpaths, JsonNode input) 
+	public static JsonNode extract(SubsetSelection objpaths, JsonNode input) 
 			throws IOException, TypedObjectExtractionException {
 		TokenSequenceProvider tsp = createTokenSequenceProvider(new TreeTraversingParser(input));
 		JsonTreeGenerator jgen = new JsonTreeGenerator(mapper);
@@ -54,12 +54,12 @@ public class SubdataExtractor {
 	 * a mapping or array.
 	 * @throws TypedObjectExtractionException 
 	 */
-	public static void extract(ObjectPaths objpaths, JsonParser jp, JsonGenerator output) 
+	public static void extract(SubsetSelection objpaths, JsonParser jp, JsonGenerator output) 
 			throws IOException, TypedObjectExtractionException {
 		extractFields(objpaths, createTokenSequenceProvider(jp), output);
 	}
 	
-	private static void extractFields(ObjectPaths objpaths, TokenSequenceProvider jts, JsonGenerator output) 
+	private static void extractFields(SubsetSelection objpaths, TokenSequenceProvider jts, JsonGenerator output) 
 	        throws IOException, TypedObjectExtractionException {
 		//if the selection is empty, we return without adding anything
 		SubdataExtractionNode root = new SubdataExtractionNode();

--- a/src/us/kbase/typedobj/core/SubsetSelection.java
+++ b/src/us/kbase/typedobj/core/SubsetSelection.java
@@ -6,42 +6,47 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * Class is responsible for storing "JSON Pointer" paths pointing to particular places in 
- * JSON data (that is constructed based on arrays and maps nested in each other in any
- * combinations). Path elements are separated by '/' character. In order to be able to
- * use '/' itself as part of mapping keys RFC6901 approach is used 
- * (http://tools.ietf.org/html/rfc6901).
+ * Class is responsible for storing "JSON Pointer" paths pointing to particular
+ * places in JSON data (that is constructed based on arrays and maps nested in
+ * each other in any combinations). Path elements are separated by '/'
+ * character. In order to be able to use '/' itself as part of mapping keys
+ * RFC6901 approach is used (http://tools.ietf.org/html/rfc6901).
  * @author rsutormin
+ * @author gaprice@lbl.gov
  */
 public class SubsetSelection implements Iterable<String> {
 	
+	//TODO TEST unit tests
+
 	public static final SubsetSelection EMPTY = new SubsetSelection(null);
-	
+
 	private final List<String> paths;
 	private final boolean strictMaps;
 	private final boolean strictArrays;
-	
-   /** sets default behavior for extraction.  If strict is true, then errors are thrown if a field
-     * in map is requested but does not exist in the data object. If strict is false, then
-     * if the field in map is missing, nothing is returned.  This is useful for optional
-     * fields, but may be prone to error if a user has a typo in the path.
-     */
-    public static boolean STRICT_MAPS_DEFAULT = false;
 
-    /** sets default behavior for extraction.  If strict is true, then errors are thrown if an
-     * array element is requested but does not exist in the data object. If strict is false and
-     * an array element is missing, nothing is returned.  This is useful for optional
-     * array items, but may be prone to error if a user has a typo in the path.
-     */
-    public static boolean STRICT_ARRAYS_DEFAULT = true;
+	/** Sets default behavior for extraction.  If strict is true, then errors
+	 * are thrown if a field in a map is requested but does not exist in the
+	 * data object. If strict is false, then if the field in a map is missing,
+	 * nothing is returned.  This is useful for optional fields, but may be
+	 * prone to error if a user has a typo in the path.
+	 */
+	public static final boolean STRICT_MAPS_DEFAULT = false;
 
-    /**
-     * Construct set of JSON Pointer paths with default values for strictMaps (false)
-     * and strictArrays (true).
-     * @param paths JSON Pointer paths
-     */
+	/** Sets default behavior for extraction.  If strict is true, then errors
+	 * are thrown if an array element is requested but does not exist in the
+	 * data object. If strict is false and an array element is missing, nothing
+	 * is returned.  This is useful for optional array items, but may be prone
+	 * to error if a user has a typo in the path.
+	 */
+	public static final boolean STRICT_ARRAYS_DEFAULT = true;
+
+	/**
+	 * Construct set of JSON Pointer paths with default values for strictMaps
+	 * (false) and strictArrays (true).
+	 * @param paths JSON Pointer paths
+	 */
 	public SubsetSelection(final List<String> paths) {
-	    this(paths, STRICT_MAPS_DEFAULT, STRICT_ARRAYS_DEFAULT);
+		this(paths, STRICT_MAPS_DEFAULT, STRICT_ARRAYS_DEFAULT);
 	}
 
 	/**
@@ -50,122 +55,135 @@ public class SubsetSelection implements Iterable<String> {
 	 * @param strictMaps restriction mode for maps
 	 * @param strictArrays restriction mode for arrays
 	 */
-	public SubsetSelection(final List<String> paths, boolean strictMaps, boolean strictArrays) {
-	    if (paths == null) {
+	public SubsetSelection(
+			final List<String> paths,
+			final boolean strictMaps,
+			final boolean strictArrays) {
+		if (paths == null) {
 			this.paths = Collections.unmodifiableList(
 					new LinkedList<String>());
 		} else {
 			this.paths = Collections.unmodifiableList(
 					new LinkedList<String>(paths));
 		}
-	    this.strictMaps = strictMaps;
-	    this.strictArrays = strictArrays;
+		this.strictMaps = strictMaps;
+		this.strictArrays = strictArrays;
 	}
-	
+
 	/**
 	 * Give restriction mode for maps
 	 * @return restriction mode for maps
 	 */
 	public boolean isStrictMaps() {
-        return strictMaps;
-    }
-	
+		return strictMaps;
+	}
+
 	/**
 	 * Give restriction mode for arrays
 	 * @return restriction mode for arrays
 	 */
 	public boolean isStrictArrays() {
-        return strictArrays;
-    }
-	
+		return strictArrays;
+	}
+
 	@Override
 	public Iterator<String> iterator() {
 		return paths.iterator();
 	}
-	
+
+	/** Returns the number of subset paths in this selection.
+	 * @return the number of subset paths.
+	 */
 	public int size() {
 		return paths.size();
 	}
-	
+
+	/** Returns true if there are no subset paths in this selection, false
+	 * otherwise.
+	 * @return true if there are no subset paths in this selection.
+	 */
 	public boolean isEmpty() {
 		return paths.isEmpty();
 	}
-	
+
+	// yeah, I'm not touching this
 	/**
-	 * Parse path according to JsonPointer rules (http://tools.ietf.org/html/rfc6901).
+	 * Parse path according to JsonPointer rules
+	 * (http://tools.ietf.org/html/rfc6901).
 	 * @param index number of path in set of paths
 	 * @return parsed path
-	 * @throws JsonPointerParseException in case there are '~' characters not followed by '0' or '1'
+	 * @throws JsonPointerParseException in case there are '~'
+	 * characters not followed by '0' or '1'
 	 */
 	public String[] getPath(int index) throws JsonPointerParseException {
-	    String p = paths.get(index);
-	    if (p.startsWith("/"))
-	        p = p.substring(1);
-	    if (p.endsWith("/"))
-	        p = p.substring(0, p.length() - 1);
-	    String[] ret = p.split("/");
-	    for (int pos = 0; pos < ret.length; pos++) {
-	        if (ret[pos].indexOf('~') >= 0) {
-	            StringBuilder item = new StringBuilder(ret[pos]);
-	            int n = 0;
-	            int origN = 0;
-	            while (n < item.length()) {
-	                if (item.charAt(n) == '~') {
-	                    char next = n + 1 < item.length() ? item.charAt(n + 1) : (char)0;
-	                    if (next == '1') {
-	                        item.setCharAt(n, '/');
-	                    } else if (next != '0') {
-	                        String errorBlock = ret[pos];
-	                        errorBlock = errorBlock.substring(0, origN) + "[->]" + errorBlock.substring(origN);
-	                        throw new JsonPointerParseException("Wrong usage of ~ in json pointer path: " + 
-	                                paths.get(index) + " (" + errorBlock + ")");
-	                    }
-	                    item.deleteCharAt(n + 1);
-	                    origN++;
-	                }
-	                n++;
-	                origN++;
-	            }
-	            ret[pos] = item.toString();
-	        }
-	    }
+		String p = paths.get(index);
+		if (p.startsWith("/"))
+			p = p.substring(1);
+		if (p.endsWith("/"))
+			p = p.substring(0, p.length() - 1);
+		String[] ret = p.split("/");
+		for (int pos = 0; pos < ret.length; pos++) {
+			if (ret[pos].indexOf('~') >= 0) {
+				StringBuilder item = new StringBuilder(ret[pos]);
+				int n = 0;
+				int origN = 0;
+				while (n < item.length()) {
+					if (item.charAt(n) == '~') {
+						char next = n + 1 < item.length() ? item.charAt(n + 1) : (char)0;
+						if (next == '1') {
+							item.setCharAt(n, '/');
+						} else if (next != '0') {
+							String errorBlock = ret[pos];
+							errorBlock = errorBlock.substring(0, origN) + "[->]" + errorBlock.substring(origN);
+							throw new JsonPointerParseException("Wrong usage of ~ in json pointer path: " + 
+									paths.get(index) + " (" + errorBlock + ")");
+						}
+						item.deleteCharAt(n + 1);
+						origN++;
+					}
+					n++;
+					origN++;
+				}
+				ret[pos] = item.toString();
+			}
+		}
 		return ret;
 	}
 
 	@Override
-    public String toString() {
-        return "ObjectPaths [paths=" + paths + ", strictMaps=" + strictMaps
-                + ", strictArrays=" + strictArrays + "]";
-    }
+	public String toString() {
+		return "ObjectPaths [paths=" + paths + ", strictMaps=" + strictMaps
+				+ ", strictArrays=" + strictArrays + "]";
+	}
 
 	@Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((paths == null) ? 0 : paths.hashCode());
-        result = prime * result + (strictArrays ? 1231 : 1237);
-        result = prime * result + (strictMaps ? 1231 : 1237);
-        return result;
-    }
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((paths == null) ? 0 : paths.hashCode());
+		result = prime * result + (strictArrays ? 1231 : 1237);
+		result = prime * result + (strictMaps ? 1231 : 1237);
+		return result;
+	}
 
 	@Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        SubsetSelection other = (SubsetSelection) obj;
-        if (paths == null) {
-            if (other.paths != null)
-                return false;
-        } else if (!paths.equals(other.paths))
-            return false;
-        if (strictArrays != other.strictArrays)
-            return false;
-        if (strictMaps != other.strictMaps)
-            return false;
-        return true;
-    }
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SubsetSelection other = (SubsetSelection) obj;
+		if (paths == null) {
+			if (other.paths != null)
+				return false;
+		} else if (!paths.equals(other.paths))
+			return false;
+		if (strictArrays != other.strictArrays)
+			return false;
+		if (strictMaps != other.strictMaps)
+			return false;
+		return true;
+	}
 }

--- a/src/us/kbase/typedobj/core/SubsetSelection.java
+++ b/src/us/kbase/typedobj/core/SubsetSelection.java
@@ -13,9 +13,9 @@ import java.util.List;
  * (http://tools.ietf.org/html/rfc6901).
  * @author rsutormin
  */
-public class ObjectPaths implements Iterable<String> {
+public class SubsetSelection implements Iterable<String> {
 	
-	public static final ObjectPaths EMPTY = new ObjectPaths(null);
+	public static final SubsetSelection EMPTY = new SubsetSelection(null);
 	
 	private final List<String> paths;
 	private final boolean strictMaps;
@@ -40,7 +40,7 @@ public class ObjectPaths implements Iterable<String> {
      * and strictArrays (true).
      * @param paths JSON Pointer paths
      */
-	public ObjectPaths(final List<String> paths) {
+	public SubsetSelection(final List<String> paths) {
 	    this(paths, STRICT_MAPS_DEFAULT, STRICT_ARRAYS_DEFAULT);
 	}
 
@@ -50,7 +50,7 @@ public class ObjectPaths implements Iterable<String> {
 	 * @param strictMaps restriction mode for maps
 	 * @param strictArrays restriction mode for arrays
 	 */
-	public ObjectPaths(final List<String> paths, boolean strictMaps, boolean strictArrays) {
+	public SubsetSelection(final List<String> paths, boolean strictMaps, boolean strictArrays) {
 	    if (paths == null) {
 			this.paths = Collections.unmodifiableList(
 					new LinkedList<String>());
@@ -156,7 +156,7 @@ public class ObjectPaths implements Iterable<String> {
             return false;
         if (getClass() != obj.getClass())
             return false;
-        ObjectPaths other = (ObjectPaths) obj;
+        SubsetSelection other = (SubsetSelection) obj;
         if (paths == null) {
             if (other.paths != null)
                 return false;

--- a/src/us/kbase/typedobj/test/ObjectExtractionByPathTest.java
+++ b/src/us/kbase/typedobj/test/ObjectExtractionByPathTest.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 import us.kbase.common.test.TestException;
-import us.kbase.typedobj.core.ObjectPaths;
+import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.typedobj.core.SubdataExtractor;
 import us.kbase.typedobj.exceptions.TypedObjectExtractionException;
 
@@ -128,13 +128,13 @@ public class ObjectExtractionByPathTest {
 		for(int k=0; k<paths.size(); k++) {
 			pathStrings.add(paths.get(k).asText());
 		}
-		ObjectPaths op;
+		SubsetSelection op;
 		try {
 			JsonNode extract;
 			if (strict != null) {
-			    op = new ObjectPaths(pathStrings, strict.asBoolean(), ObjectPaths.STRICT_ARRAYS_DEFAULT);
+			    op = new SubsetSelection(pathStrings, strict.asBoolean(), SubsetSelection.STRICT_ARRAYS_DEFAULT);
 			} else {
-			    op = new ObjectPaths(pathStrings);
+			    op = new SubsetSelection(pathStrings);
 			}
             extract = SubdataExtractor.extract(op, data);
 			

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -67,7 +67,7 @@ import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.workspace.database.ListObjectsParameters;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
-import us.kbase.workspace.database.ObjectIDWithRefChain;
+import us.kbase.workspace.database.ObjectIDWithRefPath;
 import us.kbase.workspace.database.Types;
 import us.kbase.workspace.database.Workspace;
 import us.kbase.workspace.database.ObjectIdentifier;
@@ -870,7 +870,7 @@ public class WorkspaceServer extends JsonServerServlet {
 						"Error on object chain #%s: The minimum size of a reference chain is 2 ObjectIdentities",
 						count));
 			}
-			chains.add(new ObjectIDWithRefChain(
+			chains.add(new ObjectIDWithRefPath(
 					lor.get(0), lor.subList(1, lor.size())));
 			count++;
 		}

--- a/src/us/kbase/workspace/database/ByteArrayFileCacheManager.java
+++ b/src/us/kbase/workspace/database/ByteArrayFileCacheManager.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import us.kbase.common.service.JsonTokenStream;
 import us.kbase.common.service.UObject;
-import us.kbase.typedobj.core.ObjectPaths;
+import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.typedobj.core.SubdataExtractor;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.exceptions.TypedObjectExtractionException;
@@ -151,7 +151,7 @@ public class ByteArrayFileCacheManager {
 
 	@SuppressWarnings("resource")
 	public ByteArrayFileCache getSubdataExtraction(
-			final ByteArrayFileCache parent, final ObjectPaths paths)
+			final ByteArrayFileCache parent, final SubsetSelection paths)
 			throws TypedObjectExtractionException,
 			FileCacheLimitExceededException, FileCacheIOException {
 		final OutputStream[] origin = {new ByteArrayOutputStream()};
@@ -303,7 +303,7 @@ public class ByteArrayFileCacheManager {
 			}
 		}
 		
-		private void getSubdataExtractionAsStream(final ObjectPaths paths, 
+		private void getSubdataExtractionAsStream(final SubsetSelection paths, 
 				final OutputStream os)
 				throws TypedObjectExtractionException {
 			checkIfDestroyed();

--- a/src/us/kbase/workspace/database/ObjIDWithChainAndSubset.java
+++ b/src/us/kbase/workspace/database/ObjIDWithChainAndSubset.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import us.kbase.typedobj.core.ObjectPaths;
 
-public class ObjIDWithChainAndSubset extends ObjectIDWithRefChain {
+public class ObjIDWithChainAndSubset extends ObjectIDWithRefPath {
 
 	//TODO TEST unit tests
 	

--- a/src/us/kbase/workspace/database/ObjIDWithChainAndSubset.java
+++ b/src/us/kbase/workspace/database/ObjIDWithChainAndSubset.java
@@ -62,7 +62,7 @@ public class ObjIDWithChainAndSubset extends ObjectIDWithRefPath {
 		builder.append("ObjIDWithChainsAndSubset [paths=");
 		builder.append(paths);
 		builder.append(", getChain()=");
-		builder.append(getChain());
+		builder.append(getRefPath());
 		builder.append(", getWorkspaceIdentifier()=");
 		builder.append(getWorkspaceIdentifier());
 		builder.append(", getName()=");

--- a/src/us/kbase/workspace/database/ObjIDWithChainAndSubset.java
+++ b/src/us/kbase/workspace/database/ObjIDWithChainAndSubset.java
@@ -2,24 +2,25 @@ package us.kbase.workspace.database;
 
 import java.util.List;
 
-import us.kbase.typedobj.core.ObjectPaths;
+import us.kbase.typedobj.core.SubsetSelection;
 
 public class ObjIDWithChainAndSubset extends ObjectIDWithRefPath {
 
 	//TODO TEST unit tests
+	//TODO JAVADOC
 	
-	private final ObjectPaths paths;
+	private final SubsetSelection subset;
 	
 	public ObjIDWithChainAndSubset(
 			final ObjectIdentifier id,
-			final List<ObjectIdentifier> chain,
-			final ObjectPaths subset) {
-		super(id, chain);
-		this.paths = subset == null ? ObjectPaths.EMPTY : subset;
+			final List<ObjectIdentifier> refpath,
+			final SubsetSelection subset) {
+		super(id, refpath);
+		this.subset = subset == null ? SubsetSelection.EMPTY : subset;
 	}
 	
-	public ObjectPaths getPaths() {
-		return paths;
+	public SubsetSelection getSubSet() {
+		return subset;
 	}
 
 	/* (non-Javadoc)
@@ -29,7 +30,7 @@ public class ObjIDWithChainAndSubset extends ObjectIDWithRefPath {
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
-		result = prime * result + ((paths == null) ? 0 : paths.hashCode());
+		result = prime * result + ((subset == null) ? 0 : subset.hashCode());
 		return result;
 	}
 
@@ -45,10 +46,10 @@ public class ObjIDWithChainAndSubset extends ObjectIDWithRefPath {
 		if (getClass() != obj.getClass())
 			return false;
 		ObjIDWithChainAndSubset other = (ObjIDWithChainAndSubset) obj;
-		if (paths == null) {
-			if (other.paths != null)
+		if (subset == null) {
+			if (other.subset != null)
 				return false;
-		} else if (!paths.equals(other.paths))
+		} else if (!subset.equals(other.subset))
 			return false;
 		return true;
 	}
@@ -59,9 +60,9 @@ public class ObjIDWithChainAndSubset extends ObjectIDWithRefPath {
 	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
-		builder.append("ObjIDWithChainsAndSubset [paths=");
-		builder.append(paths);
-		builder.append(", getChain()=");
+		builder.append("ObjIDWithChainsAndSubset [subset=");
+		builder.append(subset);
+		builder.append(", getRefPath()=");
 		builder.append(getRefPath());
 		builder.append(", getWorkspaceIdentifier()=");
 		builder.append(getWorkspaceIdentifier());

--- a/src/us/kbase/workspace/database/ObjIDWithRefPathAndSubset.java
+++ b/src/us/kbase/workspace/database/ObjIDWithRefPathAndSubset.java
@@ -4,14 +4,14 @@ import java.util.List;
 
 import us.kbase.typedobj.core.SubsetSelection;
 
-public class ObjIDWithChainAndSubset extends ObjectIDWithRefPath {
+public class ObjIDWithRefPathAndSubset extends ObjectIDWithRefPath {
 
 	//TODO TEST unit tests
 	//TODO JAVADOC
 	
 	private final SubsetSelection subset;
 	
-	public ObjIDWithChainAndSubset(
+	public ObjIDWithRefPathAndSubset(
 			final ObjectIdentifier id,
 			final List<ObjectIdentifier> refpath,
 			final SubsetSelection subset) {
@@ -45,7 +45,7 @@ public class ObjIDWithChainAndSubset extends ObjectIDWithRefPath {
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
-		ObjIDWithChainAndSubset other = (ObjIDWithChainAndSubset) obj;
+		ObjIDWithRefPathAndSubset other = (ObjIDWithRefPathAndSubset) obj;
 		if (subset == null) {
 			if (other.subset != null)
 				return false;

--- a/src/us/kbase/workspace/database/ObjectIDWithRefPath.java
+++ b/src/us/kbase/workspace/database/ObjectIDWithRefPath.java
@@ -8,20 +8,21 @@ import java.util.List;
 public class ObjectIDWithRefPath extends ObjectIdentifier {
 
 	//TODO TEST unit tests
+	//TODO JAVADOC
 	
-	private List<ObjectIdentifier> chain;
+	private List<ObjectIdentifier> refpath;
 	
 	public ObjectIDWithRefPath(
 			final ObjectIdentifier id,
-			List<ObjectIdentifier> chain) {
+			List<ObjectIdentifier> refpath) {
 		super(id);
-		if (chain == null || chain.isEmpty()) {
-			chain = new LinkedList<ObjectIdentifier>();
+		if (refpath == null || refpath.isEmpty()) {
+			refpath = new LinkedList<ObjectIdentifier>();
 		} 
-		this.chain = Collections.unmodifiableList(
-				new ArrayList<ObjectIdentifier>(chain));
+		this.refpath = Collections.unmodifiableList(
+				new ArrayList<ObjectIdentifier>(refpath));
 		
-		for (final ObjectIdentifier oi: this.chain) {
+		for (final ObjectIdentifier oi: this.refpath) {
 			if (oi == null) {
 				throw new IllegalArgumentException(
 						"Nulls are not allowed in reference chains");
@@ -29,12 +30,12 @@ public class ObjectIDWithRefPath extends ObjectIdentifier {
 		}
 	}
 	
-	public List<ObjectIdentifier> getChain() {
-		return chain;
+	public List<ObjectIdentifier> getRefPath() {
+		return refpath;
 	}
 	
 	public boolean hasChain() {
-		return !chain.isEmpty();
+		return !refpath.isEmpty();
 	}
 	
 	public ObjectIdentifier getLast() {
@@ -42,7 +43,7 @@ public class ObjectIDWithRefPath extends ObjectIdentifier {
 			throw new IllegalStateException(
 					"This object identifier has no reference chain");
 		}
-		return chain.get(chain.size() - 1);
+		return refpath.get(refpath.size() - 1);
 	}
 
 	/* (non-Javadoc)
@@ -52,7 +53,7 @@ public class ObjectIDWithRefPath extends ObjectIdentifier {
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
-		result = prime * result + ((chain == null) ? 0 : chain.hashCode());
+		result = prime * result + ((refpath == null) ? 0 : refpath.hashCode());
 		return result;
 	}
 
@@ -68,10 +69,10 @@ public class ObjectIDWithRefPath extends ObjectIdentifier {
 		if (getClass() != obj.getClass())
 			return false;
 		ObjectIDWithRefPath other = (ObjectIDWithRefPath) obj;
-		if (chain == null) {
-			if (other.chain != null)
+		if (refpath == null) {
+			if (other.refpath != null)
 				return false;
-		} else if (!chain.equals(other.chain))
+		} else if (!refpath.equals(other.refpath))
 			return false;
 		return true;
 	}
@@ -82,8 +83,8 @@ public class ObjectIDWithRefPath extends ObjectIdentifier {
 	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
-		builder.append("ObjectIDWithRefChains [chain=");
-		builder.append(chain);
+		builder.append("ObjectIDWithRefChains [refpath=");
+		builder.append(refpath);
 		builder.append(", getWorkspaceIdentifier()=");
 		builder.append(getWorkspaceIdentifier());
 		builder.append(", getName()=");

--- a/src/us/kbase/workspace/database/ObjectIDWithRefPath.java
+++ b/src/us/kbase/workspace/database/ObjectIDWithRefPath.java
@@ -34,12 +34,12 @@ public class ObjectIDWithRefPath extends ObjectIdentifier {
 		return refpath;
 	}
 	
-	public boolean hasChain() {
+	public boolean hasRefPath() {
 		return !refpath.isEmpty();
 	}
 	
 	public ObjectIdentifier getLast() {
-		if (!hasChain()) {
+		if (!hasRefPath()) {
 			throw new IllegalStateException(
 					"This object identifier has no reference chain");
 		}

--- a/src/us/kbase/workspace/database/ObjectIDWithRefPath.java
+++ b/src/us/kbase/workspace/database/ObjectIDWithRefPath.java
@@ -5,13 +5,13 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-public class ObjectIDWithRefChain extends ObjectIdentifier {
+public class ObjectIDWithRefPath extends ObjectIdentifier {
 
 	//TODO TEST unit tests
 	
 	private List<ObjectIdentifier> chain;
 	
-	public ObjectIDWithRefChain(
+	public ObjectIDWithRefPath(
 			final ObjectIdentifier id,
 			List<ObjectIdentifier> chain) {
 		super(id);
@@ -67,7 +67,7 @@ public class ObjectIDWithRefChain extends ObjectIdentifier {
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
-		ObjectIDWithRefChain other = (ObjectIDWithRefChain) obj;
+		ObjectIDWithRefPath other = (ObjectIDWithRefPath) obj;
 		if (chain == null) {
 			if (other.chain != null)
 				return false;

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -1106,7 +1106,7 @@ public class Workspace {
 				 * calling method input includes objectIDs with and without
 				 * chains
 				 */
-				chains.addAll(oc.getChain());
+				chains.addAll(oc.getRefPath());
 			}
 		}
 		
@@ -1149,7 +1149,7 @@ public class Workspace {
 		ObjectIdentifier pos = chain;
 		ObjectReferenceSet refs = headref;
 		int posnum = 1;
-		for (final ObjectIdentifier oi: chain.getChain()) {
+		for (final ObjectIdentifier oi: chain.getRefPath()) {
 			/* refs are guaranteed to exist, so if the db didn't find
 			 * it the user specified it incorrectly
 			 */

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -20,7 +20,7 @@ import us.kbase.common.utils.sortjson.TooManyKeysException;
 import us.kbase.common.utils.sortjson.UTF8JsonSorterFactory;
 import us.kbase.typedobj.core.AbsoluteTypeDefId;
 import us.kbase.typedobj.core.JsonDocumentLocation;
-import us.kbase.typedobj.core.ObjectPaths;
+import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.TypeDefName;
 import us.kbase.typedobj.core.ValidatedTypedObject;
@@ -955,9 +955,9 @@ public class Workspace {
 		final ResolvedResChains res = resolveObjects(user, loi,
 				nullIfInaccessible);
 		
-		final Map<ObjectIDResolvedWS, Set<ObjectPaths>> chainpaths =
+		final Map<ObjectIDResolvedWS, Set<SubsetSelection>> chainpaths =
 				setupObjectPaths(res.hadchain);
-		final Map<ObjectIDResolvedWS, Set<ObjectPaths>> stdpaths =
+		final Map<ObjectIDResolvedWS, Set<SubsetSelection>> stdpaths =
 				setupObjectPaths(res.nochain);
 		
 		//TODO CODE make an overall resource manager that takes the config as an arg and handles returned data as well as mem & file limits 
@@ -965,9 +965,9 @@ public class Workspace {
 		
 		//this is pretty gross, think about a better api here
 		Map<ObjectIDResolvedWS,
-				Map<ObjectPaths, WorkspaceObjectData>> stddata = null;
+				Map<SubsetSelection, WorkspaceObjectData>> stddata = null;
 		Map<ObjectIDResolvedWS,
-				Map<ObjectPaths, WorkspaceObjectData>> chaindata = null;
+				Map<SubsetSelection, WorkspaceObjectData>> chaindata = null;
 		try {
 			stddata = db.getObjects(stdpaths, dataMan, 0,
 					!nullIfInaccessible, false, !nullIfInaccessible);
@@ -982,11 +982,11 @@ public class Workspace {
 			final List<WorkspaceObjectData> ret =
 					new ArrayList<WorkspaceObjectData>();
 			for (final ObjectIdentifier o: loi) {
-				final ObjectPaths p;
+				final SubsetSelection p;
 				if (o instanceof ObjIDWithChainAndSubset) {
-					p = ((ObjIDWithChainAndSubset) o).getPaths();
+					p = ((ObjIDWithChainAndSubset) o).getSubSet();
 				} else {
-					p = ObjectPaths.EMPTY;
+					p = SubsetSelection.EMPTY;
 				}
 				final WorkspaceObjectData wod;
 				// works if res.nochain.get(o) is null or stddata doesn't have
@@ -1016,12 +1016,12 @@ public class Workspace {
 	}
 
 	private void destroyGetObjectsResources(
-			final Map<ObjectIDResolvedWS, Map<ObjectPaths,
+			final Map<ObjectIDResolvedWS, Map<SubsetSelection,
 					WorkspaceObjectData>> data) {
 		if (data == null) {
 			return;
 		}
-		for (final Map<ObjectPaths, WorkspaceObjectData> paths:
+		for (final Map<SubsetSelection, WorkspaceObjectData> paths:
 				data.values()) {
 			for (final WorkspaceObjectData d: paths.values()) {
 				try {
@@ -1034,10 +1034,10 @@ public class Workspace {
 	}
 
 	private long calculateDataSize(
-			final Map<ObjectIDResolvedWS, Map<ObjectPaths,
+			final Map<ObjectIDResolvedWS, Map<SubsetSelection,
 				WorkspaceObjectData>> stddata) {
 		long dataSize = 0;
-		for (final Map<ObjectPaths, WorkspaceObjectData> paths:
+		for (final Map<SubsetSelection, WorkspaceObjectData> paths:
 				stddata.values()) {
 			for (final WorkspaceObjectData d: paths.values()) {
 				if (d.hasData()) {
@@ -1065,19 +1065,19 @@ public class Workspace {
 		}
 	}
 
-	private Map<ObjectIDResolvedWS, Set<ObjectPaths>> setupObjectPaths(
+	private Map<ObjectIDResolvedWS, Set<SubsetSelection>> setupObjectPaths(
 			final Map<ObjectIdentifier, ObjectIDResolvedWS> objs) {
-		final Map<ObjectIDResolvedWS, Set<ObjectPaths>> paths =
-				new HashMap<ObjectIDResolvedWS, Set<ObjectPaths>>();
+		final Map<ObjectIDResolvedWS, Set<SubsetSelection>> paths =
+				new HashMap<ObjectIDResolvedWS, Set<SubsetSelection>>();
 		for (final ObjectIdentifier o: objs.keySet()) {
 			final ObjectIDResolvedWS roi = objs.get(o);
 			if (!paths.containsKey(roi)) {
-				paths.put(roi, new HashSet<ObjectPaths>());
+				paths.put(roi, new HashSet<SubsetSelection>());
 			}
 			if (o instanceof ObjIDWithChainAndSubset) {
-				paths.get(roi).add(((ObjIDWithChainAndSubset) o).getPaths());
+				paths.get(roi).add(((ObjIDWithChainAndSubset) o).getSubSet());
 			} else {
-				paths.get(roi).add(ObjectPaths.EMPTY);
+				paths.get(roi).add(SubsetSelection.EMPTY);
 			}
 		}
 		return paths;

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -983,8 +983,8 @@ public class Workspace {
 					new ArrayList<WorkspaceObjectData>();
 			for (final ObjectIdentifier o: loi) {
 				final SubsetSelection p;
-				if (o instanceof ObjIDWithChainAndSubset) {
-					p = ((ObjIDWithChainAndSubset) o).getSubSet();
+				if (o instanceof ObjIDWithRefPathAndSubset) {
+					p = ((ObjIDWithRefPathAndSubset) o).getSubSet();
 				} else {
 					p = SubsetSelection.EMPTY;
 				}
@@ -1074,8 +1074,8 @@ public class Workspace {
 			if (!paths.containsKey(roi)) {
 				paths.put(roi, new HashSet<SubsetSelection>());
 			}
-			if (o instanceof ObjIDWithChainAndSubset) {
-				paths.get(roi).add(((ObjIDWithChainAndSubset) o).getSubSet());
+			if (o instanceof ObjIDWithRefPathAndSubset) {
+				paths.get(roi).add(((ObjIDWithRefPathAndSubset) o).getSubSet());
 			} else {
 				paths.get(roi).add(SubsetSelection.EMPTY);
 			}

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -1085,7 +1085,7 @@ public class Workspace {
 	
 	private Map<ObjectIdentifier, ObjectIDResolvedWS> resolveReferenceChains(
 			final WorkspaceUser user,
-			final List<ObjectIDWithRefChain> refchains,
+			final List<ObjectIDWithRefPath> refchains,
 			final Map<ObjectIdentifier, ObjectIDResolvedWS> heads,
 			final boolean ignoreErrors)
 			throws WorkspaceCommunicationException,
@@ -1100,7 +1100,7 @@ public class Workspace {
 		
 		final List<ObjectIdentifier> chains =
 				new LinkedList<ObjectIdentifier>();
-		for (final ObjectIDWithRefChain oc: refchains) {
+		for (final ObjectIDWithRefPath oc: refchains) {
 			if (oc != null) {
 				/* allow nulls in list to maintain object count in the case
 				 * calling method input includes objectIDs with and without
@@ -1125,7 +1125,7 @@ public class Workspace {
 		final Map<ObjectIdentifier, ObjectIDResolvedWS> resolvedChains =
 				new HashMap<ObjectIdentifier, ObjectIDResolvedWS>();
 		int chnum = 1;
-		for (final ObjectIDWithRefChain chain: refchains) {
+		for (final ObjectIDWithRefPath chain: refchains) {
 			if (chain != null) {
 				final ObjectReferenceSet refs = headrefs.get(heads.get(chain));
 				if (refs != null && isValidRefChain(chain, refs, reschains,
@@ -1139,7 +1139,7 @@ public class Workspace {
 	}
 	
 	private boolean isValidRefChain(
-			final ObjectIDWithRefChain chain,
+			final ObjectIDWithRefPath chain,
 			final ObjectReferenceSet headref,
 			final Map<ObjectIdentifier, ObjectIDResolvedWS> reschains,
 			final Map<ObjectIDResolvedWS, ObjectReferenceSet> chainrefs,
@@ -1438,8 +1438,8 @@ public class Workspace {
 						nullIfInaccessible, nullIfInaccessible,
 						nullIfInaccessible);
 		
-		final List<ObjectIDWithRefChain> chains =
-				new LinkedList<ObjectIDWithRefChain>();
+		final List<ObjectIDWithRefPath> chains =
+				new LinkedList<ObjectIDWithRefPath>();
 		final Map<ObjectIdentifier, ObjectIDResolvedWS> heads =
 				new HashMap<ObjectIdentifier, ObjectIDResolvedWS>();
 		final Map<ObjectIdentifier, ObjectIDResolvedWS> std =
@@ -1448,9 +1448,9 @@ public class Workspace {
 			if (ws.get(o) == null) {
 				continue;
 			}
-			if (o instanceof ObjectIDWithRefChain && 
-					((ObjectIDWithRefChain) o).hasChain()) {
-				chains.add((ObjectIDWithRefChain) o);
+			if (o instanceof ObjectIDWithRefPath && 
+					((ObjectIDWithRefPath) o).hasChain()) {
+				chains.add((ObjectIDWithRefPath) o);
 				heads.put(o, ws.get(o));
 			} else {
 				chains.add(null); // maintain count for error reporting

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -1449,7 +1449,7 @@ public class Workspace {
 				continue;
 			}
 			if (o instanceof ObjectIDWithRefPath && 
-					((ObjectIDWithRefPath) o).hasChain()) {
+					((ObjectIDWithRefPath) o).hasRefPath()) {
 				chains.add((ObjectIDWithRefPath) o);
 				heads.put(o, ws.get(o));
 			} else {

--- a/src/us/kbase/workspace/database/WorkspaceDatabase.java
+++ b/src/us/kbase/workspace/database/WorkspaceDatabase.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import us.kbase.typedobj.core.ObjectPaths;
+import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.exceptions.TypedObjectExtractionException;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
@@ -232,9 +232,9 @@ public interface WorkspaceDatabase {
 	 * @throws TypedObjectExtractionException if the subdata could not be
 	 * extracted.
 	 */
-	public Map<ObjectIDResolvedWS, Map<ObjectPaths, WorkspaceObjectData>>
+	public Map<ObjectIDResolvedWS, Map<SubsetSelection, WorkspaceObjectData>>
 			getObjects(
-					Map<ObjectIDResolvedWS, Set<ObjectPaths>> objects,
+					Map<ObjectIDResolvedWS, Set<SubsetSelection>> objects,
 					ByteArrayFileCacheManager dataManager,
 					long usedDataAllocation,
 					boolean exceptIfDeleted,

--- a/src/us/kbase/workspace/kbase/IdentifierUtils.java
+++ b/src/us/kbase/workspace/kbase/IdentifierUtils.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 
-import us.kbase.typedobj.core.ObjectPaths;
+import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.workspace.ObjectIdentity;
 import us.kbase.workspace.ObjectSpecification;
 import us.kbase.workspace.WorkspaceIdentity;
@@ -177,11 +177,11 @@ public class IdentifierUtils {
 						+ objcount + ": " + e.getLocalizedMessage(), e);
 			}
 					
-			ObjectPaths paths = new ObjectPaths(soi.getIncluded(),
+			SubsetSelection paths = new SubsetSelection(soi.getIncluded(),
 					longToBoolean(soi.getStrictMaps(),
-							ObjectPaths.STRICT_MAPS_DEFAULT),
+							SubsetSelection.STRICT_MAPS_DEFAULT),
 					longToBoolean(soi.getStrictArrays(),
-							ObjectPaths.STRICT_ARRAYS_DEFAULT));
+							SubsetSelection.STRICT_ARRAYS_DEFAULT));
 			objs.add(new ObjIDWithChainAndSubset(oi, null, paths));
 			objcount++;
 		}
@@ -231,13 +231,13 @@ public class IdentifierUtils {
 		return objs;
 	}
 
-	private static ObjectPaths getObjectPaths(final ObjectSpecification o) {
+	private static SubsetSelection getObjectPaths(final ObjectSpecification o) {
 		if (o.getIncluded() != null && !o.getIncluded().isEmpty()) {
-			return new ObjectPaths(o.getIncluded(),
+			return new SubsetSelection(o.getIncluded(),
 					longToBoolean(o.getStrictMaps(),
-							ObjectPaths.STRICT_MAPS_DEFAULT),
+							SubsetSelection.STRICT_MAPS_DEFAULT),
 					longToBoolean(o.getStrictArrays(),
-							ObjectPaths.STRICT_ARRAYS_DEFAULT));
+							SubsetSelection.STRICT_ARRAYS_DEFAULT));
 		}
 		return null;
 	}
@@ -246,7 +246,7 @@ public class IdentifierUtils {
 			final ObjectSpecification o,
 			ObjectIdentifier oi,
 			final int objcount) {
-		final ObjectPaths paths = getObjectPaths(o);
+		final SubsetSelection paths = getObjectPaths(o);
 		final List<ObjectIdentifier> refchain;
 		try {
 			final RefChainResult res = processRefChains(o);

--- a/src/us/kbase/workspace/kbase/IdentifierUtils.java
+++ b/src/us/kbase/workspace/kbase/IdentifierUtils.java
@@ -16,7 +16,7 @@ import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.workspace.ObjectIdentity;
 import us.kbase.workspace.ObjectSpecification;
 import us.kbase.workspace.WorkspaceIdentity;
-import us.kbase.workspace.database.ObjIDWithChainAndSubset;
+import us.kbase.workspace.database.ObjIDWithRefPathAndSubset;
 import us.kbase.workspace.database.ObjectIDWithRefPath;
 import us.kbase.workspace.database.ObjectIdentifier;
 import us.kbase.workspace.database.WorkspaceIdentifier;
@@ -182,7 +182,7 @@ public class IdentifierUtils {
 							SubsetSelection.STRICT_MAPS_DEFAULT),
 					longToBoolean(soi.getStrictArrays(),
 							SubsetSelection.STRICT_ARRAYS_DEFAULT));
-			objs.add(new ObjIDWithChainAndSubset(oi, null, paths));
+			objs.add(new ObjIDWithRefPathAndSubset(oi, null, paths));
 			objcount++;
 		}
 		return objs;
@@ -272,7 +272,7 @@ public class IdentifierUtils {
 		} else if (paths == null) {
 			return new ObjectIDWithRefPath(oi, refchain);
 		} else {
-			return new ObjIDWithChainAndSubset(oi, refchain, paths);
+			return new ObjIDWithRefPathAndSubset(oi, refchain, paths);
 		}
 	}
 

--- a/src/us/kbase/workspace/kbase/IdentifierUtils.java
+++ b/src/us/kbase/workspace/kbase/IdentifierUtils.java
@@ -17,15 +17,13 @@ import us.kbase.workspace.ObjectIdentity;
 import us.kbase.workspace.ObjectSpecification;
 import us.kbase.workspace.WorkspaceIdentity;
 import us.kbase.workspace.database.ObjIDWithChainAndSubset;
-import us.kbase.workspace.database.ObjectIDWithRefChain;
+import us.kbase.workspace.database.ObjectIDWithRefPath;
 import us.kbase.workspace.database.ObjectIdentifier;
 import us.kbase.workspace.database.WorkspaceIdentifier;
 
 public class IdentifierUtils {
 	
-	//TODO TEST unit tests
 	//TODO JAVADOC
-	//TODO NOW rename to IdentifierUtils
 	
 	private static final Pattern KB_WS_ID = Pattern.compile("kb\\|ws\\.(\\d+)");
 	private static final Pattern KB_OBJ_ID = Pattern.compile(
@@ -272,7 +270,7 @@ public class IdentifierUtils {
 		if (paths == null && refchain == null) {
 			return oi;
 		} else if (paths == null) {
-			return new ObjectIDWithRefChain(oi, refchain);
+			return new ObjectIDWithRefPath(oi, refchain);
 		} else {
 			return new ObjIDWithChainAndSubset(oi, refchain, paths);
 		}

--- a/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
@@ -35,7 +35,7 @@ import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.common.utils.sortjson.UTF8JsonSorterFactory;
 import us.kbase.typedobj.core.AbsoluteTypeDefId;
 import us.kbase.typedobj.core.LocalTypeProvider;
-import us.kbase.typedobj.core.ObjectPaths;
+import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.typedobj.core.TypeDefName;
@@ -292,7 +292,7 @@ public class MongoInternalsTest {
 		
 		// test get subset
 		final ObjIDWithChainAndSubset os = new ObjIDWithChainAndSubset(
-				clnobj, null, new ObjectPaths(Arrays.asList("/foo")));
+				clnobj, null, new SubsetSelection(Arrays.asList("/foo")));
 		WorkspaceTester.failGetSubset(ws, user1, Arrays.asList(os), noObjExcp);
 		
 		//test get ws desc
@@ -858,8 +858,8 @@ public class MongoInternalsTest {
 			Set<ObjectIDResolvedWS> oidsetver, String msg)
 			throws WorkspaceCommunicationException,
 			CorruptWorkspaceDBException, TypedObjectExtractionException {
-		final Map<ObjectIDResolvedWS, Set<ObjectPaths>> paths =
-				new HashMap<ObjectIDResolvedWS, Set<ObjectPaths>>();
+		final Map<ObjectIDResolvedWS, Set<SubsetSelection>> paths =
+				new HashMap<ObjectIDResolvedWS, Set<SubsetSelection>>();
 		for (final ObjectIDResolvedWS o: oidsetver) {
 			paths.put(o, null);
 		}

--- a/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
@@ -53,7 +53,7 @@ import us.kbase.workspace.database.ListObjectsParameters;
 import us.kbase.workspace.database.ObjIDWithChainAndSubset;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIDResolvedWS;
-import us.kbase.workspace.database.ObjectIDWithRefChain;
+import us.kbase.workspace.database.ObjectIDWithRefPath;
 import us.kbase.workspace.database.ObjectIdentifier;
 import us.kbase.workspace.database.ObjectInformation;
 import us.kbase.workspace.database.Permission;
@@ -285,7 +285,7 @@ public class MongoInternalsTest {
 				noWSExcp);
 		
 		// test get referenced objects
-		final ObjectIDWithRefChain oc = new ObjectIDWithRefChain(
+		final ObjectIDWithRefPath oc = new ObjectIDWithRefPath(
 				clnobj, Arrays.asList(stdobj));
 		WorkspaceTester.failGetReferencedObjects(ws, user1, Arrays.asList(oc),
 				noObjExcp, false, new HashSet<>(Arrays.asList(0)));

--- a/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
@@ -50,7 +50,7 @@ import us.kbase.typedobj.test.DummyValidatedTypedObject;
 import us.kbase.workspace.database.ByteArrayFileCacheManager;
 import us.kbase.workspace.database.DefaultReferenceParser;
 import us.kbase.workspace.database.ListObjectsParameters;
-import us.kbase.workspace.database.ObjIDWithChainAndSubset;
+import us.kbase.workspace.database.ObjIDWithRefPathAndSubset;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIDResolvedWS;
 import us.kbase.workspace.database.ObjectIDWithRefPath;
@@ -291,7 +291,7 @@ public class MongoInternalsTest {
 				noObjExcp, false, new HashSet<>(Arrays.asList(0)));
 		
 		// test get subset
-		final ObjIDWithChainAndSubset os = new ObjIDWithChainAndSubset(
+		final ObjIDWithRefPathAndSubset os = new ObjIDWithRefPathAndSubset(
 				clnobj, null, new SubsetSelection(Arrays.asList("/foo")));
 		WorkspaceTester.failGetSubset(ws, user1, Arrays.asList(os), noObjExcp);
 		

--- a/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
+++ b/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
@@ -15,7 +15,7 @@ import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.workspace.ObjectIdentity;
 import us.kbase.workspace.ObjectSpecification;
 import us.kbase.workspace.WorkspaceIdentity;
-import us.kbase.workspace.database.ObjIDWithChainAndSubset;
+import us.kbase.workspace.database.ObjIDWithRefPathAndSubset;
 import us.kbase.workspace.database.ObjectIDWithRefPath;
 import us.kbase.workspace.database.ObjectIdentifier;
 import us.kbase.workspace.database.WorkspaceIdentifier;
@@ -491,7 +491,7 @@ public class IdentifierUtilsTest {
 		final ObjectIdentifier oi = ret.get(0);
 		assertThat("incorrect class", oi instanceof ObjectIDWithRefPath,
 				is(false));
-		assertThat("incorrect class", oi instanceof ObjIDWithChainAndSubset,
+		assertThat("incorrect class", oi instanceof ObjIDWithRefPathAndSubset,
 				is(false));
 		
 		checkObjectIdentifier(oi, wsname, wsid, name, id, ver, refstring,
@@ -719,7 +719,7 @@ public class IdentifierUtilsTest {
 		final ObjectIdentifier oi = ret.get(0);
 		assertThat("incorrect class", oi instanceof ObjectIDWithRefPath,
 				is(true));
-		assertThat("incorrect class", oi instanceof ObjIDWithChainAndSubset,
+		assertThat("incorrect class", oi instanceof ObjIDWithRefPathAndSubset,
 				is(false));
 		
 		checkObjectIdentifier(oi, "foo", null, "bar", null, null, "foo/bar",
@@ -748,7 +748,7 @@ public class IdentifierUtilsTest {
 		final ObjectIdentifier oi = ret.get(0);
 		assertThat("incorrect class", oi instanceof ObjectIDWithRefPath,
 				is(true));
-		assertThat("incorrect class", oi instanceof ObjIDWithChainAndSubset,
+		assertThat("incorrect class", oi instanceof ObjIDWithRefPathAndSubset,
 				is(false));
 		
 		checkObjectIdentifier(oi, "foo", null, "bar", null, null, "foo/bar",
@@ -773,8 +773,8 @@ public class IdentifierUtilsTest {
 		final List<ObjectIdentifier> ret = IdentifierUtils
 				.processObjectSpecifications(oss);
 		assertThat("incorrect return size", ret.size(), is(1));
-		final ObjIDWithChainAndSubset oi =
-				(ObjIDWithChainAndSubset) ret.get(0);
+		final ObjIDWithRefPathAndSubset oi =
+				(ObjIDWithRefPathAndSubset) ret.get(0);
 		
 		checkObjectIdentifier(oi, "foo", null, "bar", null, null, "foo/bar",
 				"bar", false);
@@ -807,8 +807,8 @@ public class IdentifierUtilsTest {
 		final List<ObjectIdentifier> ret = IdentifierUtils
 				.processObjectSpecifications(oss);
 		assertThat("incorrect return size", ret.size(), is(1));
-		final ObjIDWithChainAndSubset oi =
-				(ObjIDWithChainAndSubset) ret.get(0);
+		final ObjIDWithRefPathAndSubset oi =
+				(ObjIDWithRefPathAndSubset) ret.get(0);
 		
 		checkObjectIdentifier(oi, "foo", null, "bar", null, null, "foo/bar",
 				"bar", false);
@@ -836,8 +836,8 @@ public class IdentifierUtilsTest {
 		final List<ObjectIdentifier> ret = IdentifierUtils
 				.processObjectSpecifications(oss);
 		assertThat("incorrect return size", ret.size(), is(1));
-		final ObjIDWithChainAndSubset oi =
-				(ObjIDWithChainAndSubset) ret.get(0);
+		final ObjIDWithRefPathAndSubset oi =
+				(ObjIDWithRefPathAndSubset) ret.get(0);
 		
 		checkObjectIdentifier(oi, "foo", null, "bar", null, null, "foo/bar",
 				"bar", false);
@@ -870,8 +870,8 @@ public class IdentifierUtilsTest {
 		final List<ObjectIdentifier> ret = IdentifierUtils
 				.processObjectSpecifications(oss);
 		assertThat("incorrect return size", ret.size(), is(1));
-		final ObjIDWithChainAndSubset oi =
-				(ObjIDWithChainAndSubset) ret.get(0);
+		final ObjIDWithRefPathAndSubset oi =
+				(ObjIDWithRefPathAndSubset) ret.get(0);
 		
 		checkObjectIdentifier(oi, null, 3L, null, 2L, null, "3/2", "2", false);
 		
@@ -911,7 +911,7 @@ public class IdentifierUtilsTest {
 		final ObjectIdentifier oi = ret.get(0);
 		assertThat("incorrect class", oi instanceof ObjectIDWithRefPath,
 				is(true));
-		assertThat("incorrect class", oi instanceof ObjIDWithChainAndSubset,
+		assertThat("incorrect class", oi instanceof ObjIDWithRefPathAndSubset,
 				is(false));
 		
 		checkObjectIdentifier(oi, "whoo", null, "whee", null, null,
@@ -939,7 +939,7 @@ public class IdentifierUtilsTest {
 		final ObjectIdentifier oi = ret.get(0);
 		assertThat("incorrect class", oi instanceof ObjectIDWithRefPath,
 				is(true));
-		assertThat("incorrect class", oi instanceof ObjIDWithChainAndSubset,
+		assertThat("incorrect class", oi instanceof ObjIDWithRefPathAndSubset,
 				is(false));
 		
 		checkObjectIdentifier(oi, null, 3L, null, 4L, 1L,
@@ -966,7 +966,7 @@ public class IdentifierUtilsTest {
 		final ObjectIdentifier oi = ret.get(0);
 		assertThat("incorrect class", oi instanceof ObjectIDWithRefPath,
 				is(true));
-		assertThat("incorrect class", oi instanceof ObjIDWithChainAndSubset,
+		assertThat("incorrect class", oi instanceof ObjIDWithRefPathAndSubset,
 				is(false));
 		
 		checkObjectIdentifier(oi, "bar", null, null, 2L, null,

--- a/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
+++ b/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 import org.junit.Test;
 
 import us.kbase.common.test.TestCommon;
-import us.kbase.typedobj.core.ObjectPaths;
+import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.workspace.ObjectIdentity;
 import us.kbase.workspace.ObjectSpecification;
 import us.kbase.workspace.WorkspaceIdentity;
@@ -781,7 +781,7 @@ public class IdentifierUtilsTest {
 		assertThat("incorrect hasChain()", oi.hasChain(), is(false));
 		assertThat("has ref chain", oi.getRefPath(), is((List<ObjectIdentifier>)
 				new LinkedList<ObjectIdentifier>()));
-		final ObjectPaths op = oi.getPaths();
+		final SubsetSelection op = oi.getSubSet();
 		final List<String> paths = new LinkedList<>();
 		for (final String p: op) {
 			paths.add(p);
@@ -815,7 +815,7 @@ public class IdentifierUtilsTest {
 		assertThat("incorrect hasChain()", oi.hasChain(), is(false));
 		assertThat("has ref chain", oi.getRefPath(), is((List<ObjectIdentifier>)
 				new LinkedList<ObjectIdentifier>()));
-		final ObjectPaths op = oi.getPaths();
+		final SubsetSelection op = oi.getSubSet();
 		final List<String> paths = new LinkedList<>();
 		for (final String p: op) {
 			paths.add(p);
@@ -844,7 +844,7 @@ public class IdentifierUtilsTest {
 		assertThat("incorrect hasChain()", oi.hasChain(), is(false));
 		assertThat("has ref chain", oi.getRefPath(), is((List<ObjectIdentifier>)
 				new LinkedList<ObjectIdentifier>()));
-		final ObjectPaths op = oi.getPaths();
+		final SubsetSelection op = oi.getSubSet();
 		final List<String> paths = new LinkedList<>();
 		for (final String p: op) {
 			paths.add(p);
@@ -876,7 +876,7 @@ public class IdentifierUtilsTest {
 		checkObjectIdentifier(oi, null, 3L, null, 2L, null, "3/2", "2", false);
 		
 		assertThat("incorrect hasChain()", oi.hasChain(), is(true));
-		final ObjectPaths op = oi.getPaths();
+		final SubsetSelection op = oi.getSubSet();
 		final List<String> paths = new LinkedList<>();
 		for (final String p: op) {
 			paths.add(p);

--- a/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
+++ b/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
@@ -727,7 +727,7 @@ public class IdentifierUtilsTest {
 		
 		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
 		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
-		final List<ObjectIdentifier> chain = oirc.getChain();
+		final List<ObjectIdentifier> chain = oirc.getRefPath();
 		assertThat("incorrect chain size", chain.size(), is(2));
 		
 		checkObjectIdentifier(chain.get(0), "baz", null, "bat", null, null,
@@ -756,7 +756,7 @@ public class IdentifierUtilsTest {
 		
 		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
 		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
-		final List<ObjectIdentifier> chain = oirc.getChain();
+		final List<ObjectIdentifier> chain = oirc.getRefPath();
 		assertThat("incorrect chain size", chain.size(), is(2));
 		
 		checkObjectIdentifier(chain.get(0), "baz", null, "bat", null, null,
@@ -779,7 +779,7 @@ public class IdentifierUtilsTest {
 		checkObjectIdentifier(oi, "foo", null, "bar", null, null, "foo/bar",
 				"bar", false);
 		assertThat("incorrect hasChain()", oi.hasChain(), is(false));
-		assertThat("has ref chain", oi.getChain(), is((List<ObjectIdentifier>)
+		assertThat("has ref chain", oi.getRefPath(), is((List<ObjectIdentifier>)
 				new LinkedList<ObjectIdentifier>()));
 		final ObjectPaths op = oi.getPaths();
 		final List<String> paths = new LinkedList<>();
@@ -813,7 +813,7 @@ public class IdentifierUtilsTest {
 		checkObjectIdentifier(oi, "foo", null, "bar", null, null, "foo/bar",
 				"bar", false);
 		assertThat("incorrect hasChain()", oi.hasChain(), is(false));
-		assertThat("has ref chain", oi.getChain(), is((List<ObjectIdentifier>)
+		assertThat("has ref chain", oi.getRefPath(), is((List<ObjectIdentifier>)
 				new LinkedList<ObjectIdentifier>()));
 		final ObjectPaths op = oi.getPaths();
 		final List<String> paths = new LinkedList<>();
@@ -842,7 +842,7 @@ public class IdentifierUtilsTest {
 		checkObjectIdentifier(oi, "foo", null, "bar", null, null, "foo/bar",
 				"bar", false);
 		assertThat("incorrect hasChain()", oi.hasChain(), is(false));
-		assertThat("has ref chain", oi.getChain(), is((List<ObjectIdentifier>)
+		assertThat("has ref chain", oi.getRefPath(), is((List<ObjectIdentifier>)
 				new LinkedList<ObjectIdentifier>()));
 		final ObjectPaths op = oi.getPaths();
 		final List<String> paths = new LinkedList<>();
@@ -887,7 +887,7 @@ public class IdentifierUtilsTest {
 		assertThat("incorrect strict arrays", op.isStrictArrays(), is(true));
 		
 		assertThat("incorrect hasChain()", oi.hasChain(), is(true));
-		final List<ObjectIdentifier> chain = oi.getChain();
+		final List<ObjectIdentifier> chain = oi.getRefPath();
 		assertThat("incorrect chain size", chain.size(), is(1));
 		
 		checkObjectIdentifier(chain.get(0), "whoo", null, "whee", null, null,
@@ -919,7 +919,7 @@ public class IdentifierUtilsTest {
 		
 		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
 		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
-		final List<ObjectIdentifier> chain = oirc.getChain();
+		final List<ObjectIdentifier> chain = oirc.getRefPath();
 		assertThat("incorrect chain size", chain.size(), is(1));
 		
 		checkObjectIdentifier(chain.get(0), null, 3L, null, 2L, null, "3/2",
@@ -947,7 +947,7 @@ public class IdentifierUtilsTest {
 		
 		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
 		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
-		final List<ObjectIdentifier> chain = oirc.getChain();
+		final List<ObjectIdentifier> chain = oirc.getRefPath();
 		assertThat("incorrect chain size", chain.size(), is(1));
 		
 		checkObjectIdentifier(chain.get(0), "bar", null, null, 2L, null,
@@ -974,7 +974,7 @@ public class IdentifierUtilsTest {
 		
 		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
 		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
-		final List<ObjectIdentifier> chain = oirc.getChain();
+		final List<ObjectIdentifier> chain = oirc.getRefPath();
 		assertThat("incorrect chain size", chain.size(), is(3));
 		
 		checkObjectIdentifier(chain.get(0), null, 5L, null, 6L, 7L,

--- a/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
+++ b/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
@@ -726,7 +726,7 @@ public class IdentifierUtilsTest {
 				"bar", false);
 		
 		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
-		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
+		assertThat("incorrect hasChain()", oirc.hasRefPath(), is(true));
 		final List<ObjectIdentifier> chain = oirc.getRefPath();
 		assertThat("incorrect chain size", chain.size(), is(2));
 		
@@ -755,7 +755,7 @@ public class IdentifierUtilsTest {
 				"bar", false);
 		
 		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
-		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
+		assertThat("incorrect hasChain()", oirc.hasRefPath(), is(true));
 		final List<ObjectIdentifier> chain = oirc.getRefPath();
 		assertThat("incorrect chain size", chain.size(), is(2));
 		
@@ -778,7 +778,7 @@ public class IdentifierUtilsTest {
 		
 		checkObjectIdentifier(oi, "foo", null, "bar", null, null, "foo/bar",
 				"bar", false);
-		assertThat("incorrect hasChain()", oi.hasChain(), is(false));
+		assertThat("incorrect hasChain()", oi.hasRefPath(), is(false));
 		assertThat("has ref chain", oi.getRefPath(), is((List<ObjectIdentifier>)
 				new LinkedList<ObjectIdentifier>()));
 		final SubsetSelection op = oi.getSubSet();
@@ -812,7 +812,7 @@ public class IdentifierUtilsTest {
 		
 		checkObjectIdentifier(oi, "foo", null, "bar", null, null, "foo/bar",
 				"bar", false);
-		assertThat("incorrect hasChain()", oi.hasChain(), is(false));
+		assertThat("incorrect hasChain()", oi.hasRefPath(), is(false));
 		assertThat("has ref chain", oi.getRefPath(), is((List<ObjectIdentifier>)
 				new LinkedList<ObjectIdentifier>()));
 		final SubsetSelection op = oi.getSubSet();
@@ -841,7 +841,7 @@ public class IdentifierUtilsTest {
 		
 		checkObjectIdentifier(oi, "foo", null, "bar", null, null, "foo/bar",
 				"bar", false);
-		assertThat("incorrect hasChain()", oi.hasChain(), is(false));
+		assertThat("incorrect hasChain()", oi.hasRefPath(), is(false));
 		assertThat("has ref chain", oi.getRefPath(), is((List<ObjectIdentifier>)
 				new LinkedList<ObjectIdentifier>()));
 		final SubsetSelection op = oi.getSubSet();
@@ -875,7 +875,7 @@ public class IdentifierUtilsTest {
 		
 		checkObjectIdentifier(oi, null, 3L, null, 2L, null, "3/2", "2", false);
 		
-		assertThat("incorrect hasChain()", oi.hasChain(), is(true));
+		assertThat("incorrect hasChain()", oi.hasRefPath(), is(true));
 		final SubsetSelection op = oi.getSubSet();
 		final List<String> paths = new LinkedList<>();
 		for (final String p: op) {
@@ -886,7 +886,7 @@ public class IdentifierUtilsTest {
 		assertThat("incorrect strict maps", op.isStrictMaps(), is(false));
 		assertThat("incorrect strict arrays", op.isStrictArrays(), is(true));
 		
-		assertThat("incorrect hasChain()", oi.hasChain(), is(true));
+		assertThat("incorrect hasChain()", oi.hasRefPath(), is(true));
 		final List<ObjectIdentifier> chain = oi.getRefPath();
 		assertThat("incorrect chain size", chain.size(), is(1));
 		
@@ -918,7 +918,7 @@ public class IdentifierUtilsTest {
 				"whoo/whee", "whee", false);
 		
 		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
-		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
+		assertThat("incorrect hasChain()", oirc.hasRefPath(), is(true));
 		final List<ObjectIdentifier> chain = oirc.getRefPath();
 		assertThat("incorrect chain size", chain.size(), is(1));
 		
@@ -946,7 +946,7 @@ public class IdentifierUtilsTest {
 				"3/4/1", "4", true);
 		
 		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
-		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
+		assertThat("incorrect hasChain()", oirc.hasRefPath(), is(true));
 		final List<ObjectIdentifier> chain = oirc.getRefPath();
 		assertThat("incorrect chain size", chain.size(), is(1));
 		
@@ -973,7 +973,7 @@ public class IdentifierUtilsTest {
 				"bar/2", "2", false);
 		
 		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
-		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
+		assertThat("incorrect hasChain()", oirc.hasRefPath(), is(true));
 		final List<ObjectIdentifier> chain = oirc.getRefPath();
 		assertThat("incorrect chain size", chain.size(), is(3));
 		

--- a/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
+++ b/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
@@ -16,7 +16,7 @@ import us.kbase.workspace.ObjectIdentity;
 import us.kbase.workspace.ObjectSpecification;
 import us.kbase.workspace.WorkspaceIdentity;
 import us.kbase.workspace.database.ObjIDWithChainAndSubset;
-import us.kbase.workspace.database.ObjectIDWithRefChain;
+import us.kbase.workspace.database.ObjectIDWithRefPath;
 import us.kbase.workspace.database.ObjectIdentifier;
 import us.kbase.workspace.database.WorkspaceIdentifier;
 import us.kbase.workspace.kbase.IdentifierUtils;
@@ -489,7 +489,7 @@ public class IdentifierUtilsTest {
 				.processObjectSpecifications(oss);
 		assertThat("incorrect return size", ret.size(), is(1));
 		final ObjectIdentifier oi = ret.get(0);
-		assertThat("incorrect class", oi instanceof ObjectIDWithRefChain,
+		assertThat("incorrect class", oi instanceof ObjectIDWithRefPath,
 				is(false));
 		assertThat("incorrect class", oi instanceof ObjIDWithChainAndSubset,
 				is(false));
@@ -717,7 +717,7 @@ public class IdentifierUtilsTest {
 				.processObjectSpecifications(oss);
 		assertThat("incorrect return size", ret.size(), is(1));
 		final ObjectIdentifier oi = ret.get(0);
-		assertThat("incorrect class", oi instanceof ObjectIDWithRefChain,
+		assertThat("incorrect class", oi instanceof ObjectIDWithRefPath,
 				is(true));
 		assertThat("incorrect class", oi instanceof ObjIDWithChainAndSubset,
 				is(false));
@@ -725,7 +725,7 @@ public class IdentifierUtilsTest {
 		checkObjectIdentifier(oi, "foo", null, "bar", null, null, "foo/bar",
 				"bar", false);
 		
-		final ObjectIDWithRefChain oirc = (ObjectIDWithRefChain) oi;
+		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
 		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
 		final List<ObjectIdentifier> chain = oirc.getChain();
 		assertThat("incorrect chain size", chain.size(), is(2));
@@ -746,7 +746,7 @@ public class IdentifierUtilsTest {
 				.processObjectSpecifications(oss);
 		assertThat("incorrect return size", ret.size(), is(1));
 		final ObjectIdentifier oi = ret.get(0);
-		assertThat("incorrect class", oi instanceof ObjectIDWithRefChain,
+		assertThat("incorrect class", oi instanceof ObjectIDWithRefPath,
 				is(true));
 		assertThat("incorrect class", oi instanceof ObjIDWithChainAndSubset,
 				is(false));
@@ -754,7 +754,7 @@ public class IdentifierUtilsTest {
 		checkObjectIdentifier(oi, "foo", null, "bar", null, null, "foo/bar",
 				"bar", false);
 		
-		final ObjectIDWithRefChain oirc = (ObjectIDWithRefChain) oi;
+		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
 		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
 		final List<ObjectIdentifier> chain = oirc.getChain();
 		assertThat("incorrect chain size", chain.size(), is(2));
@@ -909,7 +909,7 @@ public class IdentifierUtilsTest {
 		assertThat("incorrect return size", ret.size(), is(1));
 
 		final ObjectIdentifier oi = ret.get(0);
-		assertThat("incorrect class", oi instanceof ObjectIDWithRefChain,
+		assertThat("incorrect class", oi instanceof ObjectIDWithRefPath,
 				is(true));
 		assertThat("incorrect class", oi instanceof ObjIDWithChainAndSubset,
 				is(false));
@@ -917,7 +917,7 @@ public class IdentifierUtilsTest {
 		checkObjectIdentifier(oi, "whoo", null, "whee", null, null,
 				"whoo/whee", "whee", false);
 		
-		final ObjectIDWithRefChain oirc = (ObjectIDWithRefChain) oi;
+		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
 		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
 		final List<ObjectIdentifier> chain = oirc.getChain();
 		assertThat("incorrect chain size", chain.size(), is(1));
@@ -937,7 +937,7 @@ public class IdentifierUtilsTest {
 		assertThat("incorrect return size", ret.size(), is(1));
 
 		final ObjectIdentifier oi = ret.get(0);
-		assertThat("incorrect class", oi instanceof ObjectIDWithRefChain,
+		assertThat("incorrect class", oi instanceof ObjectIDWithRefPath,
 				is(true));
 		assertThat("incorrect class", oi instanceof ObjIDWithChainAndSubset,
 				is(false));
@@ -945,7 +945,7 @@ public class IdentifierUtilsTest {
 		checkObjectIdentifier(oi, null, 3L, null, 4L, 1L,
 				"3/4/1", "4", true);
 		
-		final ObjectIDWithRefChain oirc = (ObjectIDWithRefChain) oi;
+		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
 		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
 		final List<ObjectIdentifier> chain = oirc.getChain();
 		assertThat("incorrect chain size", chain.size(), is(1));
@@ -964,7 +964,7 @@ public class IdentifierUtilsTest {
 		assertThat("incorrect return size", ret.size(), is(1));
 
 		final ObjectIdentifier oi = ret.get(0);
-		assertThat("incorrect class", oi instanceof ObjectIDWithRefChain,
+		assertThat("incorrect class", oi instanceof ObjectIDWithRefPath,
 				is(true));
 		assertThat("incorrect class", oi instanceof ObjIDWithChainAndSubset,
 				is(false));
@@ -972,7 +972,7 @@ public class IdentifierUtilsTest {
 		checkObjectIdentifier(oi, "bar", null, null, 2L, null,
 				"bar/2", "2", false);
 		
-		final ObjectIDWithRefChain oirc = (ObjectIDWithRefChain) oi;
+		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
 		assertThat("incorrect hasChain()", oirc.hasChain(), is(true));
 		final List<ObjectIdentifier> chain = oirc.getChain();
 		assertThat("incorrect chain size", chain.size(), is(3));

--- a/src/us/kbase/workspace/test/workspace/WorkspaceLongTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceLongTest.java
@@ -28,7 +28,7 @@ import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.typedobj.core.TypeDefName;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
-import us.kbase.workspace.database.ObjIDWithChainAndSubset;
+import us.kbase.workspace.database.ObjIDWithRefPathAndSubset;
 import us.kbase.workspace.database.ObjectIdentifier;
 import us.kbase.workspace.database.ObjectInformation;
 import us.kbase.workspace.database.Provenance;
@@ -392,7 +392,7 @@ public class WorkspaceLongTest extends WorkspaceTester {
 				included.add("data/" + contigId + "/" + rnd.nextInt(featureCount));
 			long time2 = System.currentTimeMillis();
 			List<ObjectIdentifier> a = new LinkedList<ObjectIdentifier>();
-			a.add(new ObjIDWithChainAndSubset(
+			a.add(new ObjIDWithRefPathAndSubset(
 					new ObjectIdentifier(wspace, oi.getObjectId()), null,
 						new SubsetSelection(included)));
 			WorkspaceObjectData wod2 = ws.getObjects(userfoo, a).get(0);

--- a/src/us/kbase/workspace/test/workspace/WorkspaceLongTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceLongTest.java
@@ -24,7 +24,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import us.kbase.common.service.UObject;
-import us.kbase.typedobj.core.ObjectPaths;
+import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.typedobj.core.TypeDefName;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
@@ -394,7 +394,7 @@ public class WorkspaceLongTest extends WorkspaceTester {
 			List<ObjectIdentifier> a = new LinkedList<ObjectIdentifier>();
 			a.add(new ObjIDWithChainAndSubset(
 					new ObjectIdentifier(wspace, oi.getObjectId()), null,
-						new ObjectPaths(included)));
+						new SubsetSelection(included)));
 			WorkspaceObjectData wod2 = ws.getObjects(userfoo, a).get(0);
 			String data2 = UObject.getMapper().writeValueAsString(wod2.getData());
 			time2 = System.currentTimeMillis() - time2;

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import us.kbase.common.service.JsonTokenStream;
 import us.kbase.common.test.TestCommon;
 import us.kbase.typedobj.core.AbsoluteTypeDefId;
-import us.kbase.typedobj.core.ObjectPaths;
+import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.typedobj.core.TempFileListener;
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.typedobj.core.TypeDefName;
@@ -5681,13 +5681,13 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		List<WorkspaceObjectData> got = ws.getObjects(user, 
 				new LinkedList<ObjectIdentifier>(Arrays.asList(
-				new ObjIDWithChainAndSubset(oident1, null, new ObjectPaths(
+				new ObjIDWithChainAndSubset(oident1, null, new SubsetSelection(
 						Arrays.asList("/map/id3", "/map/id1"))),
-				new ObjIDWithChainAndSubset(oident1, null, new ObjectPaths(
+				new ObjIDWithChainAndSubset(oident1, null, new SubsetSelection(
 						Arrays.asList("/map/id2"))),
-				new ObjIDWithChainAndSubset(oident2, null, new ObjectPaths(
+				new ObjIDWithChainAndSubset(oident2, null, new SubsetSelection(
 						Arrays.asList("/array/2", "/array/0"))),
-				new ObjIDWithChainAndSubset(oident3, null, new ObjectPaths(
+				new ObjIDWithChainAndSubset(oident3, null, new SubsetSelection(
 						Arrays.asList("/array/2", "/array/0", "/array/3"))))));
 		Map<String, Object> expdata1 = createData(
 				"{\"map\": {\"id1\": {\"id\": 1," +
@@ -5731,15 +5731,15 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		// new test for extractor that fails on an array OOB
 		failGetSubset(user, Arrays.asList(
-				new ObjIDWithChainAndSubset(oident2, null, new ObjectPaths(
+				new ObjIDWithChainAndSubset(oident2, null, new SubsetSelection(
 						Arrays.asList("/array/3", "/array/0")))),
 				new TypedObjectExtractionException(
 						"Invalid selection: no array element exists at position '3', at: /array/3"));
 		
 		got = ws.getObjects(user, new ArrayList<ObjectIdentifier>(Arrays.asList(
-				new ObjIDWithChainAndSubset(oident1, null, new ObjectPaths(
+				new ObjIDWithChainAndSubset(oident1, null, new SubsetSelection(
 						Arrays.asList("/map/*/thing"))),
-				new ObjIDWithChainAndSubset(oident2, null, new ObjectPaths(
+				new ObjIDWithChainAndSubset(oident2, null, new SubsetSelection(
 						Arrays.asList("/array/[*]/thing"))))));
 		expdata1 = createData(
 				"{\"map\": {\"id1\": {\"thing\": \"foo\"}," +
@@ -5764,13 +5764,13 @@ public class WorkspaceTest extends WorkspaceTester {
 		}
 		
 		failGetSubset(user, Arrays.asList(
-				new ObjIDWithChainAndSubset(oident1, null, new ObjectPaths(
+				new ObjIDWithChainAndSubset(oident1, null, new SubsetSelection(
 						Arrays.asList("/map/id1/id/5")))),
 				new TypedObjectExtractionException(
 						"Invalid selection: the path given specifies fields or elements that do not exist "
 						+ "because data at this location is a scalar value (i.e. string, integer, float), at: /map/id1/id"));
 		failGetSubset(user2, Arrays.asList(
-				new ObjIDWithChainAndSubset(oident1, null, new ObjectPaths(
+				new ObjIDWithChainAndSubset(oident1, null, new SubsetSelection(
 						Arrays.asList("/map/*/thing")))),
 				new InaccessibleObjectException(
 						"Object o1 cannot be accessed: User subUser2 may not read workspace subData"));
@@ -6252,17 +6252,17 @@ public class WorkspaceTest extends WorkspaceTester {
 				(ObjectIdentifier) new ObjectIDWithRefPath(
 						simplerefoi, Arrays.asList(leaf1oi)),
 				(ObjectIdentifier) new ObjIDWithChainAndSubset(leaf2oi, null,
-						new ObjectPaths(Arrays.asList("/map/id22"))),
+						new SubsetSelection(Arrays.asList("/map/id22"))),
 				(ObjectIdentifier) new ObjIDWithChainAndSubset(leaf2oi, null,
-						new ObjectPaths(Arrays.asList("/map"))),
+						new SubsetSelection(Arrays.asList("/map"))),
 				(ObjectIdentifier) new ObjIDWithChainAndSubset(simplerefoi, null,
-						new ObjectPaths(Arrays.asList("/map/id23"))),
+						new SubsetSelection(Arrays.asList("/map/id23"))),
 				(ObjectIdentifier) new ObjIDWithChainAndSubset(simplerefoi,
 						Arrays.asList(leaf1oi),
-						new ObjectPaths(Arrays.asList("/map/id1"))),
+						new SubsetSelection(Arrays.asList("/map/id1"))),
 				(ObjectIdentifier) new ObjIDWithChainAndSubset(simplerefoi,
 						Arrays.asList(leaf1oi),
-						new ObjectPaths(Arrays.asList("/map/id3")))
+						new SubsetSelection(Arrays.asList("/map/id3")))
 				));
 		List<String> mtlist = new LinkedList<String>();
 		Map<String, String> mtmap = new HashMap<String, String>();
@@ -6855,10 +6855,10 @@ public class WorkspaceTest extends WorkspaceTester {
 			ws.setResourceConfig(build.withMaxReturnedDataSize(20).build());
 			List<ObjectIdentifier> ois1l = new LinkedList<ObjectIdentifier>(
 					Arrays.asList(new ObjIDWithChainAndSubset(oi1, null,
-					new ObjectPaths(Arrays.asList("/fo")))));
+					new SubsetSelection(Arrays.asList("/fo")))));
 			List<ObjectIdentifier> ois1lmt = new LinkedList<ObjectIdentifier>(
 					Arrays.asList(new ObjIDWithChainAndSubset(oi1, null,
-					new ObjectPaths(new ArrayList<String>()))));
+					new SubsetSelection(new ArrayList<String>()))));
 			successGetObjects(user, oi1l);
 			destroyGetObjectsResources(ws.getObjects(user, ois1l));
 			destroyGetObjectsResources(ws.getObjects(user, ois1lmt));
@@ -6883,11 +6883,11 @@ public class WorkspaceTest extends WorkspaceTester {
 			List<ObjectIdentifier> mixed = Arrays.asList(oi1,
 					new ObjectIDWithRefPath(ref2, oi2l));
 			List<ObjIDWithChainAndSubset> ois1l2 = Arrays.asList(
-					new ObjIDWithChainAndSubset(oi1, null, new ObjectPaths(Arrays.asList("/fo"))),
-					new ObjIDWithChainAndSubset(oi1, null, new ObjectPaths(Arrays.asList("/ba"))));
+					new ObjIDWithChainAndSubset(oi1, null, new SubsetSelection(Arrays.asList("/fo"))),
+					new ObjIDWithChainAndSubset(oi1, null, new SubsetSelection(Arrays.asList("/ba"))));
 			List<ObjIDWithChainAndSubset> bothoi = Arrays.asList(
-					new ObjIDWithChainAndSubset(oi1, null, new ObjectPaths(Arrays.asList("/fo"))),
-					new ObjIDWithChainAndSubset(oi2, null, new ObjectPaths(Arrays.asList("/ba"))));
+					new ObjIDWithChainAndSubset(oi1, null, new SubsetSelection(Arrays.asList("/fo"))),
+					new ObjIDWithChainAndSubset(oi2, null, new SubsetSelection(Arrays.asList("/ba"))));
 			successGetObjects(user, two);
 			successGetObjects(user, mixed);
 			destroyGetObjectsResources(ws.getObjects(user,
@@ -6963,7 +6963,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		assertThat("created no temp files on get", filesCreated[0], is(0));
 		ws.getObjects(user, new ArrayList<ObjectIdentifier>(Arrays.asList(
 				new ObjIDWithChainAndSubset(oi1, null,
-				new ObjectPaths(Arrays.asList("z")))))).get(0).getSerializedData().destroy();
+				new SubsetSelection(Arrays.asList("z")))))).get(0).getSerializedData().destroy();
 		assertThat("created 1 temp file on get subdata", filesCreated[0], is(1));
 		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());
 		
@@ -6984,14 +6984,14 @@ public class WorkspaceTest extends WorkspaceTester {
 		filesCreated[0] = 0;
 		ws.getObjects(user, new ArrayList<ObjectIdentifier>(Arrays.asList(
 				new ObjIDWithChainAndSubset(oi2, null,
-				new ObjectPaths(Arrays.asList("z")))))).get(0).getSerializedData().destroy();
+				new SubsetSelection(Arrays.asList("z")))))).get(0).getSerializedData().destroy();
 		assertThat("created 1 temp files on get subdata part object", filesCreated[0], is(1));
 		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());
 		
 		filesCreated[0] = 0;
 		ws.getObjects(user, new ArrayList<ObjectIdentifier>(Arrays.asList(
 				new ObjIDWithChainAndSubset(oi2, null,
-				new ObjectPaths(Arrays.asList("z", "y")))))).get(0).getSerializedData().destroy();
+				new SubsetSelection(Arrays.asList("z", "y")))))).get(0).getSerializedData().destroy();
 		assertThat("created 2 temp files on get subdata full object", filesCreated[0], is(2));
 		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());
 		

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -55,7 +55,7 @@ import us.kbase.workspace.database.ModuleInfo;
 import us.kbase.workspace.database.ObjIDWithChainAndSubset;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIDResolvedWS;
-import us.kbase.workspace.database.ObjectIDWithRefChain;
+import us.kbase.workspace.database.ObjectIDWithRefPath;
 import us.kbase.workspace.database.ObjectIdentifier;
 import us.kbase.workspace.database.ObjectInformation;
 import us.kbase.workspace.database.Permission;
@@ -3635,17 +3635,17 @@ public class WorkspaceTest extends WorkspaceTester {
 		ref.put("refs", Arrays.asList(wsiCopied.getName() + "/foo"));
 		data.add(new WorkspaceSaveObject(ref, REF_TYPE, null, emptyprov2, false));
 		ws.saveObjects(user2, wsiCopied, data, new IdReferenceHandlerSetFactory(1));
-		ObjectIDWithRefChain copyoc1 = new ObjectIDWithRefChain(new ObjectIdentifier(wsiCopied, 4L),
+		ObjectIDWithRefPath copyoc1 = new ObjectIDWithRefPath(new ObjectIdentifier(wsiCopied, 4L),
 				Arrays.asList(copied1));
 		
 		ref.put("refs", Arrays.asList(wsiCopied.getName() + "/foo1"));
 		ws.saveObjects(user2, wsiCopied, data, new IdReferenceHandlerSetFactory(1));
-		ObjectIDWithRefChain copyoc2 = new ObjectIDWithRefChain(new ObjectIdentifier(wsiCopied, 5L),
+		ObjectIDWithRefPath copyoc2 = new ObjectIDWithRefPath(new ObjectIdentifier(wsiCopied, 5L),
 				Arrays.asList(copied2));
 		
 		ref.put("refs", Arrays.asList(wsiCopied.getName() + "/3"));
 		ws.saveObjects(user2, wsiCopied, data, new IdReferenceHandlerSetFactory(1));
-		ObjectIDWithRefChain nocopyoc = new ObjectIDWithRefChain(new ObjectIdentifier(wsiCopied, 6L),
+		ObjectIDWithRefPath nocopyoc = new ObjectIDWithRefPath(new ObjectIdentifier(wsiCopied, 6L),
 				Arrays.asList(nocopy));
 		
 		
@@ -6249,7 +6249,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		List<WorkspaceObjectData> lwod = ws.getObjects(user1, Arrays.asList(
 				leaf2oi,
 				simplerefoi,
-				(ObjectIdentifier) new ObjectIDWithRefChain(
+				(ObjectIdentifier) new ObjectIDWithRefPath(
 						simplerefoi, Arrays.asList(leaf1oi)),
 				(ObjectIdentifier) new ObjIDWithChainAndSubset(leaf2oi, null,
 						new ObjectPaths(Arrays.asList("/map/id22"))),
@@ -6283,7 +6283,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		lwod = ws.getObjects(user1, Arrays.asList(
 				leaf2oi,
 				simplerefoi,
-				(ObjectIdentifier) new ObjectIDWithRefChain(
+				(ObjectIdentifier) new ObjectIDWithRefPath(
 						simplerefoi, Arrays.asList(leaf1oi))
 				), true);
 		try {
@@ -6298,9 +6298,9 @@ public class WorkspaceTest extends WorkspaceTester {
 				Arrays.asList(
 						leaf2oi,
 						simplerefoi,
-						(ObjectIdentifier) new ObjectIDWithRefChain(
+						(ObjectIdentifier) new ObjectIDWithRefPath(
 								simplerefoi, Arrays.asList(leaf1oi)),
-						(ObjectIdentifier) new ObjectIDWithRefChain(
+						(ObjectIdentifier) new ObjectIDWithRefPath(
 								simplerefoi, null)
 				), true, false);
 		assertThat("object info different", loi,
@@ -6408,34 +6408,34 @@ public class WorkspaceTest extends WorkspaceTester {
 		// check one hop reference dive works
 		final HashMap<String, String> mtmap = new HashMap<String, String>();
 		final LinkedList<String> mtlist = new LinkedList<String>();
-		checkReferencedObject(user1, new ObjectIDWithRefChain(new ObjectIdentifier(wsiacc1, "simpleref", 1),
+		checkReferencedObject(user1, new ObjectIDWithRefPath(new ObjectIdentifier(wsiacc1, "simpleref", 1),
 				Arrays.asList(leaf1oi1)), leaf1_1, new Provenance(user2), data1, mtlist, mtmap);
-		checkReferencedObject(user1, new ObjectIDWithRefChain(new ObjectIdentifier(wsiacc1n, "simpleref", 2),
+		checkReferencedObject(user1, new ObjectIDWithRefPath(new ObjectIdentifier(wsiacc1n, "simpleref", 2),
 				Arrays.asList(leaf1oi2)), leaf1_2, new Provenance(user2), data1, mtlist, mtmap);
-		checkReferencedObject(user1, new ObjectIDWithRefChain(new ObjectIdentifier(wsiacc1, 1),
+		checkReferencedObject(user1, new ObjectIDWithRefPath(new ObjectIdentifier(wsiacc1, 1),
 				Arrays.asList(leaf1oi2)), leaf1_2, new Provenance(user2), data1, mtlist, mtmap);
-		checkReferencedObject(user1, new ObjectIDWithRefChain(new ObjectIdentifier(wsiacc2, "simpleref2"),
+		checkReferencedObject(user1, new ObjectIDWithRefPath(new ObjectIdentifier(wsiacc2, "simpleref2"),
 				Arrays.asList(leaf2oi)), leaf2, new Provenance(user2), data2, mtlist, mtmap);
-		checkReferencedObject(user1, new ObjectIDWithRefChain(new ObjectIdentifier(wsiacc1, "provref"),
+		checkReferencedObject(user1, new ObjectIDWithRefPath(new ObjectIdentifier(wsiacc1, "provref"),
 				Arrays.asList(leaf1oi1)), leaf1_1, new Provenance(user2), data1, mtlist, mtmap);
-		checkReferencedObject(user1, new ObjectIDWithRefChain(new ObjectIdentifier(wsiacc2, "provref2"),
+		checkReferencedObject(user1, new ObjectIDWithRefPath(new ObjectIdentifier(wsiacc2, "provref2"),
 				Arrays.asList(leaf2oi)), leaf2, new Provenance(user2), data2, mtlist, mtmap);
 		
 		//fail on one hop bad reference chains
-		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefChain(new ObjectIdentifier(wsiacc2n, "simpleref2"),
+		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefPath(new ObjectIdentifier(wsiacc2n, "simpleref2"),
 				Arrays.asList(leaf1oi1))), new NoSuchReferenceException(
 				"Reference chain #1, position 1: Object simpleref2 in workspace refedaccessible2 does " +
 				"not contain a reference to object 1 with version 1 in workspace 3", null, null));
 		
-		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefChain(new ObjectIdentifier(wsiacc1, "simpleref"),
+		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefPath(new ObjectIdentifier(wsiacc1, "simpleref"),
 				Arrays.asList(leaf1oi1))), new NoSuchReferenceException(
 				"Reference chain #1, position 1: Object simpleref in workspace 1 does " +
 				"not contain a reference to object 1 with version 1 in workspace 3", null, null));
-		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefChain(new ObjectIdentifier(wsiacc1n, "simpleref", 2),
+		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefPath(new ObjectIdentifier(wsiacc1n, "simpleref", 2),
 				Arrays.asList(leaf1oi1))), new NoSuchReferenceException(
 				"Reference chain #1, position 1: Object simpleref with version 2 in workspace refedaccessible does " +
 				"not contain a reference to object 1 with version 1 in workspace 3", null, null));
-		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefChain(new ObjectIdentifier(wsiacc1n, 1, 1),
+		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefPath(new ObjectIdentifier(wsiacc1n, 1, 1),
 				Arrays.asList(leaf1oi2))), new NoSuchReferenceException(
 				"Reference chain #1, position 1: Object 1 with version 1 in workspace refedaccessible does " +
 				"not contain a reference to object 1 with version 2 in workspace 3", null, null));
@@ -6499,13 +6499,13 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		// test 2 hop reference chains with absolute references
 		List<ObjectIdentifier> a = new LinkedList<ObjectIdentifier>();
-		a.add(new ObjectIDWithRefChain(delptr12oi, Arrays.asList(del1oi, leaf1oi1)));
-		a.add(new ObjectIDWithRefChain(delptr12oi, Arrays.asList(del1oi, leaf2oi)));
-		a.add(new ObjectIDWithRefChain(delptr12oi, Arrays.asList(del2oi, leaf1oi1)));
-		a.add(new ObjectIDWithRefChain(delptrwsoi, Arrays.asList(delwsoi, leaf2oi)));
-		a.add(new ObjectIDWithRefChain(delptr12oi, Arrays.asList(del2oi, leaf2oi)));
-		a.add(new ObjectIDWithRefChain(delptr2oi, Arrays.asList(del2oi, leaf1oi1)));
-		a.add(new ObjectIDWithRefChain(delptr2oi, Arrays.asList(del2oi, leaf2oi)));
+		a.add(new ObjectIDWithRefPath(delptr12oi, Arrays.asList(del1oi, leaf1oi1)));
+		a.add(new ObjectIDWithRefPath(delptr12oi, Arrays.asList(del1oi, leaf2oi)));
+		a.add(new ObjectIDWithRefPath(delptr12oi, Arrays.asList(del2oi, leaf1oi1)));
+		a.add(new ObjectIDWithRefPath(delptrwsoi, Arrays.asList(delwsoi, leaf2oi)));
+		a.add(new ObjectIDWithRefPath(delptr12oi, Arrays.asList(del2oi, leaf2oi)));
+		a.add(new ObjectIDWithRefPath(delptr2oi, Arrays.asList(del2oi, leaf1oi1)));
+		a.add(new ObjectIDWithRefPath(delptr2oi, Arrays.asList(del2oi, leaf2oi)));
 		List<WorkspaceObjectData> lwod = ws.getObjects(user1, a);
 		try {
 			assertThat("correct list size", lwod.size(), is(7));
@@ -6523,13 +6523,13 @@ public class WorkspaceTest extends WorkspaceTester {
 		assertThat("object info not same", loi, is(Arrays.asList(
 				leaf1_1, leaf2, leaf1_1, leaf2, leaf2, leaf1_1, leaf2)));
 		
-		checkReferencedObject(user1, new ObjectIDWithRefChain(delptr12oi, Arrays.asList(del1oi)),
+		checkReferencedObject(user1, new ObjectIDWithRefPath(delptr12oi, Arrays.asList(del1oi)),
 				del1, new Provenance(user2), makeRefData(wsidun1 + "/1/1", wsidun2 + "/1/1"),
 				Arrays.asList(wsidun1 + "/1/1", wsidun2 + "/1/1"),  mtmap);
 		Map<String, String> provmap = new HashMap<String, String>();
 		provmap.put(leaf1r1, wsidun1 + "/1/1");
 		provmap.put(leaf2r, wsidun2 + "/1/1");
-		checkReferencedObject(user1, new ObjectIDWithRefChain(delptr12oi, Arrays.asList(del2oi)),
+		checkReferencedObject(user1, new ObjectIDWithRefPath(delptr12oi, Arrays.asList(del2oi)),
 				del2, p, makeRefData(), mtlist, provmap);
 		
 		// test 2 hop reference chains with temporary references
@@ -6537,9 +6537,9 @@ public class WorkspaceTest extends WorkspaceTester {
 		ObjectIdentifier leaf2tempID = new ObjectIdentifier(wsiun2, "leaf2", 1);
 		ObjectIdentifier leaf2nover = new ObjectIdentifier(wsiun2, 1);
 		a.clear();
-		a.add(new ObjectIDWithRefChain(delptr12oi, Arrays.asList(del1oi, leaf2tempWS)));
-		a.add(new ObjectIDWithRefChain(delptr12oi, Arrays.asList(del1oi, leaf2tempID)));
-		a.add(new ObjectIDWithRefChain(delptr12oi, Arrays.asList(del2oi, leaf2nover)));
+		a.add(new ObjectIDWithRefPath(delptr12oi, Arrays.asList(del1oi, leaf2tempWS)));
+		a.add(new ObjectIDWithRefPath(delptr12oi, Arrays.asList(del1oi, leaf2tempID)));
+		a.add(new ObjectIDWithRefPath(delptr12oi, Arrays.asList(del2oi, leaf2nover)));
 		lwod = ws.getObjects(user1, a);
 		try {
 			compareObjectAndInfo(lwod.get(0), leaf2, new Provenance(user2), data2, mtlist, mtmap);
@@ -6554,32 +6554,32 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		
 		// fail on 2 hop chains with absolute references
-		ObjectIDWithRefChain goodchain = new ObjectIDWithRefChain(delptr12oi, Arrays.asList(
+		ObjectIDWithRefPath goodchain = new ObjectIDWithRefPath(delptr12oi, Arrays.asList(
 				del1oi, leaf1oi1));
 		
 		failGetReferencedObjects(user1, Arrays.asList(
-				new ObjectIDWithRefChain(new ObjectIdentifier(wsiacc2n, "delptr2"),
+				new ObjectIDWithRefPath(new ObjectIdentifier(wsiacc2n, "delptr2"),
 				Arrays.asList(del1oi, leaf1oi1))), new NoSuchReferenceException(
 				"Reference chain #1, position 1: Object delptr2 in workspace refedaccessible2 does not " +
 				"contain a reference to object 2 with version 1 in workspace 3",
 				null, null));
-		failGetReferencedObjects(user1, Arrays.asList(goodchain, goodchain, new ObjectIDWithRefChain(delptr12oi,
+		failGetReferencedObjects(user1, Arrays.asList(goodchain, goodchain, new ObjectIDWithRefPath(delptr12oi,
 				Arrays.asList(del1oi, unlinkedoi))), new NoSuchReferenceException(
 				"Reference chain #3, position 2: Object 2 with version 1 in workspace 3 does not contain a " +
 				"reference to object 2 with version 1 in workspace 4",
 				null, null), Sets.newHashSet(2));
-		failGetReferencedObjects(user1, Arrays.asList(goodchain, new ObjectIDWithRefChain(delptr12oi,
+		failGetReferencedObjects(user1, Arrays.asList(goodchain, new ObjectIDWithRefPath(delptr12oi,
 				Arrays.asList(del1oi, new ObjectIdentifier(wsiun2, 3, 1))), goodchain),
 				new NoSuchReferenceException(
 				"Reference chain #2, position 2: Object 2 with version 1 in workspace 3 does not contain a " +
 				"reference to object 3 with version 1 in workspace 4",
 				null, null), Sets.newHashSet(1));
-		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefChain(delptr12oi,
+		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefPath(delptr12oi,
 				Arrays.asList(del2oi, new ObjectIdentifier(wsiun1, 1, 3)))),
 				new NoSuchReferenceException(
 				"Reference chain #1, position 2: Object 3 with version 1 in workspace 4 does not contain a " +
 				"reference to object 1 with version 3 in workspace 3", null, null));
-		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefChain(delptr12oi,
+		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefPath(delptr12oi,
 				Arrays.asList(del2oi, new ObjectIdentifier(new WorkspaceIdentifier(6), 1, 3)))),
 				new NoSuchReferenceException(
 				"Reference chain #1, position 2: Object 3 with version 1 in workspace 4 does not contain a " +
@@ -6589,48 +6589,48 @@ public class WorkspaceTest extends WorkspaceTester {
 		ObjectIdentifier leaf1badTempWs = new ObjectIdentifier(new WorkspaceIdentifier("foo"), 1, 1);
 		ObjectIdentifier leaf1badTempID = new ObjectIdentifier(wsiun1, "leaf2", 1);
 		ObjectIdentifier leaf1nover = new ObjectIdentifier(wsiun1, 1);
-		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefChain(delptr12oi,
+		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefPath(delptr12oi,
 				Arrays.asList(del1oi, leaf1badTempWs))),
 				new NoSuchReferenceException(
 				"Reference chain #1, position 2: Object 2 with version 1 in workspace 3 does not contain a " +
 				"reference to object 1 with version 1 in workspace foo", null, null));
-		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefChain(delptr12oi,
+		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefPath(delptr12oi,
 				Arrays.asList(del2oi, leaf1badTempID))),
 				new NoSuchReferenceException(
 				"Reference chain #1, position 2: Object 3 with version 1 in workspace 4 does not contain a " +
 				"reference to object leaf2 with version 1 in workspace 3", null, null));
-		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefChain(delptr12oi,
+		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefPath(delptr12oi,
 				Arrays.asList(del2oi, leaf1nover))),
 				new NoSuchReferenceException(
 				"Reference chain #1, position 2: Object 3 with version 1 in workspace 4 does not contain a " +
 				"reference to object 1 in workspace 3", null, null));
 		
 		// test various ways the root object could be inaccessible
-		failGetReferencedObjects(user2, new ArrayList<ObjectIDWithRefChain>(),
+		failGetReferencedObjects(user2, new ArrayList<ObjectIDWithRefPath>(),
 				new IllegalArgumentException("No object identifiers provided"));
-		failGetReferencedObjects(user2, Arrays.asList(new ObjectIDWithRefChain(new ObjectIdentifier(wsiun1, "leaf3"),
+		failGetReferencedObjects(user2, Arrays.asList(new ObjectIDWithRefPath(new ObjectIdentifier(wsiun1, "leaf3"),
 				Arrays.asList(new ObjectIdentifier(wsiun1, 1, 1)))),
 				new InaccessibleObjectException("Object leaf3 does not exist in workspace 3"));
-		failGetReferencedObjects(user2, Arrays.asList(new ObjectIDWithRefChain(new ObjectIdentifier(wsiun1, "leaf1", 3),
+		failGetReferencedObjects(user2, Arrays.asList(new ObjectIDWithRefPath(new ObjectIdentifier(wsiun1, "leaf1", 3),
 				Arrays.asList(new ObjectIdentifier(wsiun1, 1, 1)))),
 				new InaccessibleObjectException("Object leaf1 with version 3 does not exist in workspace 3"));
-		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefChain(new ObjectIdentifier(new WorkspaceIdentifier("fakefakefake"), "leaf1"),
+		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefPath(new ObjectIdentifier(new WorkspaceIdentifier("fakefakefake"), "leaf1"),
 				Arrays.asList(new ObjectIdentifier(wsiun1, 1, 1)))),
 				new InaccessibleObjectException("Object leaf1 cannot be accessed: No workspace with name fakefakefake exists"));
-		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefChain(new ObjectIdentifier(wsiun1n, "leaf1"),
+		failGetReferencedObjects(user1, Arrays.asList(new ObjectIDWithRefPath(new ObjectIdentifier(wsiun1n, "leaf1"),
 				Arrays.asList(new ObjectIdentifier(wsiun1, 1, 1)))),
 				new InaccessibleObjectException("Object leaf1 cannot be accessed: User refedUser may not read workspace refedunacc"));
-		failGetReferencedObjects(null, Arrays.asList(new ObjectIDWithRefChain(new ObjectIdentifier(wsiun1, "leaf1"),
+		failGetReferencedObjects(null, Arrays.asList(new ObjectIDWithRefPath(new ObjectIdentifier(wsiun1, "leaf1"),
 				Arrays.asList(new ObjectIdentifier(wsiun1, 1, 1)))),
 				new InaccessibleObjectException("Object leaf1 cannot be accessed: Anonymous users may not read workspace 3"));
 		ws.setObjectsDeleted(user2, Arrays.asList(new ObjectIdentifier(wsiun1, "leaf1")), true);
-		failGetReferencedObjects(user2, Arrays.asList(new ObjectIDWithRefChain(new ObjectIdentifier(wsiun1n, "leaf1"),
+		failGetReferencedObjects(user2, Arrays.asList(new ObjectIDWithRefPath(new ObjectIdentifier(wsiun1n, "leaf1"),
 				Arrays.asList(new ObjectIdentifier(wsiun1, 1, 1)))),
 				new InaccessibleObjectException(
 						"Object leaf1 in workspace refedunacc has been deleted"));
 		ws.setObjectsDeleted(user2, Arrays.asList(new ObjectIdentifier(wsiun1, "leaf1")), false);
 		ws.setWorkspaceDeleted(user2, wsiun1, true);
-		failGetReferencedObjects(user2, Arrays.asList(new ObjectIDWithRefChain(new ObjectIdentifier(wsiun1n, "leaf1"),
+		failGetReferencedObjects(user2, Arrays.asList(new ObjectIDWithRefPath(new ObjectIdentifier(wsiun1n, "leaf1"),
 				Arrays.asList(new ObjectIdentifier(wsiun1, 1, 1)))),
 				new InaccessibleObjectException("Object leaf1 cannot be accessed: Workspace refedunacc is deleted"));
 	}
@@ -6840,10 +6840,10 @@ public class WorkspaceTest extends WorkspaceTester {
 		ObjectIdentifier ref = new ObjectIdentifier(wsi, "ref", 1);
 		ObjectIdentifier ref2 = new ObjectIdentifier(wsi, "ref2", 1);
 		List<ObjectIdentifier> refchain = new LinkedList<ObjectIdentifier>(
-				Arrays.asList(new ObjectIDWithRefChain(ref, oi1l)));
-		List<ObjectIDWithRefChain> refchain2 = 
-				Arrays.asList(new ObjectIDWithRefChain(ref, oi1l),
-				new ObjectIDWithRefChain(ref2, oi2l));
+				Arrays.asList(new ObjectIDWithRefPath(ref, oi1l)));
+		List<ObjectIDWithRefPath> refchain2 = 
+				Arrays.asList(new ObjectIDWithRefPath(ref, oi1l),
+				new ObjectIDWithRefPath(ref2, oi2l));
 		TestCommon.assertNoTempFilesExist(tfm);
 		
 		ResourceUsageConfiguration oldcfg = ws.getResourceConfig();
@@ -6875,13 +6875,13 @@ public class WorkspaceTest extends WorkspaceTester {
 			failGetSubset(user, (List<ObjIDWithChainAndSubset>)(List<?>) ois1lmt, err);
 			TestCommon.assertNoTempFilesExist(tfm);
 			failGetReferencedObjects(user,
-					(List<ObjectIDWithRefChain>)(List<?>) refchain, err, true);
+					(List<ObjectIDWithRefPath>)(List<?>) refchain, err, true);
 			TestCommon.assertNoTempFilesExist(tfm);
 			
 			ws.setResourceConfig(build.withMaxReturnedDataSize(40).build());
 			List<ObjectIdentifier> two = Arrays.asList(oi1, oi2);
 			List<ObjectIdentifier> mixed = Arrays.asList(oi1,
-					new ObjectIDWithRefChain(ref2, oi2l));
+					new ObjectIDWithRefPath(ref2, oi2l));
 			List<ObjIDWithChainAndSubset> ois1l2 = Arrays.asList(
 					new ObjIDWithChainAndSubset(oi1, null, new ObjectPaths(Arrays.asList("/fo"))),
 					new ObjIDWithChainAndSubset(oi1, null, new ObjectPaths(Arrays.asList("/ba"))));
@@ -7054,7 +7054,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		saveObject(user, wsi, null, refdata, reftype, "ref", new Provenance(user));
 		ObjectIdentifier ref = new ObjectIdentifier(wsi, "ref", 1);
 		List<ObjectIdentifier> refAndStd = Arrays.asList(oi1,
-				new ObjectIDWithRefChain(ref, Arrays.asList(oi2)));
+				new ObjectIDWithRefPath(ref, Arrays.asList(oi2)));
 
 		// ref obj and std obj in memory
 		filesCreated[0] = 0;

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -52,7 +52,7 @@ import us.kbase.workspace.database.AllUsers;
 import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.workspace.database.ListObjectsParameters;
 import us.kbase.workspace.database.ModuleInfo;
-import us.kbase.workspace.database.ObjIDWithChainAndSubset;
+import us.kbase.workspace.database.ObjIDWithRefPathAndSubset;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIDResolvedWS;
 import us.kbase.workspace.database.ObjectIDWithRefPath;
@@ -5681,13 +5681,13 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		List<WorkspaceObjectData> got = ws.getObjects(user, 
 				new LinkedList<ObjectIdentifier>(Arrays.asList(
-				new ObjIDWithChainAndSubset(oident1, null, new SubsetSelection(
+				new ObjIDWithRefPathAndSubset(oident1, null, new SubsetSelection(
 						Arrays.asList("/map/id3", "/map/id1"))),
-				new ObjIDWithChainAndSubset(oident1, null, new SubsetSelection(
+				new ObjIDWithRefPathAndSubset(oident1, null, new SubsetSelection(
 						Arrays.asList("/map/id2"))),
-				new ObjIDWithChainAndSubset(oident2, null, new SubsetSelection(
+				new ObjIDWithRefPathAndSubset(oident2, null, new SubsetSelection(
 						Arrays.asList("/array/2", "/array/0"))),
-				new ObjIDWithChainAndSubset(oident3, null, new SubsetSelection(
+				new ObjIDWithRefPathAndSubset(oident3, null, new SubsetSelection(
 						Arrays.asList("/array/2", "/array/0", "/array/3"))))));
 		Map<String, Object> expdata1 = createData(
 				"{\"map\": {\"id1\": {\"id\": 1," +
@@ -5731,15 +5731,15 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		// new test for extractor that fails on an array OOB
 		failGetSubset(user, Arrays.asList(
-				new ObjIDWithChainAndSubset(oident2, null, new SubsetSelection(
+				new ObjIDWithRefPathAndSubset(oident2, null, new SubsetSelection(
 						Arrays.asList("/array/3", "/array/0")))),
 				new TypedObjectExtractionException(
 						"Invalid selection: no array element exists at position '3', at: /array/3"));
 		
 		got = ws.getObjects(user, new ArrayList<ObjectIdentifier>(Arrays.asList(
-				new ObjIDWithChainAndSubset(oident1, null, new SubsetSelection(
+				new ObjIDWithRefPathAndSubset(oident1, null, new SubsetSelection(
 						Arrays.asList("/map/*/thing"))),
-				new ObjIDWithChainAndSubset(oident2, null, new SubsetSelection(
+				new ObjIDWithRefPathAndSubset(oident2, null, new SubsetSelection(
 						Arrays.asList("/array/[*]/thing"))))));
 		expdata1 = createData(
 				"{\"map\": {\"id1\": {\"thing\": \"foo\"}," +
@@ -5764,27 +5764,27 @@ public class WorkspaceTest extends WorkspaceTester {
 		}
 		
 		failGetSubset(user, Arrays.asList(
-				new ObjIDWithChainAndSubset(oident1, null, new SubsetSelection(
+				new ObjIDWithRefPathAndSubset(oident1, null, new SubsetSelection(
 						Arrays.asList("/map/id1/id/5")))),
 				new TypedObjectExtractionException(
 						"Invalid selection: the path given specifies fields or elements that do not exist "
 						+ "because data at this location is a scalar value (i.e. string, integer, float), at: /map/id1/id"));
 		failGetSubset(user2, Arrays.asList(
-				new ObjIDWithChainAndSubset(oident1, null, new SubsetSelection(
+				new ObjIDWithRefPathAndSubset(oident1, null, new SubsetSelection(
 						Arrays.asList("/map/*/thing")))),
 				new InaccessibleObjectException(
 						"Object o1 cannot be accessed: User subUser2 may not read workspace subData"));
 		
 		try {
 			ws.getObjects(user2, new LinkedList<ObjectIdentifier>(
-					Arrays.asList(new ObjIDWithChainAndSubset(
+					Arrays.asList(new ObjIDWithRefPathAndSubset(
 					new ObjectIdentifier(wsi, 2), null, null))));
 			fail("Able to get obj data from private workspace");
 		} catch (InaccessibleObjectException ioe) {
 			assertThat("correct exception message", ioe.getLocalizedMessage(),
 					is("Object 2 cannot be accessed: User subUser2 may not read workspace subData"));
 			assertThat("correct object returned", ioe.getInaccessibleObject(),
-					is((ObjectIdentifier) new ObjIDWithChainAndSubset(
+					is((ObjectIdentifier) new ObjIDWithRefPathAndSubset(
 							new ObjectIdentifier(wsi, 2), null, null)));
 		}
 	}
@@ -6251,16 +6251,16 @@ public class WorkspaceTest extends WorkspaceTester {
 				simplerefoi,
 				(ObjectIdentifier) new ObjectIDWithRefPath(
 						simplerefoi, Arrays.asList(leaf1oi)),
-				(ObjectIdentifier) new ObjIDWithChainAndSubset(leaf2oi, null,
+				(ObjectIdentifier) new ObjIDWithRefPathAndSubset(leaf2oi, null,
 						new SubsetSelection(Arrays.asList("/map/id22"))),
-				(ObjectIdentifier) new ObjIDWithChainAndSubset(leaf2oi, null,
+				(ObjectIdentifier) new ObjIDWithRefPathAndSubset(leaf2oi, null,
 						new SubsetSelection(Arrays.asList("/map"))),
-				(ObjectIdentifier) new ObjIDWithChainAndSubset(simplerefoi, null,
+				(ObjectIdentifier) new ObjIDWithRefPathAndSubset(simplerefoi, null,
 						new SubsetSelection(Arrays.asList("/map/id23"))),
-				(ObjectIdentifier) new ObjIDWithChainAndSubset(simplerefoi,
+				(ObjectIdentifier) new ObjIDWithRefPathAndSubset(simplerefoi,
 						Arrays.asList(leaf1oi),
 						new SubsetSelection(Arrays.asList("/map/id1"))),
-				(ObjectIdentifier) new ObjIDWithChainAndSubset(simplerefoi,
+				(ObjectIdentifier) new ObjIDWithRefPathAndSubset(simplerefoi,
 						Arrays.asList(leaf1oi),
 						new SubsetSelection(Arrays.asList("/map/id3")))
 				));
@@ -6854,10 +6854,10 @@ public class WorkspaceTest extends WorkspaceTester {
 			
 			ws.setResourceConfig(build.withMaxReturnedDataSize(20).build());
 			List<ObjectIdentifier> ois1l = new LinkedList<ObjectIdentifier>(
-					Arrays.asList(new ObjIDWithChainAndSubset(oi1, null,
+					Arrays.asList(new ObjIDWithRefPathAndSubset(oi1, null,
 					new SubsetSelection(Arrays.asList("/fo")))));
 			List<ObjectIdentifier> ois1lmt = new LinkedList<ObjectIdentifier>(
-					Arrays.asList(new ObjIDWithChainAndSubset(oi1, null,
+					Arrays.asList(new ObjIDWithRefPathAndSubset(oi1, null,
 					new SubsetSelection(new ArrayList<String>()))));
 			successGetObjects(user, oi1l);
 			destroyGetObjectsResources(ws.getObjects(user, ois1l));
@@ -6870,9 +6870,9 @@ public class WorkspaceTest extends WorkspaceTester {
 			IllegalArgumentException err = new IllegalArgumentException(String.format(errstr, 20, 19));
 			failGetObjects(user, oi1l, err, true);
 			TestCommon.assertNoTempFilesExist(tfm);
-			failGetSubset(user, (List<ObjIDWithChainAndSubset>)(List<?>) ois1l, err);
+			failGetSubset(user, (List<ObjIDWithRefPathAndSubset>)(List<?>) ois1l, err);
 			TestCommon.assertNoTempFilesExist(tfm);
-			failGetSubset(user, (List<ObjIDWithChainAndSubset>)(List<?>) ois1lmt, err);
+			failGetSubset(user, (List<ObjIDWithRefPathAndSubset>)(List<?>) ois1lmt, err);
 			TestCommon.assertNoTempFilesExist(tfm);
 			failGetReferencedObjects(user,
 					(List<ObjectIDWithRefPath>)(List<?>) refchain, err, true);
@@ -6882,12 +6882,12 @@ public class WorkspaceTest extends WorkspaceTester {
 			List<ObjectIdentifier> two = Arrays.asList(oi1, oi2);
 			List<ObjectIdentifier> mixed = Arrays.asList(oi1,
 					new ObjectIDWithRefPath(ref2, oi2l));
-			List<ObjIDWithChainAndSubset> ois1l2 = Arrays.asList(
-					new ObjIDWithChainAndSubset(oi1, null, new SubsetSelection(Arrays.asList("/fo"))),
-					new ObjIDWithChainAndSubset(oi1, null, new SubsetSelection(Arrays.asList("/ba"))));
-			List<ObjIDWithChainAndSubset> bothoi = Arrays.asList(
-					new ObjIDWithChainAndSubset(oi1, null, new SubsetSelection(Arrays.asList("/fo"))),
-					new ObjIDWithChainAndSubset(oi2, null, new SubsetSelection(Arrays.asList("/ba"))));
+			List<ObjIDWithRefPathAndSubset> ois1l2 = Arrays.asList(
+					new ObjIDWithRefPathAndSubset(oi1, null, new SubsetSelection(Arrays.asList("/fo"))),
+					new ObjIDWithRefPathAndSubset(oi1, null, new SubsetSelection(Arrays.asList("/ba"))));
+			List<ObjIDWithRefPathAndSubset> bothoi = Arrays.asList(
+					new ObjIDWithRefPathAndSubset(oi1, null, new SubsetSelection(Arrays.asList("/fo"))),
+					new ObjIDWithRefPathAndSubset(oi2, null, new SubsetSelection(Arrays.asList("/ba"))));
 			successGetObjects(user, two);
 			successGetObjects(user, mixed);
 			destroyGetObjectsResources(ws.getObjects(user,
@@ -6917,7 +6917,7 @@ public class WorkspaceTest extends WorkspaceTester {
 			destroyGetObjectsResources(ws.getObjects(user, all));
 			ws.setResourceConfig(build.withMaxReturnedDataSize(59).build());
 			err = new IllegalArgumentException(String.format(errstr, 60, 59));
-			failGetSubset(user, (List<ObjIDWithChainAndSubset>)(List<?>) all, err);
+			failGetSubset(user, (List<ObjIDWithRefPathAndSubset>)(List<?>) all, err);
 			TestCommon.assertNoTempFilesExist(tfm);
 		} finally {
 			ws.setResourceConfig(oldcfg);
@@ -6962,7 +6962,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		ws.getObjects(user, Arrays.asList(oi1));
 		assertThat("created no temp files on get", filesCreated[0], is(0));
 		ws.getObjects(user, new ArrayList<ObjectIdentifier>(Arrays.asList(
-				new ObjIDWithChainAndSubset(oi1, null,
+				new ObjIDWithRefPathAndSubset(oi1, null,
 				new SubsetSelection(Arrays.asList("z")))))).get(0).getSerializedData().destroy();
 		assertThat("created 1 temp file on get subdata", filesCreated[0], is(1));
 		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());
@@ -6983,14 +6983,14 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		filesCreated[0] = 0;
 		ws.getObjects(user, new ArrayList<ObjectIdentifier>(Arrays.asList(
-				new ObjIDWithChainAndSubset(oi2, null,
+				new ObjIDWithRefPathAndSubset(oi2, null,
 				new SubsetSelection(Arrays.asList("z")))))).get(0).getSerializedData().destroy();
 		assertThat("created 1 temp files on get subdata part object", filesCreated[0], is(1));
 		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());
 		
 		filesCreated[0] = 0;
 		ws.getObjects(user, new ArrayList<ObjectIdentifier>(Arrays.asList(
-				new ObjIDWithChainAndSubset(oi2, null,
+				new ObjIDWithRefPathAndSubset(oi2, null,
 				new SubsetSelection(Arrays.asList("z", "y")))))).get(0).getSerializedData().destroy();
 		assertThat("created 2 temp files on get subdata full object", filesCreated[0], is(2));
 		TestCommon.assertNoTempFilesExist(ws.getTempFilesManager());

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -51,7 +51,7 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
 import us.kbase.workspace.database.AllUsers;
 import us.kbase.workspace.database.DefaultReferenceParser;
 import us.kbase.workspace.database.ListObjectsParameters;
-import us.kbase.workspace.database.ObjIDWithChainAndSubset;
+import us.kbase.workspace.database.ObjIDWithRefPathAndSubset;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIDResolvedWS;
 import us.kbase.workspace.database.ObjectIDWithRefPath;
@@ -994,7 +994,7 @@ public class WorkspaceTester {
 	
 	protected void failGetSubset(
 			final WorkspaceUser user,
-			final List<ObjIDWithChainAndSubset> objs,
+			final List<ObjIDWithRefPathAndSubset> objs,
 			final Exception e)
 			throws Exception {
 		failGetSubset(ws, user, objs, e);
@@ -1004,7 +1004,7 @@ public class WorkspaceTester {
 	public static void failGetSubset(
 			final Workspace ws,
 			final WorkspaceUser user,
-			final List<ObjIDWithChainAndSubset> objs,
+			final List<ObjIDWithRefPathAndSubset> objs,
 			final Exception e)
 			throws Exception {
 		try {

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -54,7 +54,7 @@ import us.kbase.workspace.database.ListObjectsParameters;
 import us.kbase.workspace.database.ObjIDWithChainAndSubset;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIDResolvedWS;
-import us.kbase.workspace.database.ObjectIDWithRefChain;
+import us.kbase.workspace.database.ObjectIDWithRefPath;
 import us.kbase.workspace.database.ObjectIdentifier;
 import us.kbase.workspace.database.ObjectInformation;
 import us.kbase.workspace.database.Permission;
@@ -906,7 +906,7 @@ public class WorkspaceTester {
 	
 	protected void failGetReferencedObjects(
 			final WorkspaceUser user,
-			final List<ObjectIDWithRefChain> objs,
+			final List<ObjectIDWithRefPath> objs,
 			final Exception e)
 			throws Exception {
 		
@@ -915,7 +915,7 @@ public class WorkspaceTester {
 	
 	protected void failGetReferencedObjects(
 			final WorkspaceUser user,
-			final List<ObjectIDWithRefChain> objs,
+			final List<ObjectIDWithRefPath> objs,
 			final Exception e,
 			final Set<Integer> nulls)
 			throws Exception {
@@ -925,13 +925,13 @@ public class WorkspaceTester {
 	
 	protected void failGetReferencedObjects(
 			final WorkspaceUser user,
-			final List<ObjectIDWithRefChain> objs,
+			final List<ObjectIDWithRefPath> objs,
 			final Exception e,
 			final boolean onlyTestReturningData)
 			throws Exception {
 		Set<Integer> nulls = new HashSet<Integer>();
 		int count = 0;
-		for (@SuppressWarnings("unused") ObjectIDWithRefChain foo: objs) {
+		for (@SuppressWarnings("unused") ObjectIDWithRefPath foo: objs) {
 			nulls.add(count);
 			count++;
 		}
@@ -940,7 +940,7 @@ public class WorkspaceTester {
 	
 	protected void failGetReferencedObjects(
 			final WorkspaceUser user,
-			final List<ObjectIDWithRefChain> objs,
+			final List<ObjectIDWithRefPath> objs,
 			final Exception e,
 			final boolean onlyTestReturningData,
 			final Set<Integer> nulls)
@@ -952,7 +952,7 @@ public class WorkspaceTester {
 	public static void failGetReferencedObjects(
 			final Workspace ws,
 			final WorkspaceUser user,
-			final List<ObjectIDWithRefChain> objs,
+			final List<ObjectIDWithRefPath> objs,
 			final Exception e,
 			final boolean onlyTestReturningData,
 			final Set<Integer> nulls)
@@ -1867,7 +1867,7 @@ public class WorkspaceTester {
 		assertThat("listed correct objects", g, is(new HashSet<ObjectInformation>(expected)));
 	}
 	
-	protected void checkReferencedObject(WorkspaceUser user, ObjectIDWithRefChain chain,
+	protected void checkReferencedObject(WorkspaceUser user, ObjectIDWithRefPath chain,
 			ObjectInformation oi, Provenance p, Map<String, ? extends Object> data,
 			List<String> refs, Map<String, String> refmap) throws Exception {
 		ObjectInformation info = ws.getObjectInformation(user,
@@ -1885,7 +1885,7 @@ public class WorkspaceTester {
 	protected void failCreateObjectChain(ObjectIdentifier oi, List<ObjectIdentifier> chain,
 			Exception e) {
 		try {
-			new ObjectIDWithRefChain(oi, chain);
+			new ObjectIDWithRefPath(oi, chain);
 			fail("bad args to object chain");
 		} catch (Exception exp) {
 			assertExceptionCorrect(exp, e);


### PR DESCRIPTION
Renamed and cleaned up a number of classes to avoid confusion between the path through the workspace reference graph and the paths into an object for the purposes of subset selection.

Went through getObjects and getObjectInformation and refactored variable names in preparation for what's to come