### PR TITLE
TASK-831 Refactor objectresolver & fix bug

### DIFF
--- a/docsource/releasenotes.rst
+++ b/docsource/releasenotes.rst
@@ -26,6 +26,9 @@ UPDATED FEATURES / MAJOR BUG FIXES:
   conversion to auth2.
 * The credentials for the Handle Manager service in the deploy.cfg file now require a token.
 * The credentials for the file backend in the deploy.cfg file now require a token.
+* Fixed a bug where performing a permissions search for a readable, deleted object with an
+  incoming reference from a readable, non-deleted object would fail with a deleted object
+  exception.
 
 VERSION: 0.7.1 (Released 6/22/17)
 ---------------------------------

--- a/src/us/kbase/workspace/database/PermissionsCheckerFactory.java
+++ b/src/us/kbase/workspace/database/PermissionsCheckerFactory.java
@@ -5,6 +5,7 @@ import static us.kbase.workspace.database.Util.noNulls;
 import static us.kbase.common.utils.StringUtils.checkString;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -217,7 +218,7 @@ public class PermissionsCheckerFactory {
 	 * @return a new permissions checker.
 	 */
 	public ObjectPermissionsChecker getObjectChecker(
-			final List<ObjectIdentifier> objects,
+			final Collection<ObjectIdentifier> objects,
 			final Permission perm) {
 		return new ObjectPermissionsChecker(objects, perm);
 	}
@@ -265,10 +266,10 @@ public class PermissionsCheckerFactory {
 	public class ObjectPermissionsChecker extends
 			AbstractObjectPermissionsChecker<ObjectPermissionsChecker> {
 		
-		private final List<ObjectIdentifier> objects;
+		private final Collection<ObjectIdentifier> objects;
 		
 		private ObjectPermissionsChecker(
-				final List<ObjectIdentifier> objects,
+				final Collection<ObjectIdentifier> objects,
 				final Permission perm) {
 			super(perm);
 			nonNull(objects, "objects");

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -910,7 +910,7 @@ public class Workspace {
 				ReferenceSearchMaximumSizeExceededException, NoSuchObjectException {
 		
 		final ObjectResolver.Builder orb = ObjectResolver.getBuilder(db, user)
-				.withNullIfInaccessible(nullIfInaccessible)
+				.withIgnoreInaccessible(nullIfInaccessible)
 				.withMaximumObjectsSearched(maximumObjectSearchCount);
 		for (final ObjectIdentifier oi: loi) {
 			orb.withObject(oi);
@@ -1179,7 +1179,7 @@ public class Workspace {
 				NoSuchObjectException {
 	
 		final ObjectResolver.Builder orb = ObjectResolver.getBuilder(db, user)
-				.withNullIfInaccessible(nullIfInaccessible)
+				.withIgnoreInaccessible(nullIfInaccessible)
 				.withMaximumObjectsSearched(maximumObjectSearchCount);
 		for (final ObjectIdentifier oi: loi) {
 			orb.withObject(oi);

--- a/src/us/kbase/workspace/database/WorkspaceDatabase.java
+++ b/src/us/kbase/workspace/database/WorkspaceDatabase.java
@@ -388,6 +388,8 @@ public interface WorkspaceDatabase {
 			throws WorkspaceCommunicationException, NoSuchObjectException;
 	
 	/** Get information about a set of objects.
+	 * 
+	 * Note that the reference path provided is always simply the reference of the object.
 	 * @param objectIDs the object IDs for which to retrieve information.
 	 * @param includeMetadata true to return user supplied metadata with the
 	 * information.

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -2953,15 +2953,22 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		//there's a possibility of a race condition here if a workspace is
 		//deleted and undeleted or vice versa in a very short amount of time,
 		//but that seems so unlikely it's not worth the code
+		
+		if (delete) {
+			// delete objects first so that we can't have undeleted object in a deleted workspace 
+			setObjectsDeleted(rwsi, new ArrayList<Long>(), delete);
+		}
 		try {
-			wsjongo.getCollection(COL_WORKSPACES).update(
-							M_DELWS_UPD, rwsi.getID())
+			wsjongo.getCollection(COL_WORKSPACES).update(M_DELWS_UPD, rwsi.getID())
 					.with(M_DELWS_WTH, delete, new Date());
 		} catch (MongoException me) {
 			throw new WorkspaceCommunicationException(
 					"There was a problem communicating with the database", me);
 		}
-		setObjectsDeleted(rwsi, new ArrayList<Long>(), delete);
+		if (!delete) {
+			//undelete object last so we yadda yadda
+			setObjectsDeleted(rwsi, new ArrayList<Long>(), delete);
+		}
 	}
 	
 	@Override

--- a/src/us/kbase/workspace/test/workspace/ObjectResolverTest.java
+++ b/src/us/kbase/workspace/test/workspace/ObjectResolverTest.java
@@ -1,0 +1,85 @@
+package us.kbase.workspace.test.workspace;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static us.kbase.common.test.TestCommon.set;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.workspace.database.AllUsers;
+import us.kbase.workspace.database.ObjectIDResolvedWS;
+import us.kbase.workspace.database.ObjectIDWithRefPath;
+import us.kbase.workspace.database.ObjectIdentifier;
+import us.kbase.workspace.database.ObjectReferenceSet;
+import us.kbase.workspace.database.ObjectResolver;
+import us.kbase.workspace.database.ObjectResolver.ObjectResolution;
+import us.kbase.workspace.database.Permission;
+import us.kbase.workspace.database.PermissionSet;
+import us.kbase.workspace.database.Reference;
+import us.kbase.workspace.database.ResolvedWorkspaceID;
+import us.kbase.workspace.database.WorkspaceDatabase;
+import us.kbase.workspace.database.WorkspaceIdentifier;
+import us.kbase.workspace.database.WorkspaceUser;
+
+public class ObjectResolverTest {
+
+	/* ObjectResolver is, as of 6/25/17, mostly covered by WorkspaceTest. New tests should
+	 * be written here and old tests moved to start slimming down the insanity of the latter class.
+	 */
+	//TODO TEST add tests for 100% coverage of ObjectResolver
+	
+	@Test
+	public void searchOnReadableDeletedObject() throws Exception {
+		// tests a bug where a deleted but readable object would not be accessible via search
+		final WorkspaceDatabase wsdb = mock(WorkspaceDatabase.class);
+		
+		final WorkspaceIdentifier wsi = new WorkspaceIdentifier("wsfoo");
+		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(3, "wsfoo", false, false);
+		final ObjectIdentifier objid = new ObjectIdentifier(wsi, "objfoo");
+		
+		final ObjectIDWithRefPath obj = new ObjectIDWithRefPath(objid);
+		final ObjectIDResolvedWS objresws = new ObjectIDResolvedWS(rwsi, "objfoo");
+		final Reference ref = new Reference("3/24/1");
+		final Reference topref = new Reference("3/27/1");
+		final ObjectIDResolvedWS objres = new ObjectIDResolvedWS(rwsi, 24, 1);
+		
+		final WorkspaceUser user = new WorkspaceUser("userfoo");
+		
+		when(wsdb.getPermissions(user, Permission.READ, false)).thenReturn(
+				PermissionSet.getBuilder(user, new AllUsers('*'))
+				.withWorkspace(rwsi, Permission.READ, Permission.NONE)
+				.build());
+		when(wsdb.resolveWorkspaces(set(wsi), true)).thenReturn(ImmutableMap.of(wsi, rwsi));
+		when(wsdb.getPermissions(user, set(rwsi))).thenReturn(
+				PermissionSet.getBuilder(user, new AllUsers('*'))
+				.withWorkspace(rwsi, Permission.READ, Permission.NONE)
+				.build());
+		when(wsdb.getObjectReference(set(objresws))).thenReturn(ImmutableMap.of(
+				objresws, ref));
+		when(wsdb.getObjectExistsRef(set(ref))).thenReturn(ImmutableMap.of(ref, false));
+		when(wsdb.getObjectIncomingReferences(set(ref))).thenReturn(ImmutableMap.of(
+				ref, new ObjectReferenceSet(ref, set(topref), true)));
+		when(wsdb.getObjectExistsRef(set(topref))).thenReturn(ImmutableMap.of(topref, true));
+		
+		final ObjectResolver or = ObjectResolver.getBuilder(wsdb, user)
+				.withObject(obj).resolve();
+		
+		assertThat("incorrect objects", or.getObjects(), is(Arrays.asList(obj)));
+		assertThat("incorrect object resolution", or.getObjectResolution(obj),
+				is(ObjectResolution.PATH));
+		assertThat("incorrect path objects", or.getObjects(true), is(set(obj)));
+		assertThat("incorrect pathless objects", or.getObjects(false), is(set()));
+		assertThat("incorrect resolved object", or.getResolvedObject(obj), is(objres));
+		assertThat("incorrect path resolved objects", or.getResolvedObjects(true),
+				is(set(objres)));
+		assertThat("incorrect pathless resolved objects", or.getResolvedObjects(false), is(set()));
+		assertThat("incorrect ref path", or.getReferencePath(obj), is(Arrays.asList(
+				topref, ref)));
+	}
+}


### PR DESCRIPTION
If an object was set for search, was in a readable workspace, and was
deleted, the lookup would fail even if there was a valid reference path
to the object.

The refactor to fix this bug also led to simplification of the search
code.