### PR TITLE
Move reference searching code into package & extract internal classes.

### DIFF
--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -44,9 +44,10 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFa
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
-import us.kbase.workspace.database.SearchReferenceDAG.ReferenceDAGTopologyProvider;
-import us.kbase.workspace.database.SearchReferenceDAG.ReferenceProviderException;
-import us.kbase.workspace.database.SearchReferenceDAG.ReferenceSearchMaximumSizeExceededException;
+import us.kbase.workspace.database.refsearch.SearchReferenceDAG;
+import us.kbase.workspace.database.refsearch.SearchReferenceDAG.ReferenceDAGTopologyProvider;
+import us.kbase.workspace.database.refsearch.SearchReferenceDAG.ReferenceProviderException;
+import us.kbase.workspace.database.refsearch.SearchReferenceDAG.ReferenceSearchMaximumSizeExceededException;
 import us.kbase.workspace.database.exceptions.CorruptWorkspaceDBException;
 import us.kbase.workspace.database.exceptions.InaccessibleObjectException;
 import us.kbase.workspace.database.exceptions.NoSuchObjectException;

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -45,7 +45,7 @@ import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
 import us.kbase.workspace.database.refsearch.SearchReferenceDAG;
-import us.kbase.workspace.database.refsearch.SearchReferenceDAG.ReferenceDAGTopologyProvider;
+import us.kbase.workspace.database.refsearch.ReferenceDAGTopologyProvider;
 import us.kbase.workspace.database.refsearch.SearchReferenceDAG.ReferenceProviderException;
 import us.kbase.workspace.database.refsearch.SearchReferenceDAG.ReferenceSearchMaximumSizeExceededException;
 import us.kbase.workspace.database.exceptions.CorruptWorkspaceDBException;

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -46,8 +46,9 @@ import us.kbase.typedobj.idref.RemappedId;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
 import us.kbase.workspace.database.refsearch.SearchReferenceDAG;
 import us.kbase.workspace.database.refsearch.ReferenceDAGTopologyProvider;
-import us.kbase.workspace.database.refsearch.SearchReferenceDAG.ReferenceProviderException;
-import us.kbase.workspace.database.refsearch.SearchReferenceDAG.ReferenceSearchMaximumSizeExceededException;
+import us.kbase.workspace.database.refsearch.ReferenceProviderException;
+import us.kbase.workspace.database.refsearch.ReferenceSearchFailedException;
+import us.kbase.workspace.database.refsearch.ReferenceSearchMaximumSizeExceededException;
 import us.kbase.workspace.database.exceptions.CorruptWorkspaceDBException;
 import us.kbase.workspace.database.exceptions.InaccessibleObjectException;
 import us.kbase.workspace.database.exceptions.NoSuchObjectException;
