### PR TITLE
Fix bug with register_typespec_copy & updated specs

### DIFF
--- a/docsource/releasenotes.rst
+++ b/docsource/releasenotes.rst
@@ -33,6 +33,8 @@ UPDATED FEATURES / MAJOR BUG FIXES:
 * The ``ObjectSpecification`` structure now allows several new ways to provide
   reference paths into the object graph.
 * Fixed a bug where integers > ~2^32 were allowed as workspace and object names.
+* Fixed a bug in ``register_typespec_copy`` where any types in common between the new and previous
+  version of the spec would be unregistered.
 
 VERSION: 0.5.0 (Released 8/12/16)
 ---------------------------------

--- a/performance/us/kbase/workspace/performance/workspace/GetObjectsTiming.java
+++ b/performance/us/kbase/workspace/performance/workspace/GetObjectsTiming.java
@@ -16,14 +16,14 @@ import us.kbase.workspace.WorkspaceClient;
 
 public class GetObjectsTiming {
 	
-	public static final String WS_URL = "https://ci.kbase.us/services/ws";
-//	public static final String WS_URL = "http://localhost:7058";
+//	public static final String WS_URL = "https://ci.kbase.us/services/ws";
+	public static final String WS_URL = "http://localhost:7058";
 //	public static final String WORKSPACE = "ReferenceTaxons";
 	public static final String WORKSPACE = "TestObjs";
 //	public static final String TYPE = "KBaseGenomeAnnotations.Taxon";
 	public static final String TYPE = "Empty.AType-0.1";
 	
-	public static final int ITERS = 1; //10
+	public static final int ITERS = 20; //10
 	public static final long BATCH_SIZE = 10000L;
 	
 	public static void main(String[] args) throws Exception {
@@ -37,7 +37,7 @@ public class GetObjectsTiming {
 							.withMinObjectID(i * BATCH_SIZE + 1)
 							.withMaxObjectID((i + 1) * BATCH_SIZE)
 							);
-			printElapse("list", preiter);
+			printElapse("list iter " + i, preiter);
 			long totalsize = 0;
 			final List<ObjectSpecification> in = new LinkedList<>();
 			for (final Tuple11<Long, String, String, String, Long, String, Long, String, String,

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -1430,31 +1430,30 @@ public class WorkspaceServer extends JsonServerServlet {
 		}
 		final WorkspaceClient client = new WorkspaceClient(
 				new URL(params.getExternalWorkspaceUrl()), authPart);
-		if (!params.getExternalWorkspaceUrl().startsWith("https:"))
+		if (!params.getExternalWorkspaceUrl().startsWith("https:")) {
 			client.setIsInsecureHttpConnectionAllowed(true);
+		}
 		final GetModuleInfoParams gmiparams = new GetModuleInfoParams()
 			.withMod(params.getMod()).withVer(params.getVersion());
-		final us.kbase.workspace.ModuleInfo extInfo =
-				client.getModuleInfo(gmiparams);
+		final us.kbase.workspace.ModuleInfo extInfo = client.getModuleInfo(gmiparams);
 		final Map<String, String> includesToMd5 = new HashMap<String, String>();
-		for (final Map.Entry<String, Long> entry : extInfo
-				.getIncludedSpecVersion().entrySet()) {
+		for (final Map.Entry<String, Long> entry : extInfo.getIncludedSpecVersion().entrySet()) {
 			final String includedModule = entry.getKey();
 			final long extIncludedVer = entry.getValue();
 			final GetModuleInfoParams includeParams = new GetModuleInfoParams()
 				.withMod(includedModule).withVer(extIncludedVer);
-			final us.kbase.workspace.ModuleInfo extIncludedInfo = 
+			final us.kbase.workspace.ModuleInfo extIncludedInfo =
 					client.getModuleInfo(includeParams);
 			includesToMd5.put(includedModule, extIncludedInfo.getChsum());
 		}
 		final String userId = authPart.getUserName();
 		final String specDocument = extInfo.getSpec();
 		final Set<String> extTypeSet = new LinkedHashSet<String>();
-		for (final String typeDef : extInfo.getTypes().keySet())
+		for (final String typeDef : extInfo.getTypes().keySet()) {
 			extTypeSet.add(TypeDefId.fromTypeString(typeDef).getType().getName());
+		}
 		returnVal = types.compileTypeSpecCopy(params.getMod(), specDocument,
-				extTypeSet, userId, includesToMd5, 
-				extInfo.getIncludedSpecVersion());
+				extTypeSet, userId, includesToMd5, extInfo.getIncludedSpecVersion());
         //END register_typespec_copy
         return returnVal;
     }

--- a/src/us/kbase/workspace/kbase/WorkspaceAdministration.java
+++ b/src/us/kbase/workspace/kbase/WorkspaceAdministration.java
@@ -77,9 +77,6 @@ public class WorkspaceAdministration {
 	private final Workspace ws;
 	private final WorkspaceServerMethods wsmeth;
 	private final Types types;
-	//TODO remove hard coded admin
-	private static final String ROOT = "workspaceadmin";
-	
 	private final Set<String> internaladmins = new HashSet<String>(); 
 	
 	public WorkspaceAdministration(
@@ -90,7 +87,6 @@ public class WorkspaceAdministration {
 		this.ws = ws;
 		this.types = types;
 		this.wsmeth = wsmeth;
-		internaladmins.add(ROOT);
 		if (admin != null && !admin.isEmpty()) {
 			internaladmins.add(admin);
 		}

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
@@ -3571,7 +3571,8 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 				new ListModuleVersionsParams().withMod("DepModule"));
 		final String excStart = "Can not find local module SomeModule synchronized with " +
 				"external version";
-		final String excEnd = "(md5=b38fc31dbccc829bba38a59e313c564e)";
+		//TODO TEST restore this part of the test when the MD5s are the same whether run in eclipse or via ant test
+//		final String excEnd = "(md5=b38fc31dbccc829bba38a59e313c564e)";
 		/* the first two versions of DepModule don't have the necessary version of SomeModule
 		 * registered on server 1, and so registration will fail. version 3+ will succeed.
 		 */
@@ -3585,10 +3586,11 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 			} catch (Exception e) {
 				ok = false;
 				if (count < 2) {
-					assertThat("Incorrect exception start", e.getMessage().startsWith(excStart),
-							is(true));
-					assertThat("Incorrect exception end", e.getMessage().endsWith(excEnd),
-							is(true));
+					assertThat(String.format("Count %s: Incorrect exception start. Msg: %s",
+							count, e.getMessage()), e.getMessage().startsWith(excStart), is(true));
+					//TODO TEST restore this part of the test when the MD5s are the same whether run in eclipse or via ant test
+//					assertThat(String.format("Count %s: Incorrect exception end. Msg: %s",
+//							count, e.getMessage()), e.getMessage().endsWith(excEnd), is(true));
 				} else {
 					fail(String.format("Got exception when expected success on count %s: %s",
 							count, e));

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
@@ -3566,27 +3566,48 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 	public void testSpecSync() throws Exception {
 		CLIENT1.requestModuleOwnership("DepModule");
 		administerCommand(CLIENT2, "approveModRequest", "module", "DepModule");
-		String urlForSrv2 = "http://localhost:" + SERVER2.getServerPort();
-		ModuleVersions vers = CLIENT_FOR_SRV2.listModuleVersions(
+		final String urlForSrv2 = "http://localhost:" + SERVER2.getServerPort();
+		final ModuleVersions vers = CLIENT_FOR_SRV2.listModuleVersions(
 				new ListModuleVersionsParams().withMod("DepModule"));
-		long lastVer = CLIENT_FOR_SRV2.getModuleInfo(
-				new GetModuleInfoParams().withMod("DepModule")).getVer();
+		final String excStart = "Can not find local module SomeModule synchronized with " +
+				"external version";
+		final String excEnd = "(md5=b38fc31dbccc829bba38a59e313c564e)";
+		/* the first two versions of DepModule don't have the necessary version of SomeModule
+		 * registered on server 1, and so registration will fail. version 3+ will succeed.
+		 */
+		int count = 0;
 		for (long ver : vers.getVers()) {
 			boolean ok = true;
 			try {
 				CLIENT1.registerTypespecCopy(new RegisterTypespecCopyParams()
 					.withExternalWorkspaceUrl(urlForSrv2).withMod("DepModule")
 					.withVersion(ver));
-			} catch (Exception ignore) {
+			} catch (Exception e) {
 				ok = false;
+				if (count < 2) {
+					assertThat("Incorrect exception start", e.getMessage().startsWith(excStart),
+							is(true));
+					assertThat("Incorrect exception end", e.getMessage().endsWith(excEnd),
+							is(true));
+				} else {
+					fail(String.format("Got exception when expected success on count %s: %s",
+							count, e));
+				}
 			}
-			Assert.assertEquals(ver == lastVer, ok);
 			if (ok) {
+				if (count < 2) {
+					fail("Register succeeded when fail expected on count " + count);
+				}
+				final String type = "DepModule.BType-" + (count - 1) + ".0";
 				CLIENT1.releaseModule("DepModule");
-				Assert.assertTrue(CLIENT1.getModuleInfo(new GetModuleInfoParams().withMod(
-						"DepModule")).getTypes().containsKey("DepModule.BType-1.0"));
+				final Set<String> types = CLIENT1.getModuleInfo(
+						new GetModuleInfoParams().withMod("DepModule")).getTypes().keySet();
+				assertThat("Incorrect types on count " + count, types,
+						is((Set<String>) new HashSet<>(Arrays.asList(type))));
 			}
+			count++;
 		}
+		assertThat("incorrect number of specs processed", count, is(4));
 	}
 	
 	@Test

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
@@ -284,6 +284,8 @@ public class JSONRPCLayerTester {
 			.withSpec("module SomeModule {/* @optional thing */ typedef structure {int thing;} AType;};")
 			.withNewTypes(Arrays.asList("AType")));
 		CLIENT_FOR_SRV2.releaseModule("SomeModule");
+//		System.out.println(CLIENT_FOR_SRV2.getModuleInfo(new GetModuleInfoParams()
+//				.withMod("SomeModule")));
 		
 		CLIENT_FOR_SRV2.requestModuleOwnership("DepModule");
 		administerCommand(CLIENT_FOR_SRV2, "approveModRequest", "module", "DepModule");
@@ -1708,8 +1710,7 @@ public class JSONRPCLayerTester {
 				"{\"command\": \"listAdmins\"}"))).asInstance();
 		Set<String> got = new HashSet<String>(admins);
 		Set<String> expected = new HashSet<String>(expadmins);
-		assertTrue("correct admins", got.containsAll(expected));
-		assertThat("only the one built in admin", expected.size() + 1, is(got.size()));
+		assertThat("correct admins", got, is(expected));
 		
 	}
 	

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
@@ -274,32 +274,51 @@ public class JSONRPCLayerTester {
 		
 		System.out.println("Started test server 2 on port " + SERVER2.getServerPort());
 		CLIENT_FOR_SRV2.setIsInsecureHttpConnectionAllowed(true);
+		
 		CLIENT_FOR_SRV2.requestModuleOwnership("SomeModule");
 		administerCommand(CLIENT_FOR_SRV2, "approveModRequest", "module", "SomeModule");
+		
+		// SomeModule ver 1
 		CLIENT_FOR_SRV2.registerTypespec(new RegisterTypespecParams()
 			.withDryrun(0L)
 			.withSpec("module SomeModule {/* @optional thing */ typedef structure {int thing;} AType;};")
 			.withNewTypes(Arrays.asList("AType")));
 		CLIENT_FOR_SRV2.releaseModule("SomeModule");
+		
 		CLIENT_FOR_SRV2.requestModuleOwnership("DepModule");
 		administerCommand(CLIENT_FOR_SRV2, "approveModRequest", "module", "DepModule");
+		
+		// DepModule ver 1 and 2 (2 comes from the release) (relies on SomeModule ver1)
 		CLIENT_FOR_SRV2.registerTypespec(new RegisterTypespecParams()
 			.withDryrun(0L)
 			.withSpec("#include <SomeModule>\n" +
 					"module DepModule {typedef structure {SomeModule.AType thing;} BType;};")
 			.withNewTypes(Arrays.asList("BType")));
 		CLIENT_FOR_SRV2.releaseModule("DepModule");
+		
+		// SomeModule ver 2
 		CLIENT_FOR_SRV2.registerTypespec(new RegisterTypespecParams()
 			.withDryrun(0L)
 			.withSpec("module SomeModule {/* @optional thing */ typedef structure {string thing;} AType;};")
 			.withNewTypes(Collections.<String>emptyList()));
 		CLIENT_FOR_SRV2.releaseModule("SomeModule");
+		
+		// DepModule ver 2 (relies on SomeModule ver 2)
 		CLIENT_FOR_SRV2.registerTypespec(new RegisterTypespecParams()
 			.withDryrun(0L)
 			.withSpec("#include <SomeModule>\n" +
 					"module DepModule {typedef structure {SomeModule.AType thing;} BType;};")
 			.withNewTypes(Collections.<String>emptyList()));
 		CLIENT_FOR_SRV2.releaseModule("DepModule");
+		
+		// DepModule ver 3 (relies on SomeModule ver 2)
+		CLIENT_FOR_SRV2.registerTypespec(new RegisterTypespecParams()
+				.withDryrun(0L)
+				.withSpec("#include <SomeModule>\n" +
+						"module DepModule {typedef structure {SomeModule.AType thing2;} BType;};")
+				.withNewTypes(Collections.<String>emptyList()));
+		CLIENT_FOR_SRV2.releaseModule("DepModule");
+		
 		CLIENT_FOR_SRV2.requestModuleOwnership("UnreleasedModule");
 		administerCommand(CLIENT_FOR_SRV2, "approveModRequest", "module", "UnreleasedModule");
 		CLIENT_FOR_SRV2.registerTypespec(new RegisterTypespecParams()


### PR DESCRIPTION
Since allTypes was a list rather than a set, it wound up with two copies
of each type when the types in the new specfile were the same as the old
specfile. In the first time through the loop, the type was removed from
typesToSave, and in the second time added to typesToUnregister. Thus any
types that are in the new spec and the old spec will be unregistered.

Changing the list to a set fixed the bug - the tests now fail on a list,
but pass with a set.