### PR TITLE
TASK-806 Prep for adding admin version of get_workspace_info PTII

### DIFF
--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -532,10 +532,9 @@ public class Workspace {
 						oldWsName[1]);
 			} // else don't change the name
 		} else {
+			new WorkspaceIdentifier(newName.get(), newUser); //checks for illegal names
 			if (newName.get().equals(rwsi.getName())) {
 				newName = Optional.absent(); // no need to change name
-			} else {
-				new WorkspaceIdentifier(newName.get(), newUser); //checks for illegal names
 			}
 		}
 		db.setWorkspaceOwner(rwsi, owner, newUser, newName);

--- a/src/us/kbase/workspace/database/WorkspaceDatabase.java
+++ b/src/us/kbase/workspace/database/WorkspaceDatabase.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.base.Optional;
+
 import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.exceptions.TypedObjectExtractionException;
@@ -130,16 +132,34 @@ public interface WorkspaceDatabase {
 			WorkspaceCommunicationException, CorruptWorkspaceDBException,
 			NoSuchObjectException;
 	
-	public WorkspaceInformation lockWorkspace(WorkspaceUser user,
-			ResolvedWorkspaceID wsid)
+	/** Lock a workspace, preventing further modifications other than making the workspace
+	 * publicly readable.
+	 * @param wsid the workspace.
+	 * @throws WorkspaceCommunicationException if a communication error occurs when contacting
+	 * the storage system.
+	 * @throws CorruptWorkspaceDBException if corrupt data is found in the database.
+	 */
+	public void lockWorkspace(ResolvedWorkspaceID wsid)
 			throws WorkspaceCommunicationException, CorruptWorkspaceDBException;
 	
 	public void setPermissions(ResolvedWorkspaceID rwsi,
 			List<WorkspaceUser> users, Permission perm) throws
 			WorkspaceCommunicationException, CorruptWorkspaceDBException;
 
-	public WorkspaceInformation setWorkspaceOwner(ResolvedWorkspaceID rwsi,
-			WorkspaceUser user, WorkspaceUser newUser, String newName)
+	/** Change a workspace's owner.
+	 * @param rwsi the workspace.
+	 * @param user the current owner.
+	 * @param newUser the new owner.
+	 * @param newName the new workspace name, or null if the name should not change.
+	 * @throws WorkspaceCommunicationException if a communication error occurs when contacting
+	 * the storage system.
+	 * @throws CorruptWorkspaceDBException if corrupt data is found in the database.
+	 */
+	public void setWorkspaceOwner(
+			ResolvedWorkspaceID rwsi,
+			WorkspaceUser user,
+			WorkspaceUser newUser,
+			Optional<String> newName)
 			throws WorkspaceCommunicationException, CorruptWorkspaceDBException;
 	
 	public void setGlobalPermission(ResolvedWorkspaceID rwsi, Permission perm)
@@ -431,8 +451,14 @@ public interface WorkspaceDatabase {
 			boolean includeHidden, int limit)
 			throws WorkspaceCommunicationException;
 	
-	public WorkspaceInformation renameWorkspace(WorkspaceUser user,
-			ResolvedWorkspaceID wsid, String newname)
+	/** Rename a workspace.
+	 * @param wsid the workspace.
+	 * @param newname the new name for the workspace.
+	 * @throws WorkspaceCommunicationException if a communication error with
+	 * the storage system occurs
+	 * @throws CorruptWorkspaceDBException if corrupt data is found in the storage system.
+	 */
+	public void renameWorkspace(ResolvedWorkspaceID wsid, String newname)
 			throws WorkspaceCommunicationException, CorruptWorkspaceDBException;
 	
 	public ObjectInformation renameObject(

--- a/src/us/kbase/workspace/database/WorkspaceDatabase.java
+++ b/src/us/kbase/workspace/database/WorkspaceDatabase.java
@@ -178,8 +178,7 @@ public interface WorkspaceDatabase {
 	 * @throws WorkspaceCommunicationException if a communication error occurs.
 	 * @throws CorruptWorkspaceDBException if the workspace database is corrupt.
 	 */
-	public Permission getPermission(WorkspaceUser user,
-			ResolvedWorkspaceID rwsi)
+	public Permission getPermission(WorkspaceUser user, ResolvedWorkspaceID rwsi)
 			throws WorkspaceCommunicationException, CorruptWorkspaceDBException;
 	
 	/** Get permissions for a workspace for one user. This method will also
@@ -189,14 +188,14 @@ public interface WorkspaceDatabase {
 	 *  
 	 * @param user the user for whom to get permissions. If the user is null,
 	 * only the global readability of the workspace will be returned. 
-	 * @param rwsi the workspace to check.
+	 * @param rwsi the workspace to check. Note that the workspace may not be in
+	 * the output - this indicates the user has no permissions to the workspace.
 	 * @return the user's and global users' permission for the workspace.
 	 * @throws WorkspaceCommunicationException if a communication error occurs.
 	 * @throws CorruptWorkspaceDBException if the workspace database is corrupt.
 	 */
-	public PermissionSet getPermissions(WorkspaceUser user,
-			ResolvedWorkspaceID rwsi) throws 
-			WorkspaceCommunicationException, CorruptWorkspaceDBException;
+	public PermissionSet getPermissions(WorkspaceUser user, ResolvedWorkspaceID rwsi)
+			throws WorkspaceCommunicationException, CorruptWorkspaceDBException;
 	
 	/** Get permissions for a set of workspaces for one user. If the user is
 	 * null, only the global readability of the workspaces will be returned.
@@ -205,13 +204,14 @@ public interface WorkspaceDatabase {
 	 * 
 	 * @param user the user for whom to get permissions. If the user is null,
 	 * only the global readability of the workspaces will be returned. 
-	 * @param rwsis the workspaces to check.
+	 * @param rwsis the workspaces to check. If empty, all workspaces
+	 * to which the user has permission will be returned. Note that not all the workspaces in the
+	 * set may be in the output - this indicates the user has no permissions to that workspace.
 	 * @return the user's and global users' permission for the workspaces.
 	 * @throws WorkspaceCommunicationException if a communication error occurs.
 	 * @throws CorruptWorkspaceDBException if the workspace database is corrupt.
 	 */
-	public PermissionSet getPermissions(WorkspaceUser user,
-			Set<ResolvedWorkspaceID> rwsis)
+	public PermissionSet getPermissions(WorkspaceUser user, Set<ResolvedWorkspaceID> rwsis)
 			throws WorkspaceCommunicationException, CorruptWorkspaceDBException;
 	
 	/** Returns all the workspaces for which the user has the specified
@@ -229,8 +229,10 @@ public interface WorkspaceDatabase {
 	 * @throws WorkspaceCommunicationException if a communication error occurs.
 	 * @throws CorruptWorkspaceDBException if the workspace database is corrupt.
 	 */
-	public PermissionSet getPermissions(WorkspaceUser user,
-			Permission perm, boolean excludeGlobalRead)
+	public PermissionSet getPermissions(
+			WorkspaceUser user,
+			Permission perm,
+			boolean excludeGlobalRead)
 			throws WorkspaceCommunicationException, CorruptWorkspaceDBException;
 
 	/** Get permissions for a set of workspaces for one user.
@@ -238,9 +240,10 @@ public interface WorkspaceDatabase {
 	 * @param user the user for whom to get permissions. If the user is null,
 	 * only the global readability of the workspaces will be returned. 
 	 * @param rwsis the list of workspaces to check. If empty, all workspaces
-	 * to which the user has permission will be returned.
+	 * to which the user has permission will be returned. Note that not all the workspaces in the
+	 * set may be in the output - this indicates the user has no permissions to that workspace.
 	 * @param perm the minimum permission required for a workspace to be
-	 * included in the permission set.
+	 * included in the permission set. Minimum READ.
 	 * @param excludeGlobalRead exclude globally readable workspaces.
 	 * @param excludeDeletedWorkspaces exclude deleted workspaces. Deleted
 	 * workspaces in the supplied list are not affected.
@@ -248,9 +251,12 @@ public interface WorkspaceDatabase {
 	 * @throws WorkspaceCommunicationException if a communication error occurs.
 	 * @throws CorruptWorkspaceDBException if the workspace database is corrupt.
 	 */
-	public PermissionSet getPermissions(WorkspaceUser user,
-			Set<ResolvedWorkspaceID> rwsis, Permission perm,
-			boolean excludeGlobalRead, boolean excludeDeletedWorkspaces)
+	public PermissionSet getPermissions(
+			WorkspaceUser user,
+			Set<ResolvedWorkspaceID> rwsis,
+			Permission perm,
+			boolean excludeGlobalRead,
+			boolean excludeDeletedWorkspaces)
 			throws WorkspaceCommunicationException, CorruptWorkspaceDBException;
 	
 	/** Returns all users' permissions for a set of workspaces */
@@ -274,7 +280,7 @@ public interface WorkspaceDatabase {
 //			throws CorruptWorkspaceDBException, WorkspaceCommunicationException;
 	
 	/** Get information about a workspace.
-	 * @param user the user that is requesting the information.l
+	 * @param user the user that is requesting the information.
 	 * @param rwsi the workspace.
 	 * @return the workspace information.
 	 * @throws CorruptWorkspaceDBException if corrupt data is found in the storage

--- a/src/us/kbase/workspace/database/WorkspaceDatabase.java
+++ b/src/us/kbase/workspace/database/WorkspaceDatabase.java
@@ -42,6 +42,10 @@ public interface WorkspaceDatabase {
 			throws NoSuchWorkspaceException, WorkspaceCommunicationException;
 
 	/** Resolve a workspace identifier.
+	 * 
+	 * WARNING - may return deleted workspaces. There is no guarantee how long deleted workspaces
+	 * may remain in the system, and attempting to access them again may result in an exception.
+	 * 
 	 * @param wsi the workspace identifier.
 	 * @param allowDeleted allow the target workspace to be in the deleted state.
 	 * @return the resolved identifier.
@@ -56,6 +60,10 @@ public interface WorkspaceDatabase {
 			throws NoSuchWorkspaceException, WorkspaceCommunicationException;
 	
 	/** Resolve a set of workspace identifiers.
+	 * 
+	 * WARNING - may return deleted workspaces. There is no guarantee how long deleted workspaces
+	 * may remain in the system, and attempting to access them again may result in an exception.
+	 * 
 	 * @param wsis the workspace identifiers.
 	 * @param suppressErrors if true, deleted workspaces will be returned in the results, and
 	 * workspace identifiers that specify non-existent workspaces will be ignored. If false,

--- a/src/us/kbase/workspace/database/WorkspaceDatabase.java
+++ b/src/us/kbase/workspace/database/WorkspaceDatabase.java
@@ -230,9 +230,34 @@ public interface WorkspaceDatabase {
 			Set<ResolvedWorkspaceID> rwsi)
 			throws WorkspaceCommunicationException, CorruptWorkspaceDBException;
 
-	public WorkspaceInformation getWorkspaceInformation(WorkspaceUser user,
-			ResolvedWorkspaceID rwsi) throws CorruptWorkspaceDBException,
-			WorkspaceCommunicationException;
+	/** Get information about any workspace, regardless of user permissions. The user permission
+	 * returned is always 'none'.
+	 * 
+	 * This method should only be run by an administrator. Standard user should run
+	 * {@link #getWorkspaceInformation(WorkspaceUser, ResolvedWorkspaceID)}
+	 * @param rwsi the workspace.
+	 * @return workspace information.
+	 * @throws CorruptWorkspaceDBException if corrupt data is found in the storage
+	 * system.
+	 * @throws WorkspaceCommunicationException if a communication error occurs when contacting the
+	 * storage system.
+	 */
+//	public WorkspaceInformation getWorkspaceInformation(ResolvedWorkspaceID rwsi)
+//			throws CorruptWorkspaceDBException, WorkspaceCommunicationException;
+	
+	/** Get information about a workspace.
+	 * @param user the user that is requesting the information.l
+	 * @param rwsi the workspace.
+	 * @return the workspace information.
+	 * @throws CorruptWorkspaceDBException if corrupt data is found in the storage
+	 * system.
+	 * @throws WorkspaceCommunicationException if a communication error occurs when contacting the
+	 * storage system.
+	 */
+	public WorkspaceInformation getWorkspaceInformation(
+			WorkspaceUser user,
+			ResolvedWorkspaceID rwsi)
+			throws CorruptWorkspaceDBException, WorkspaceCommunicationException;
 	
 	public void setWorkspaceDescription(ResolvedWorkspaceID wsid,
 			String description) throws WorkspaceCommunicationException;

--- a/src/us/kbase/workspace/database/WorkspaceInformation.java
+++ b/src/us/kbase/workspace/database/WorkspaceInformation.java
@@ -10,6 +10,7 @@ public interface WorkspaceInformation {
 	public Date getModDate();
 	public long getApproximateObjects();
 	public Permission getUserPermission();
+	//TODO CODE decouple the permissions and the ws info.
 	public boolean isGloballyReadable();
 	public boolean isLocked();
 	public String getLockState();

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -637,8 +637,7 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		if (maxid > 0) {
 			incrementWorkspaceCounter(toWS, maxid);
 		}
-		updateClonedWorkspaceInformation(
-				user, globalRead, toWS.getID(), newname);
+		updateClonedWorkspaceInformation(user, globalRead, toWS.getID(), newname);
 		return getWorkspaceInformation(user, toWS);
 	}
 
@@ -649,8 +648,8 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 			final boolean globalRead,
 			final long id,
 			final String newname)
-			throws PreExistingWorkspaceException,
-			WorkspaceCommunicationException, CorruptWorkspaceDBException {
+			throws PreExistingWorkspaceException, WorkspaceCommunicationException,
+				CorruptWorkspaceDBException {
 		
 		final DBObject q = new BasicDBObject(Fields.WS_ID, id);
 
@@ -989,14 +988,12 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 	}
 	
 	@Override
-	public Permission getPermission(final WorkspaceUser user,
-			final ResolvedWorkspaceID wsi) throws 
-			WorkspaceCommunicationException, CorruptWorkspaceDBException {
+	public Permission getPermission(final WorkspaceUser user, final ResolvedWorkspaceID wsi)
+			throws WorkspaceCommunicationException, CorruptWorkspaceDBException {
 		return getPermissions(user, wsi).getPermission(wsi, true);
 	}
-	public PermissionSet getPermissions(final WorkspaceUser user,
-			final ResolvedWorkspaceID rwsi) throws 
-			WorkspaceCommunicationException, CorruptWorkspaceDBException {
+	public PermissionSet getPermissions(final WorkspaceUser user, final ResolvedWorkspaceID rwsi)
+			throws WorkspaceCommunicationException, CorruptWorkspaceDBException {
 		final Set<ResolvedWorkspaceID> wsis =
 				new HashSet<ResolvedWorkspaceID>();
 		wsis.add(rwsi);
@@ -1013,12 +1010,11 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 
 	@Override
 	public PermissionSet getPermissions(
-			final WorkspaceUser user, final Permission perm,
+			final WorkspaceUser user,
+			final Permission perm,
 			final boolean excludeGlobalRead)
-			throws WorkspaceCommunicationException,
-			CorruptWorkspaceDBException {
-		return getPermissions(user,
-				new HashSet<ResolvedWorkspaceID>(), perm, excludeGlobalRead,
+			throws WorkspaceCommunicationException, CorruptWorkspaceDBException {
+		return getPermissions(user, new HashSet<ResolvedWorkspaceID>(), perm, excludeGlobalRead,
 				false);
 	}
 	
@@ -1029,8 +1025,7 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 			final Permission perm,
 			final boolean excludeGlobalRead,
 			final boolean excludeDeletedWorkspaces)
-			throws WorkspaceCommunicationException,
-			CorruptWorkspaceDBException {
+			throws WorkspaceCommunicationException, CorruptWorkspaceDBException {
 		if (perm == null || Permission.NONE.equals(perm)) {
 			throw new IllegalArgumentException(
 					"Permission cannot be null or NONE");
@@ -1038,8 +1033,7 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		final Set<ResolvedMongoWSID> rmwsis = query.convertResolvedWSID(rwsis);
 		final Map<ResolvedMongoWSID, Map<User, Permission>> userperms;
 		if (user != null) {
-			userperms = query.queryPermissions(rmwsis, 
-					new HashSet<User>(Arrays.asList(user)),
+			userperms = query.queryPermissions(rmwsis, new HashSet<User>(Arrays.asList(user)),
 					perm, excludeDeletedWorkspaces);
 		} else {
 			userperms = new HashMap<ResolvedMongoWSID, Map<User,Permission>>();
@@ -1048,11 +1042,9 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		final Map<ResolvedMongoWSID, Map<User, Permission>> globalperms;
 		if (excludeGlobalRead || perm.compareTo(Permission.WRITE) >= 0) {
 			if (userperms.isEmpty()) {
-				globalperms =
-						new HashMap<ResolvedMongoWSID, Map<User,Permission>>();
+				globalperms = new HashMap<ResolvedMongoWSID, Map<User,Permission>>();
 			} else {
-				globalperms = query.queryPermissions(userperms.keySet(),
-						allusers);
+				globalperms = query.queryPermissions(userperms.keySet(), allusers);
 			}
 		} else {
 			globalperms = query.queryPermissions(rmwsis, allusers,
@@ -1296,14 +1288,21 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		return new WorkspaceUser((String) ws.get(Fields.WS_OWNER));
 	}
 	
+//	@Override
+//	public WorkspaceInformation getWorkspaceInformation(final ResolvedWorkspaceID rwsi)
+//			throws WorkspaceCommunicationException, CorruptWorkspaceDBException {
+//		final ResolvedMongoWSID m = query.convertResolvedWSID(rwsi);
+//		final Map<String, Object> ws = query.queryWorkspace(m, FLDS_WS_NO_DESC);
+//		final PermissionSet perms = getPermissions(null, m);
+//		return generateWSInfo(rwsi, perms, ws);
+//	}
+	
 	@Override
 	public WorkspaceInformation getWorkspaceInformation(
 			final WorkspaceUser user, final ResolvedWorkspaceID rwsi)
-			throws WorkspaceCommunicationException,
-			CorruptWorkspaceDBException {
+			throws WorkspaceCommunicationException, CorruptWorkspaceDBException {
 		final ResolvedMongoWSID m = query.convertResolvedWSID(rwsi);
-		final Map<String, Object> ws = query.queryWorkspace(m,
-				FLDS_WS_NO_DESC);
+		final Map<String, Object> ws = query.queryWorkspace(m, FLDS_WS_NO_DESC);
 		final PermissionSet perms = getPermissions(user, m);
 		return generateWSInfo(rwsi, perms, ws);
 	}

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -637,13 +637,22 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		if (maxid > 0) {
 			incrementWorkspaceCounter(toWS, maxid);
 		}
-		updateClonedWorkspaceInformation(user, globalRead, toWS.getID(), newname);
-		return getWorkspaceInformation(user, toWS);
+		final Date moddate = updateClonedWorkspaceInformation(
+				user, globalRead, toWS.getID(), newname);
+		return new MongoWSInfo(wsinfo.getId(),
+				newname,
+				user,
+				moddate,
+				maxid,
+				Permission.OWNER,
+				globalRead,
+				wsinfo.isLocked(),
+				new UncheckedUserMetadata(meta));
 	}
 
 	// this method expects that the id exists. If it does not it'll throw an
 	// IllegalState exception.
-	private void updateClonedWorkspaceInformation(
+	private Date updateClonedWorkspaceInformation(
 			final WorkspaceUser user,
 			final boolean globalRead,
 			final long id,
@@ -653,8 +662,9 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		
 		final DBObject q = new BasicDBObject(Fields.WS_ID, id);
 
+		final Date moddate = new Date();
 		final DBObject ws = new BasicDBObject();
-		ws.put(Fields.WS_MODDATE, new Date());
+		ws.put(Fields.WS_MODDATE, moddate);
 		ws.put(Fields.WS_NAME, newname);
 		
 		final DBObject update = new BasicDBObject(
@@ -676,6 +686,7 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		}
 		setCreatedWorkspacePermissions(user, globalRead,
 				new ResolvedMongoWSID(newname, id, false, false));
+		return moddate;
 	}
 
 	private void addExcludedToCloneQuery(

--- a/src/us/kbase/workspace/database/mongo/QueryMethods.java
+++ b/src/us/kbase/workspace/database/mongo/QueryMethods.java
@@ -119,7 +119,7 @@ public class QueryMethods {
 				/* This will cause havoc when GC is active. Could resolve a deleted workspace,
 				 * which is allowed, and then GC before getting here
 				 * 
-				 * UPDATE - In general deleted workspaces should get resolved workspace ids.
+				 * UPDATE - In general deleted workspaces shouldn't get resolved workspace ids.
 				 * there are currently (5/30/17) two places where they can:
 				 * 1) to undelete a workspace, and that should go directly to an undelete method.
 				 * 2) When traversing the object graph into deleted workspaces. The user would

--- a/src/us/kbase/workspace/database/mongo/QueryMethods.java
+++ b/src/us/kbase/workspace/database/mongo/QueryMethods.java
@@ -116,7 +116,24 @@ public class QueryMethods {
 				new HashMap<ResolvedMongoWSID, Map<String,Object>>();
 		for (final Long id: ids.keySet()) {
 			if (!idres.containsKey(id)) {
-				//TODO GC this will cause havoc when GC is active. Could resolve a deleted workspace, which is allowed, and then GC before getting here
+				/* This will cause havoc when GC is active. Could resolve a deleted workspace,
+				 * which is allowed, and then GC before getting here
+				 * 
+				 * UPDATE - In general deleted workspaces should get resolved workspace ids.
+				 * there are currently (5/30/17) two places where they can:
+				 * 1) to undelete a workspace, and that should go directly to an undelete method.
+				 * 2) When traversing the object graph into deleted workspaces. The user would
+				 * have to extract the workspace ID and send it here, but that should be safe since
+				 * if its in the object graph, it contains objects with non-zero reference counts
+				 * and therefore can't be deleted permanently.
+				 * 
+				 * TODO CODE consider making the undelete method take a workspaceIdentifier
+				 * rather than a resolved ID to remove any ability to get a resolved ID for a
+				 * deleted workspace.
+				 * 
+				 * Also consider just returning all the WS info in one shot rather than futzing
+				 * with resolved IDs and WorkspaceInfos.
+				 */
 				throw new CorruptWorkspaceDBException(
 						"Resolved workspace unexpectedly deleted from database: "
 						+ id);
@@ -517,11 +534,9 @@ public class QueryMethods {
 			final Set<User> users,
 			final Permission minPerm,
 			final boolean excludeDeletedWorkspaces)
-			throws WorkspaceCommunicationException,
-			CorruptWorkspaceDBException {
+			throws WorkspaceCommunicationException, CorruptWorkspaceDBException {
 		final DBObject query = new BasicDBObject();
-		final Map<Long, ResolvedMongoWSID> idToWS =
-				new HashMap<Long, ResolvedMongoWSID>();
+		final Map<Long, ResolvedMongoWSID> idToWS = new HashMap<Long, ResolvedMongoWSID>();
 		if (rwsis != null && rwsis.size() > 0) {
 			final Set<Long> wsids = new HashSet<Long>();
 			for (final ResolvedMongoWSID r: rwsis) {
@@ -538,8 +553,7 @@ public class QueryMethods {
 			query.put(Fields.ACL_USER, new BasicDBObject("$in", u));
 		}
 		if (minPerm != null & !Permission.NONE.equals(minPerm)) {
-			query.put(Fields.ACL_PERM, new BasicDBObject("$gte",
-					minPerm.getPermission()));
+			query.put(Fields.ACL_PERM, new BasicDBObject("$gte", minPerm.getPermission()));
 		}
 		final DBObject proj = new BasicDBObject();
 		proj.put(Fields.MONGO_ID, 0);
@@ -549,11 +563,9 @@ public class QueryMethods {
 		
 		final Map<ResolvedMongoWSID, Map<User, Permission>> wsidToPerms =
 				new HashMap<ResolvedMongoWSID, Map<User, Permission>>();
-		final Map<Long, List<DBObject>> noWS =
-				new HashMap<Long, List<DBObject>>();
+		final Map<Long, List<DBObject>> noWS = new HashMap<Long, List<DBObject>>();
 		try {
-			final DBCursor res = wsmongo.getCollection(workspaceACLCollection)
-					.find(query, proj);
+			final DBCursor res = wsmongo.getCollection(workspaceACLCollection).find(query, proj);
 			for (final DBObject m: res) {
 				final Long id = (Long) m.get(Fields.ACL_WSID);
 				if (!idToWS.containsKey(id)) {
@@ -578,9 +590,8 @@ public class QueryMethods {
 			}
 		}
 		if (!noWS.isEmpty()) {
-			final Map<Long, Map<String, Object>> ws =
-					queryWorkspacesByID(noWS.keySet(), PROJ_WS_ID_NAME_LOCK_DEL,
-							excludeDeletedWorkspaces);
+			final Map<Long, Map<String, Object>> ws = queryWorkspacesByID(
+					noWS.keySet(), PROJ_WS_ID_NAME_LOCK_DEL, excludeDeletedWorkspaces);
 			for (final Long id: ws.keySet()) {
 				final ResolvedMongoWSID wsid = new ResolvedMongoWSID(
 						(String) ws.get(id).get(Fields.WS_NAME),

--- a/src/us/kbase/workspace/kbase/WorkspaceAdministration.java
+++ b/src/us/kbase/workspace/kbase/WorkspaceAdministration.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
 
 import us.kbase.auth.AuthException;
 import us.kbase.auth.AuthToken;
@@ -171,7 +172,7 @@ public class WorkspaceAdministration {
 							params.wsi);
 			final WorkspaceInformation info = ws.setWorkspaceOwner(null, wsi,
 					params.new_user == null ? null :
-					getUser(params.new_user), params.new_name, true);
+					getUser(params.new_user), Optional.fromNullable(params.new_name), true);
 			getLogger().info(SET_WORKSPACE_OWNER + " " + info.getId() + " " +
 					info.getOwner().getUser());
 			return wsInfoToTuple(info);

--- a/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
@@ -83,6 +83,7 @@ import us.kbase.workspace.database.mongo.ResolvedMongoWSID;
 import us.kbase.workspace.test.WorkspaceTestCommon;
 import us.kbase.workspace.test.workspace.WorkspaceTester;
 
+import com.google.common.base.Optional;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.DBCursor;
@@ -346,7 +347,7 @@ public class MongoInternalsTest {
 		
 		//test set ws owner
 		WorkspaceTester.failSetWorkspaceOwner(ws, user1, cloning,
-				new WorkspaceUser("barbaz"), "barbaz", false, noWSExcp);
+				new WorkspaceUser("barbaz"), Optional.of("barbaz"), false, noWSExcp);
 		
 		//test list workspaces
 		List<WorkspaceInformation> wsl = ws.listWorkspaces(

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -280,6 +280,22 @@ public class WorkspaceTest extends WorkspaceTester {
 		ws.setGlobalPermission(SOMEUSER, new WorkspaceIdentifier("foo2"), Permission.NONE);
 	}
 	
+//	@Test
+//	public void adminGetWorkspaceInfo() throws Exception {
+//		WorkspaceUser user = new WorkspaceUser("blahblah");
+//		WorkspaceIdentifier wsi = new WorkspaceIdentifier("somews");
+//		Map<String, String> meta = new HashMap<String, String>();
+//		meta.put("foo", "bar");
+//		meta.put("foo2", "bar2");
+//		
+//		WorkspaceInformation info = ws.createWorkspace(user, wsi.getName(),
+//				false, null, new WorkspaceUserMetadata(meta));
+//		
+//		final WorkspaceInformation wsinfo = ws.getWorkspaceInformationAsAdmin(wsi);
+//		checkWSInfo(wsinfo, user, wsi.getName(), 0, Permission.NONE, false, 1, info.getModDate(),
+//				"unlocked", meta);
+//	}
+	
 	@Test
 	public void workspaceMetadata() throws Exception {
 		WorkspaceUser user = new WorkspaceUser("blahblah");

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -614,14 +614,21 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		//illegal name change to invalid user
 		final Optional<String> newName = Optional.of("bar:wsfoo");
-		failSetWorkspaceOwner(u2, wsi, u1, newName, false,
-				new IllegalArgumentException("Workspace name bar:wsfoo must only contain the user name foo prior to the : delimiter"));
-		failSetWorkspaceOwner(null, wsi, u1, newName, true,
-				new IllegalArgumentException("Workspace name bar:wsfoo must only contain the user name foo prior to the : delimiter"));
+		failSetWorkspaceOwner(u2, wsi, u1, newName, false, new IllegalArgumentException(
+				"Workspace name bar:wsfoo must only contain the user name foo " +
+				"prior to the : delimiter"));
+		failSetWorkspaceOwner(null, wsi, u1, newName, true, new IllegalArgumentException(
+				"Workspace name bar:wsfoo must only contain the user name foo " +
+				"prior to the : delimiter"));
 		
-		//test auto rename of workspace
+		//test failing name when ws is prefixed by previous user name
 		ws.renameWorkspace(u2, wsi, "bar:wsfoo");
 		wsi = new WorkspaceIdentifier("bar:wsfoo");
+		failSetWorkspaceOwner(u2, wsi, u1, Optional.of("bar:wsfoo"), false,
+				new IllegalArgumentException("Workspace name bar:wsfoo must only contain " +
+						"the user name foo prior to the : delimiter"));
+		
+		//test auto rename of workspace
 		wsinfo = ws.setWorkspaceOwner(u2, wsi, u1, Optional.<String>absent(), false);
 		wsi = new WorkspaceIdentifier("foo:wsfoo");
 		checkWSInfo(wsinfo, u1, wsi.getName(), 0L, Permission.OWNER, false, "unlocked", mt);

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -87,6 +87,7 @@ import ch.qos.logback.classic.Logger;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
 import com.mongodb.DB;
 
 @RunWith(Parameterized.class)
@@ -1681,7 +1682,7 @@ public class WorkspaceTester {
 			final WorkspaceUser user,
 			final WorkspaceIdentifier wsi,
 			final WorkspaceUser newuser,
-			final String name,
+			final Optional<String> name,
 			final boolean asAdmin,
 			final Exception expected)
 			throws Exception {
@@ -1693,7 +1694,7 @@ public class WorkspaceTester {
 			final WorkspaceUser user,
 			final WorkspaceIdentifier wsi,
 			final WorkspaceUser newuser,
-			final String name,
+			final Optional<String> name,
 			final boolean asAdmin,
 			final Exception expected)
 			throws Exception {


### PR DESCRIPTION
Mostly code documentation, clarification, and fixing several bugs found while clarifying and documenting code.

Bugs
* No longer suppresses errors when modifying locked workspaces
  * Fortunately only read methods were doing this currently
* Fixed a bug where deleted workspaces were being returned when inappropriate
  * Again, fortunately deleted object checks later in the code meant this bug currently had no impact
* Fixed a bug in setWorkspaceOwner where illegal workspace names could be set based on pretty specific inputs.

Decoupled various getWorkspaceInfo calls from other method calls. The methods now return void and the getWorkspaceInfo calls are pulled up a layer. Also eliminated a getWorkspaceInfo call when cloning a workspace, as all the info to create the WorkspaceInfo object is already available. No need for more DB access.

All of the above simplified the call tree above generateWorkspaceInfo and allowed easier analysis of the impacts of a change to that method. Thus, the method was changed so that it now creates a WI object with NONE permissions if the workspace in question is not in the permission set rather than throwing an exception. The workspace will not be in the permission set in the case of an admin calling getWorkspaceInfo with a null user.