@@ -1583,7 +1584,7 @@ public class Workspace {
 			final SearchReferenceDAG search = new SearchReferenceDAG(wsIDs, startingRefs,
 					refProvider, maximumObjectSearchCount, !nullIfInaccessible);
 			return searchObjectDAGBuildResolvedObjectPaths(resobjs, objrefs, search);
-		} catch (final SearchReferenceDAG.ReferenceSearchFailedException |
+		} catch (final ReferenceSearchFailedException |
 				ObjectDAGSearchFromObjectIDFailedException e) {
 			final ObjectIdentifier failedOn = searchObjectDAGGetSearchFailedTarget(
 					e, objrefs, resobjs);
@@ -1645,9 +1646,8 @@ public class Workspace {
 
 		if (e instanceof ObjectDAGSearchFromObjectIDFailedException) {
 			return ((ObjectDAGSearchFromObjectIDFailedException) e).getSearchTarget();
-		} else if (e instanceof SearchReferenceDAG.ReferenceSearchFailedException) {
-			final Reference failedOn = ((SearchReferenceDAG.ReferenceSearchFailedException) e)
-					.getFailedReference();
+		} else if (e instanceof ReferenceSearchFailedException) {
+			final Reference failedOn = ((ReferenceSearchFailedException) e).getFailedReference();
 			for (final Entry<ObjectIdentifier, ObjectIDResolvedWS> es: resobjs.entrySet()) {
 				if (failedOn.equals(objrefs.get(es.getValue()))) {
 					return es.getKey();

--- a/src/us/kbase/workspace/database/refsearch/ReferenceDAGTopologyProvider.java
+++ b/src/us/kbase/workspace/database/refsearch/ReferenceDAGTopologyProvider.java
@@ -5,7 +5,7 @@ import java.util.Set;
 
 import us.kbase.workspace.database.ObjectReferenceSet;
 import us.kbase.workspace.database.Reference;
-import us.kbase.workspace.database.refsearch.SearchReferenceDAG.ReferenceProviderException;
+import us.kbase.workspace.database.refsearch.ReferenceProviderException;
 
 /** Provides information necessary for searching the reference graph about one or more
  * references:

--- a/src/us/kbase/workspace/database/refsearch/ReferenceDAGTopologyProvider.java
+++ b/src/us/kbase/workspace/database/refsearch/ReferenceDAGTopologyProvider.java
@@ -1,0 +1,40 @@
+package us.kbase.workspace.database.refsearch;
+
+import java.util.Map;
+import java.util.Set;
+
+import us.kbase.workspace.database.ObjectReferenceSet;
+import us.kbase.workspace.database.Reference;
+import us.kbase.workspace.database.refsearch.SearchReferenceDAG.ReferenceProviderException;
+
+/** Provides information necessary for searching the reference graph about one or more
+ * references:
+ * - For a set of references, provides the references adjacent (either incoming or outgoing,
+ * but not both) to those references in the reference DAG.
+ * - For a set of references, provides whether the references exist.
+ * @author gaprice@lbl.gov
+ *
+ */
+public interface ReferenceDAGTopologyProvider {
+
+	/** Given a set of references, returns the set of references associated with the target
+	 * references in the graph. The references may be the incoming or outgoing references to
+	 * or from the target references, depending on which way the search should proceed. *Only*
+	 * the incoming or outgoing references should be provided for one search, never a mix of
+	 * both.
+	 * @param sourceRefs the references for which associated references should be found.
+	 * @return a mapping from each source reference to the references that refer to the source
+	 * reference.
+	 */
+	public Map<Reference, ObjectReferenceSet> getAssociatedReferences(
+			Set<Reference> sourceRefs)
+					throws ReferenceProviderException;
+
+	/** Determines whether a reference a) exists and b) is not in the deleted state.
+	 * @param refs the references to check.
+	 * @return a mapping from each reference to a boolean that is true if the reference exists
+	 * and is not in the deleted state.
+	 */
+	public Map<Reference, Boolean> getReferenceExists(Set<Reference> refs)
+			throws ReferenceProviderException;
+}

--- a/src/us/kbase/workspace/database/refsearch/ReferenceProviderException.java
+++ b/src/us/kbase/workspace/database/refsearch/ReferenceProviderException.java
@@ -1,0 +1,17 @@
+package us.kbase.workspace.database.refsearch;
+
+/** An exception thrown when a failure occurs in a reference provider.
+ * @author gaprice@lbl.gov
+ *
+ */
+@SuppressWarnings("serial")
+public class ReferenceProviderException extends Exception {
+	
+	/** Construct the exception.
+	 * @param message an exception message.
+	 * @cause the cause of the exception.
+	 */
+	public ReferenceProviderException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/us/kbase/workspace/database/refsearch/ReferenceSearchFailedException.java
+++ b/src/us/kbase/workspace/database/refsearch/ReferenceSearchFailedException.java
@@ -1,0 +1,29 @@
+package us.kbase.workspace.database.refsearch;
+
+import us.kbase.workspace.database.Reference;
+
+/** An exception thrown when a search from a particular reference is exhausted without meeting
+ * the search criteria.
+ * @author gaprice@lbl.gov
+ *
+ */
+@SuppressWarnings("serial")
+public class ReferenceSearchFailedException extends Exception {
+	
+	private final Reference failedRef;
+	
+	/** Construct the exception.
+	 * @param failedOn the reference for which the search failed.
+	 */
+	public ReferenceSearchFailedException(final Reference failedOn) {
+		super();
+		failedRef = failedOn;
+	}
+	
+	/** Get the reference for which the search failed.
+	 * @return the reference for which the search failed.
+	 */
+	public Reference getFailedReference() {
+		return failedRef;
+	}
+}

--- a/src/us/kbase/workspace/database/refsearch/ReferenceSearchMaximumSizeExceededException.java
+++ b/src/us/kbase/workspace/database/refsearch/ReferenceSearchMaximumSizeExceededException.java
@@ -1,0 +1,16 @@
+package us.kbase.workspace.database.refsearch;
+
+/** An exception thrown when a search has traversed the maximum number of references allowed.
+ * @author gaprice@lbl.gov
+ *
+ */
+@SuppressWarnings("serial")
+public class ReferenceSearchMaximumSizeExceededException extends Exception {
+	
+	/** Construct the exception.
+	 * @param message an exception message.
+	 */
+	public ReferenceSearchMaximumSizeExceededException(final String message) {
+		super(message);
+	}
+}

--- a/src/us/kbase/workspace/database/refsearch/SearchReferenceDAG.java
+++ b/src/us/kbase/workspace/database/refsearch/SearchReferenceDAG.java
@@ -1,4 +1,4 @@
-package us.kbase.workspace.database;
+package us.kbase.workspace.database.refsearch;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,6 +10,9 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
+
+import us.kbase.workspace.database.ObjectReferenceSet;
+import us.kbase.workspace.database.Reference;
 
 /** Searches a reference graph from a set of target references to find references in a provided
  * set of workspaces, and returns the path from each found object to its respective target object.

--- a/src/us/kbase/workspace/database/refsearch/SearchReferenceDAG.java
+++ b/src/us/kbase/workspace/database/refsearch/SearchReferenceDAG.java
@@ -29,39 +29,6 @@ public class SearchReferenceDAG {
 	private final ReferenceDAGTopologyProvider refProvider;
 	private final boolean throwExceptionOnFail;
 	
-	
-	/** Provides information necessary for searching the reference graph about one or more
-	 * references:
-	 * - For a set of references, provides the references adjacent (either incoming or outgoing,
-	 * but not both) to those references in the reference DAG.
-	 * - For a set of references, provides whether the references exist.
-	 * @author gaprice@lbl.gov
-	 *
-	 */
-	public interface ReferenceDAGTopologyProvider {
-		
-		/** Given a set of references, returns the set of references associated with the target
-		 * references in the graph. The references may be the incoming or outgoing references to
-		 * or from the target references, depending on which way the search should proceed. *Only*
-		 * the incoming or outgoing references should be provided for one search, never a mix of
-		 * both.
-		 * @param sourceRefs the references for which associated references should be found.
-		 * @return a mapping from each source reference to the references that refer to the source
-		 * reference.
-		 */
-		public Map<Reference, ObjectReferenceSet> getAssociatedReferences(
-				Set<Reference> sourceRefs)
-				throws ReferenceProviderException;
-		
-		/** Determines whether a reference a) exists and b) is not in the deleted state.
-		 * @param refs the references to check.
-		 * @return a mapping from each reference to a boolean that is true if the reference exists
-		 * and is not in the deleted state.
-		 */
-		public Map<Reference, Boolean> getReferenceExists(Set<Reference> refs)
-				throws ReferenceProviderException;
-	}
-	
 	/** An exception thrown when a failure occurs in a reference provider.
 	 * @author gaprice@lbl.gov
 	 *

--- a/src/us/kbase/workspace/database/refsearch/SearchReferenceDAG.java
+++ b/src/us/kbase/workspace/database/refsearch/SearchReferenceDAG.java
@@ -29,63 +29,6 @@ public class SearchReferenceDAG {
 	private final ReferenceDAGTopologyProvider refProvider;
 	private final boolean throwExceptionOnFail;
 	
-	/** An exception thrown when a failure occurs in a reference provider.
-	 * @author gaprice@lbl.gov
-	 *
-	 */
-	@SuppressWarnings("serial")
-	public static class ReferenceProviderException extends Exception {
-		
-		/** Construct the exception.
-		 * @param message an exception message.
-		 * @cause the cause of the exception.
-		 */
-		public ReferenceProviderException(final String message, final Throwable cause) {
-			super(message, cause);
-		}
-	}
-	
-	/** An exception thrown when a search from a particular reference is exhausted without meeting
-	 * the search criteria.
-	 * @author gaprice@lbl.gov
-	 *
-	 */
-	@SuppressWarnings("serial")
-	public static class ReferenceSearchFailedException extends Exception {
-		
-		private final Reference failedRef;
-		
-		/** Construct the exception.
-		 * @param failedOn the reference for which the search failed.
-		 */
-		public ReferenceSearchFailedException(final Reference failedOn) {
-			super();
-			failedRef = failedOn;
-		}
-		
-		/** Get the reference for which the search failed.
-		 * @return the reference for which the search failed.
-		 */
-		public Reference getFailedReference() {
-			return failedRef;
-		}
-	}
-	
-	/** An exception thrown when a search has traversed the maximum number of references allowed.
-	 * @author gaprice@lbl.gov
-	 *
-	 */
-	@SuppressWarnings("serial")
-	public static class ReferenceSearchMaximumSizeExceededException extends Exception {
-		
-		/** Construct the exception.
-		 * @param message an exception message.
-		 */
-		public ReferenceSearchMaximumSizeExceededException(final String message) {
-			super(message);
-		}
-	}
-	
 	/** Construct and perform a search in a directed, acyclic reference graph from a set of target
 	 * references to objects that a) exist in one of a set of workspaces and b) are at the
 	 * head of a reference path leading to the target objects.

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -68,7 +68,7 @@ import us.kbase.workspace.database.UncheckedUserMetadata;
 import us.kbase.workspace.database.WorkspaceSaveObject;
 import us.kbase.workspace.database.Provenance.ProvenanceAction;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
-import us.kbase.workspace.database.refsearch.SearchReferenceDAG.ReferenceSearchMaximumSizeExceededException;
+import us.kbase.workspace.database.refsearch.ReferenceSearchMaximumSizeExceededException;
 import us.kbase.workspace.database.User;
 import us.kbase.workspace.database.WorkspaceIdentifier;
 import us.kbase.workspace.database.WorkspaceInformation;

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -68,7 +68,7 @@ import us.kbase.workspace.database.UncheckedUserMetadata;
 import us.kbase.workspace.database.WorkspaceSaveObject;
 import us.kbase.workspace.database.Provenance.ProvenanceAction;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
-import us.kbase.workspace.database.SearchReferenceDAG.ReferenceSearchMaximumSizeExceededException;
+import us.kbase.workspace.database.refsearch.SearchReferenceDAG.ReferenceSearchMaximumSizeExceededException;
 import us.kbase.workspace.database.User;
 import us.kbase.workspace.database.WorkspaceIdentifier;
 import us.kbase.workspace.database.WorkspaceInformation;


### PR DESCRIPTION
Was going to get too messy if I tried to jam all the necessary tree classes into the same class.