### PR TITLE
Release WS 0.7.0

### DIFF
--- a/docsource/releasenotes.rst
+++ b/docsource/releasenotes.rst
@@ -2,8 +2,8 @@ Workspace service release notes
 ===============================
 
 
-VERSION: 0.7.0 (Released TBD)
------------------------------
+VERSION: 0.7.0 (Released 5/5/17)
+--------------------------------
 
 BACKWARDS INCOMPATIBILITIES:
 

--- a/src/us/kbase/common/test/service/ServiceCheckerTest.java
+++ b/src/us/kbase/common/test/service/ServiceCheckerTest.java
@@ -72,10 +72,11 @@ public class ServiceCheckerTest {
 		test();
 	}
 	
-	@Test
-	public void testHTTP() throws Exception {
-		test();
-	}
+	// no longer any http SDK services available
+//	@Test
+//	public void testHTTP() throws Exception {
+//		test();
+//	}
 	
 	@Test
 	public void test500() throws Exception {

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -115,7 +115,7 @@ public class WorkspaceServer extends JsonServerServlet {
 	//TODO JAVADOC really low priority, sorry
 	//TODO INIT timestamps for startup script
 
-	private static final String VER = "0.7.0-dev2";
+	private static final String VER = "0.7.0";
 	private static final String GIT =
 			"https://github.com/kbase/workspace_deluxe";
 

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
@@ -88,7 +88,7 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 	
 	@Test
 	public void ver() throws Exception {
-		assertThat("got correct version", CLIENT_NO_AUTH.ver(), is("0.7.0-dev2"));
+		assertThat("got correct version", CLIENT_NO_AUTH.ver(), is("0.7.0"));
 	}
 	
 	public void status() throws Exception {


### PR DESCRIPTION
Required deactivating a service checker test since dev03 is gone and
there are no more SDK services accessible via HTTP.

Could put up a local service for the test (or stick something on heroku)
but that's hardly worth it.