### PR TITLE
TASK-833 Add event listener framework

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -58,7 +58,6 @@
 	<classpathentry kind="lib" path="/jars/lib/jars/kbase/shock/shock-client-0.0.14.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/kbase/handle/HandleManagerClient-160803-08c8da3.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/kbase/handle/HandleServiceClient-160803-b9de699.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/kbase/common/kbase-common-0.0.24.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/kbase/auth/kbase-auth-0.4.4.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/equalsverifier/equalsverifier-2.2.2.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/junit/junit-4.12.jar"/>
@@ -67,5 +66,6 @@
 	<classpathentry kind="lib" path="/jars/lib/jars/bytebuddy/byte-buddy-1.6.8.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/bytebuddy/byte-buddy-agent-1.6.8.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/objenesis/objenesis-2.5.1.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/kbase/common/kbase-common-0.0.24.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/deploy.cfg.example
+++ b/deploy.cfg.example
@@ -13,13 +13,13 @@ mongodb-database = workspace
 # password for the account
 #mongodb-pwd = add password here
 
-# The KBase authorization server url.
+# the KBase authorization server url.
 auth-service-url = https://kbase.us/services/auth/api/legacy/KBase/Sessions/Login
 
-# The Globus v1 authorization API url.
+# the Globus v1 authorization API url.
 globus-url = https://kbase.us/services/auth/api/legacy/globus/
 
-# The urls for the Handle Service and Handle Manager.
+# the urls for the Handle Service and Handle Manager.
 handle-service-url =
 handle-manager-url =
 # The token used to access the handle manager.
@@ -30,7 +30,7 @@ handle-manager-token =
 # is changed and the server restarted.
 ws-admin = workspaceadmin
 
-# Token for the backend account (e.g. shock if used).
+# token for the backend account (e.g. shock if used).
 backend-token =
 
 # port for the service.
@@ -40,23 +40,36 @@ port = 7058
 # processed simultaneously.
 server-threads = 20
 
-#Minimum memory size in MB. This must be 500Mb * server-threads.
+# minimum memory size in MB. This must be 500Mb * server-threads.
 min-memory = 10000
 
-#Maximum memory size in MB.
+# maximum memory size in MB.
 max-memory = 15000
 
 # directory for temporary files. Maximum usage is 10GB * server-threads.
 # Ideally, this will be on an SSD drive for speed.
 temp-dir = ws_temp_dir
 
-# Document server name. Used for logging.
+# active listeners - a comma separated list, by name, of event listeners that will be registered.
+# Add or remove a name from the list in order to activate or deactivate a listener.
+# listeners=X
+
+# any listener factory implementations and their configurations, grouped by the names in the
+# listeners configuration parameter. The listener configuration will be provided to the listener as a
+# key-value map. Example:
+# listener-X-class=us.kbase.workspace.database.listener.NullListenerFactory
+# listener-X-config-key1=value1
+# listener-X-config-key2=value2
+# listener-X-config-printEvents=true
+# listener-X-config-throwException=false
+
+# document server name. Used for logging.
 doc-server-name = WorkspaceDocServ
 # Document server document location relative to the classpath. If this
 # variable is changed it must also be changed in build.xml
 doc-server-docs-location = /server_docs
 
-# MongoDB reconnect retry count. The workspace will try to reconnect 1/s until
+# mongoDB reconnect retry count. The workspace will try to reconnect 1/s until
 # this limit has been reached. This is useful for starting the Workspace
 # automatically after a server restart, as MongoDB can take quite a while to
 # get from start to accepting connections.

--- a/src/us/kbase/typedobj/core/TypedObjectValidator.java
+++ b/src/us/kbase/typedobj/core/TypedObjectValidator.java
@@ -56,7 +56,7 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSet.TooManyIdsException;
  * @author gaprice@lbl.gov
  * @author rsutormin
  */
-public final class TypedObjectValidator {
+public class TypedObjectValidator {
 	
 	private static final boolean VERBOSE_EXCEPTIONS = false;
 	

--- a/src/us/kbase/workspace/database/ResourceUsageConfigurationBuilder.java
+++ b/src/us/kbase/workspace/database/ResourceUsageConfigurationBuilder.java
@@ -164,6 +164,58 @@ public class ResourceUsageConfigurationBuilder {
 		public long getMaxReturnedDataSize() {
 			return maxReturnedDataSize;
 		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + getOuterType().hashCode();
+			result = prime * result + maxIncomingDataMemoryUsage;
+			result = prime * result + maxObjectSize;
+			result = prime * result + maxRelabelAndSortMemoryUsage;
+			result = prime * result + maxReturnedDataMemoryUsage;
+			result = prime * result + (int) (maxReturnedDataSize ^ (maxReturnedDataSize >>> 32));
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+			ResourceUsageConfiguration other = (ResourceUsageConfiguration) obj;
+			if (!getOuterType().equals(other.getOuterType())) {
+				return false;
+			}
+			if (maxIncomingDataMemoryUsage != other.maxIncomingDataMemoryUsage) {
+				return false;
+			}
+			if (maxObjectSize != other.maxObjectSize) {
+				return false;
+			}
+			if (maxRelabelAndSortMemoryUsage != other.maxRelabelAndSortMemoryUsage) {
+				return false;
+			}
+			if (maxReturnedDataMemoryUsage != other.maxReturnedDataMemoryUsage) {
+				return false;
+			}
+			if (maxReturnedDataSize != other.maxReturnedDataSize) {
+				return false;
+			}
+			return true;
+		}
+
+		private ResourceUsageConfigurationBuilder getOuterType() {
+			return ResourceUsageConfigurationBuilder.this;
+		}
+		
+		
 	}
 
 }

--- a/src/us/kbase/workspace/database/WorkspaceInformation.java
+++ b/src/us/kbase/workspace/database/WorkspaceInformation.java
@@ -4,13 +4,15 @@ import java.util.Date;
 
 public interface WorkspaceInformation {
 	
+	//TODO NOW get rid of this interface and make a value class with a builder.
+	//TODO CODE add is deleted.
+	
 	public long getId();
 	public String getName();
 	public WorkspaceUser getOwner();
 	public Date getModDate();
-	public long getApproximateObjects();
+	public long getApproximateObjects(); //TODO NOW change to max objects
 	public Permission getUserPermission();
-	//TODO CODE decouple the permissions and the ws info.
 	public boolean isGloballyReadable();
 	public boolean isLocked();
 	public String getLockState();

--- a/src/us/kbase/workspace/listener/BadListenerFactory.java
+++ b/src/us/kbase/workspace/listener/BadListenerFactory.java
@@ -1,0 +1,29 @@
+package us.kbase.workspace.listener;
+
+import java.util.Map;
+
+/** Doesn't have a zero argument constructor, and so fails to start.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class BadListenerFactory implements WorkspaceEventListenerFactory {
+
+	public BadListenerFactory(final int foo) {}
+	
+	@Override
+	public WorkspaceEventListener configure(Map<String, String> cfg)
+			throws ListenerInitializationException {
+		return new BadListener();
+	}
+	
+	public class BadListener implements WorkspaceEventListener {
+
+		@Override
+		public void createWorkspace(long id) {}
+
+		@Override
+		public void cloneWorkspace(long id) {}
+		
+	}
+
+}

--- a/src/us/kbase/workspace/listener/ListenerInitializationException.java
+++ b/src/us/kbase/workspace/listener/ListenerInitializationException.java
@@ -1,0 +1,15 @@
+package us.kbase.workspace.listener;
+
+/** Thrown when a workspace event listener cannot be initialized.
+ * @author gaprice@lbl.gov
+ *
+ */
+@SuppressWarnings("serial")
+public class ListenerInitializationException extends Exception {
+	
+	public ListenerInitializationException(final String message) {
+		super(message);
+	}
+	
+
+}

--- a/src/us/kbase/workspace/listener/NullListenerFactory.java
+++ b/src/us/kbase/workspace/listener/NullListenerFactory.java
@@ -1,0 +1,47 @@
+package us.kbase.workspace.listener;
+
+import java.util.Map;
+
+/** A trivial example of a listener implementation.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class NullListenerFactory implements WorkspaceEventListenerFactory {
+
+	@Override
+	public WorkspaceEventListener configure(final Map<String, String> cfg)
+			throws ListenerInitializationException {
+		final boolean printEvents = "true".equals(cfg.get("printEvents"));
+		if ("true".equals(cfg.get("throwException"))) {
+			throw new ListenerInitializationException("But you told me to! It's so not fair!");
+		}
+		return new NullEventListener(printEvents);
+	}
+	
+	public static class NullEventListener implements WorkspaceEventListener {
+		
+		private final boolean printEvents;
+		
+		private NullEventListener(final boolean printEvents) {
+			this.printEvents = printEvents;
+		}
+		
+		private void print(final String s) {
+			if (printEvents) {
+				System.out.println(s);
+			}
+		}
+
+		@Override
+		public void createWorkspace(long id) {
+			print("createWorkspace " + id);
+		}
+
+		@Override
+		public void cloneWorkspace(long id) {
+			print("cloneWorkspace " + id);
+		}
+
+	}
+
+}

--- a/src/us/kbase/workspace/listener/WorkspaceEventListener.java
+++ b/src/us/kbase/workspace/listener/WorkspaceEventListener.java
@@ -1,0 +1,23 @@
+package us.kbase.workspace.listener;
+
+/** A listener for workspace events.
+ * @author gaprice@lbl.gov
+ * 
+ * @see WorkspaceEventListenerFactory
+ *
+ */
+public interface WorkspaceEventListener {
+	
+	/** Notification that a workspace was created.
+	 * @param id the workspace ID.
+	 */
+	void createWorkspace(final long id);
+	
+	/** Notification that a workspace was cloned.
+	 * @param id the workspace ID.
+	 */
+	void cloneWorkspace(final long id);
+	
+	//TODO NOW add more events & test
+
+}

--- a/src/us/kbase/workspace/listener/WorkspaceEventListenerFactory.java
+++ b/src/us/kbase/workspace/listener/WorkspaceEventListenerFactory.java
@@ -1,0 +1,19 @@
+package us.kbase.workspace.listener;
+
+import java.util.Map;
+
+/** A configuration agent for a workspace event listener. Given a configuration,
+ * properly creates and configures an event listener.
+ * @author gaprice@lbl.gov
+ *
+ */
+public interface WorkspaceEventListenerFactory {
+	
+	/** Given a configuration, creates a listener.
+	 * @param cfg the listener configuration.
+	 * @return the new listener.
+	 * @throws ListenerInitializationException if the listener could not be initialized.
+	 */
+	WorkspaceEventListener configure(Map<String, String> cfg)
+			throws ListenerInitializationException;
+}

--- a/src/us/kbase/workspace/listener/package-info.java
+++ b/src/us/kbase/workspace/listener/package-info.java
@@ -1,0 +1,5 @@
+/** Interfaces for workspace event listeners.
+ * @author gaprice@lbl.gov
+ *
+ */
+package us.kbase.workspace.listener;

--- a/src/us/kbase/workspace/test/workspace/WorkspaceConstructorTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceConstructorTest.java
@@ -1,0 +1,112 @@
+package us.kbase.workspace.test.workspace;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import us.kbase.common.test.TestCommon;
+import us.kbase.typedobj.core.TypedObjectValidator;
+import us.kbase.workspace.database.ResourceUsageConfigurationBuilder;
+import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
+import us.kbase.workspace.database.Workspace;
+import us.kbase.workspace.database.WorkspaceDatabase;
+import us.kbase.workspace.listener.WorkspaceEventListener;
+
+public class WorkspaceConstructorTest {
+
+	@Test
+	public void construct3() throws Exception {
+		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
+		final TypedObjectValidator tv = mock(TypedObjectValidator.class);
+		final ResourceUsageConfiguration cfg = new ResourceUsageConfigurationBuilder()
+				.withMaxObjectSize(3).build();
+		
+		final Workspace ws = new Workspace(db, cfg, tv);
+		
+		assertThat("incorrect resource cfg", ws.getResourceConfig(), is(cfg));
+		assertThat("incorrect max search count", ws.getMaximumObjectSearchCount(), is(10000));
+		
+		// not worth the trouble to run something to check that the db and val are set. If not,
+		// lots of other tests will fail
+	}
+	
+	@Test
+	public void construct4() throws Exception {
+		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
+		final TypedObjectValidator tv = mock(TypedObjectValidator.class);
+		final ResourceUsageConfiguration cfg = new ResourceUsageConfigurationBuilder()
+				.withMaxObjectSize(3).build();
+		final WorkspaceEventListener l = mock(WorkspaceEventListener.class);
+		
+		final Workspace ws = new Workspace(db, cfg, tv, Arrays.asList(l));
+		
+		assertThat("incorrect resource cfg", ws.getResourceConfig(), is(cfg));
+		assertThat("incorrect max search count", ws.getMaximumObjectSearchCount(), is(10000));
+		
+		// not worth the trouble to run something to check that the db, val, and l are set. If not,
+		// lots of other tests will fail
+	}
+	
+	@Test
+	public void construct3Fail() throws Exception {
+		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
+		final TypedObjectValidator tv = mock(TypedObjectValidator.class);
+		final ResourceUsageConfiguration cfg = new ResourceUsageConfigurationBuilder()
+				.withMaxObjectSize(3).build();
+		
+		failConstruct(null, cfg, tv, new NullPointerException("db cannot be null"));
+		failConstruct(db, null, tv, new NullPointerException("cfg cannot be null"));
+		failConstruct(db, cfg, null, new NullPointerException("validator cannot be null"));
+	}
+	
+	@Test
+	public void construct4Fail() throws Exception {
+		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
+		final TypedObjectValidator tv = mock(TypedObjectValidator.class);
+		final ResourceUsageConfiguration cfg = new ResourceUsageConfigurationBuilder()
+				.withMaxObjectSize(3).build();
+		final WorkspaceEventListener wel = mock(WorkspaceEventListener.class);
+		final List<WorkspaceEventListener> l = Arrays.asList(wel);
+		
+		
+		failConstruct(null, cfg, tv, l, new NullPointerException("db cannot be null"));
+		failConstruct(db, null, tv, l, new NullPointerException("cfg cannot be null"));
+		failConstruct(db, cfg, null, l, new NullPointerException("validator cannot be null"));
+		failConstruct(db, cfg, tv, null, new NullPointerException("listeners"));
+		failConstruct(db, cfg, tv, Arrays.asList(wel, null),
+				new NullPointerException("null item in listeners"));
+	}
+
+	private void failConstruct(
+			final WorkspaceDatabase db,
+			final ResourceUsageConfiguration cfg,
+			final TypedObjectValidator tv,
+			final Exception e) {
+		try {
+			new Workspace(db, cfg, tv);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+	private void failConstruct(
+			final WorkspaceDatabase db,
+			final ResourceUsageConfiguration cfg,
+			final TypedObjectValidator tv,
+			final List<WorkspaceEventListener> l,
+			final Exception e) {
+		try {
+			new Workspace(db, cfg, tv, l);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+}

--- a/src/us/kbase/workspace/test/workspace/WorkspaceListenerTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceListenerTest.java
@@ -1,0 +1,141 @@
+package us.kbase.workspace.test.workspace;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static us.kbase.common.test.TestCommon.set;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.typedobj.core.TypedObjectValidator;
+import us.kbase.workspace.database.AllUsers;
+import us.kbase.workspace.database.Permission;
+import us.kbase.workspace.database.PermissionSet;
+import us.kbase.workspace.database.ResolvedWorkspaceID;
+import us.kbase.workspace.database.ResourceUsageConfigurationBuilder;
+import us.kbase.workspace.database.Workspace;
+import us.kbase.workspace.database.WorkspaceDatabase;
+import us.kbase.workspace.database.WorkspaceIdentifier;
+import us.kbase.workspace.database.WorkspaceInformation;
+import us.kbase.workspace.database.WorkspaceUser;
+import us.kbase.workspace.database.WorkspaceUserMetadata;
+import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
+import us.kbase.workspace.listener.WorkspaceEventListener;
+
+public class WorkspaceListenerTest {
+
+	@Test
+	public void createWorkspace1Listener() throws Exception {
+		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
+		final TypedObjectValidator tv = mock(TypedObjectValidator.class);
+		final ResourceUsageConfiguration cfg = new ResourceUsageConfigurationBuilder().build();
+		final WorkspaceEventListener l = mock(WorkspaceEventListener.class);
+		final WorkspaceUserMetadata meta = new WorkspaceUserMetadata();
+		
+		//TODO NOW change to value class
+		final WorkspaceInformation info = mock(WorkspaceInformation.class);
+		
+		final Workspace ws = new Workspace(db, cfg, tv, Arrays.asList(l));
+		
+		when(db.createWorkspace(new WorkspaceUser("foo"), "ws", false, null, meta))
+				.thenReturn(info);
+		
+		when(info.getId()).thenReturn(6L);
+		
+		ws.createWorkspace(new WorkspaceUser("foo"), "ws", false, null, null);
+		
+		verify(l).createWorkspace(6L);
+	}
+	
+	@Test
+	public void createWorkspace2Listeners() throws Exception {
+		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
+		final TypedObjectValidator tv = mock(TypedObjectValidator.class);
+		final ResourceUsageConfiguration cfg = new ResourceUsageConfigurationBuilder().build();
+		final WorkspaceEventListener l1 = mock(WorkspaceEventListener.class);
+		final WorkspaceEventListener l2 = mock(WorkspaceEventListener.class);
+		final WorkspaceUserMetadata meta = new WorkspaceUserMetadata();
+		
+		//TODO NOW change to value class
+		final WorkspaceInformation info = mock(WorkspaceInformation.class);
+		
+		final Workspace ws = new Workspace(db, cfg, tv, Arrays.asList(l1, l2));
+		
+		when(db.createWorkspace(new WorkspaceUser("foo"), "ws", false, null, meta))
+				.thenReturn(info);
+		
+		when(info.getId()).thenReturn(6L);
+		
+		ws.createWorkspace(new WorkspaceUser("foo"), "ws", false, null, null);
+		
+		verify(l1).createWorkspace(6L);
+		verify(l2).createWorkspace(6L);
+	}
+	
+	@Test
+	public void cloneWorkspace1Listener() throws Exception {
+		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
+		final TypedObjectValidator tv = mock(TypedObjectValidator.class);
+		final ResourceUsageConfiguration cfg = new ResourceUsageConfigurationBuilder().build();
+		final WorkspaceEventListener l = mock(WorkspaceEventListener.class);
+		final WorkspaceUserMetadata meta = new WorkspaceUserMetadata();
+		
+		final WorkspaceUser user = new WorkspaceUser("foo");
+		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
+		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ugh", false, false);
+		
+		//TODO NOW change to value class
+		final WorkspaceInformation info = mock(WorkspaceInformation.class);
+		
+		final Workspace ws = new Workspace(db, cfg, tv, Arrays.asList(l));
+		
+		when(db.resolveWorkspaces(set(wsi))).thenReturn(ImmutableMap.of(wsi, rwsi));
+		when(db.getPermissions(user, set(rwsi))).thenReturn(
+				PermissionSet.getBuilder(user, new AllUsers('*'))
+						.withWorkspace(rwsi, Permission.READ, Permission.NONE).build());
+		when(db.cloneWorkspace(user, rwsi, "whee", false, null, meta, null)).thenReturn(info);
+		
+		when(info.getId()).thenReturn(7L);
+		
+		ws.cloneWorkspace(user, wsi, "whee", false, null, null, null);
+		
+		verify(l).cloneWorkspace(7L);
+	}
+	
+	@Test
+	public void cloneWorkspace2Listeners() throws Exception {
+		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
+		final TypedObjectValidator tv = mock(TypedObjectValidator.class);
+		final ResourceUsageConfiguration cfg = new ResourceUsageConfigurationBuilder().build();
+		final WorkspaceEventListener l1 = mock(WorkspaceEventListener.class);
+		final WorkspaceEventListener l2 = mock(WorkspaceEventListener.class);
+		final WorkspaceUserMetadata meta = new WorkspaceUserMetadata();
+		
+		final WorkspaceUser user = new WorkspaceUser("foo");
+		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
+		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ugh", false, false);
+		
+		//TODO NOW change to value class
+		final WorkspaceInformation info = mock(WorkspaceInformation.class);
+		
+		final Workspace ws = new Workspace(db, cfg, tv, Arrays.asList(l1, l2));
+		
+		when(db.resolveWorkspaces(set(wsi))).thenReturn(ImmutableMap.of(wsi, rwsi));
+		when(db.getPermissions(user, set(rwsi))).thenReturn(
+				PermissionSet.getBuilder(user, new AllUsers('*'))
+						.withWorkspace(rwsi, Permission.READ, Permission.NONE).build());
+		when(db.cloneWorkspace(user, rwsi, "whee", false, null, meta, null)).thenReturn(info);
+		
+		when(info.getId()).thenReturn(7L);
+		
+		ws.cloneWorkspace(user, wsi, "whee", false, null, null, null);
+		
+		verify(l1).cloneWorkspace(7L);
+		verify(l2).cloneWorkspace(7L);
+	}
+	
+}


### PR DESCRIPTION
Allows implementing and loading workspace event listeners at startup without touching workspace code.

Currently only listens to workspace create and clone events. 

TODO Add other events of interest.