### PR TITLE
Sort listObject output when possible, new indexes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -289,6 +289,7 @@
       <src path="${test}"/>
       <exclude name="performance/**"/>
       <exclude name="debugging/**"/>
+      <exclude name="sorting/**"/>
     </javac>
     <junit fork="yes" failureproperty="test.failed">
       <classpath refid="test.client.import.classpath"/>

--- a/docsource/releasenotes.rst
+++ b/docsource/releasenotes.rst
@@ -9,19 +9,27 @@ BACKWARDS INCOMPATIBILITIES:
 * Building and running the service now requires Java 8.
 * The ``getPermissions`` administration command, like the ``get_permissions`` method, is now
   deprecated.
+  
+ADMIN NOTES:
+
+* Two new indexes have been added to the workspace versions mongo collection:
+    * the index ``{savedby: 1}`` with no options
+    * the index ``{ws: 1, id: 1, ver: -1}`` with ``{unique: 1}``
 
 NEW FEATURES:
 
 * Adds a workspace event listener API. Event listeners must implement the
   ``us.kbase.workspace.listener.WorkspaceEventListenerFactory`` and ``WorkspaceEventListener``
   interfaces. Specify listeners to be loaded on start up in the ``deploy.cfg`` file (see
-  ``deploy.cfg.example`` for an example. See
+  ``deploy.cfg.example`` for an example). See
   ``us.kbase.workspace.test.listener.NullListenerFactory`` for an example implementation.
 * Added the ``getPermissionsMass`` administration command.
 * Added the ``getWorkspaceInfo`` administration command.
 * Added the ``listObjects`` administration command.
 * Added the ``getObjectInfo`` administration command.
 * Added the ``getObjects`` administration command.
+* ``list_objects`` will now sort the output if no filters other than the object id filters are
+  applied. The sort order is workspace id ascending, object id ascending, and version descending.
 
 UPDATED FEATURES / MAJOR BUG FIXES:
 
@@ -29,10 +37,10 @@ UPDATED FEATURES / MAJOR BUG FIXES:
 * Fixed a bug where the administrator ``setWorkspaceOwner`` command in very specific
   cases could allow setting an illegal workspace name.
 * Fixed a bug where an admin could delete a locked workspace.
-* Removed ``kbase-admin`` credentials from the deploy.cfg file as they're obsolete after the
+* Removed ``kbase-admin`` credentials from the ``deploy.cfg`` file as they're obsolete after the
   conversion to auth2.
-* The credentials for the Handle Manager service in the deploy.cfg file now require a token.
-* The credentials for the file backend in the deploy.cfg file now require a token.
+* The credentials for the Handle Manager service in the ``deploy.cfg`` file now require a token.
+* The credentials for the file backend in the ``deploy.cfg`` file now require a token.
 * Fixed a bug where performing a permissions search for a readable, deleted object with an
   incoming reference from a readable, non-deleted object would fail with a deleted object
   exception.

--- a/src/us/kbase/workspace/database/GetObjectInformationParameters.java
+++ b/src/us/kbase/workspace/database/GetObjectInformationParameters.java
@@ -6,7 +6,7 @@ import java.util.List;
 import us.kbase.typedobj.core.TypeDefId;
 
 /** Parameters for the WorkspaceDatabase getObjectInformation method.
- * Created from ListObjectsParameters.
+ * Created from {@link ListObjectsParameters}.
  * 
  * @author gaprice@lbl.gov
  *
@@ -170,5 +170,20 @@ public class GetObjectInformationParameters {
 	 */
 	public boolean asAdmin() {
 		return asAdmin;
+	}
+	
+	/** Check if there are no filters set other than the object ID filters. The object ID filters
+	 * may or may not be set.
+	 * The other filters are the two date filters, the metadata filter, the savers filter, and
+	 * the type filter.
+	 * @return true if no filters other than the object ID filters are set.
+	 */
+	public boolean isObjectIDFiltersOnly() {
+		boolean oidFiltersOnly = after == null;
+		oidFiltersOnly = oidFiltersOnly && before == null;
+		oidFiltersOnly = oidFiltersOnly && meta.isEmpty();
+		oidFiltersOnly = oidFiltersOnly && savers.isEmpty();
+		oidFiltersOnly = oidFiltersOnly && type == null; // must have workspaces specified
+		return oidFiltersOnly;
 	}
 }

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -120,79 +120,83 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 	
 	private final TempFilesManager tfm;
 	
-	private static final Map<String, Map<List<String>, List<String>>> INDEXES;
 	private static final String IDX_UNIQ = "unique";
 	private static final String IDX_SPARSE = "sparse";
-	static {
+	
+	private HashMap<String, List<IndexSpecification>> getIndexSpecs() {
+		// should probably rework this and the index spec class
 		//hardcoded indexes
-		INDEXES = new HashMap<String, Map<List<String>, List<String>>>();
+		final HashMap<String, List<IndexSpecification>> indexes = new HashMap<>();
 		
 		//workspaces indexes
-		Map<List<String>, List<String>> ws = new HashMap<List<String>, List<String>>();
+		final LinkedList<IndexSpecification> ws = new LinkedList<>();
 		//find workspaces you own
-		ws.put(Arrays.asList(Fields.WS_OWNER), Arrays.asList(""));
+		ws.add(idxSpec(Fields.WS_OWNER, 1));
 		//find workspaces by permanent id
-		ws.put(Arrays.asList(Fields.WS_ID), Arrays.asList(IDX_UNIQ));
+		ws.add(idxSpec(Fields.WS_ID, 1, IDX_UNIQ));
 		//find workspaces by mutable name
-		ws.put(Arrays.asList(Fields.WS_NAME), Arrays.asList(IDX_UNIQ));
+		ws.add(idxSpec(Fields.WS_NAME, 1, IDX_UNIQ));
 		//find workspaces by metadata
-		ws.put(Arrays.asList(Fields.WS_META), Arrays.asList(IDX_SPARSE));
-		INDEXES.put(COL_WORKSPACES, ws);
+		ws.add(idxSpec(Fields.WS_META, 1, IDX_SPARSE));
+		indexes.put(COL_WORKSPACES, ws);
 		
 		//workspace acl indexes
-		Map<List<String>, List<String>> wsACL = new HashMap<List<String>, List<String>>();
+		final LinkedList<IndexSpecification> wsACL = new LinkedList<>();
 		//get a user's permission for a workspace, index covers queries
-		wsACL.put(Arrays.asList(Fields.ACL_WSID, Fields.ACL_USER, Fields.ACL_PERM), Arrays.asList(IDX_UNIQ));
+		wsACL.add(idxSpec(Fields.ACL_WSID, 1, Fields.ACL_USER, 1, Fields.ACL_PERM, 1, IDX_UNIQ));
 		//find workspaces to which a user has some level of permission, index coves queries
-		wsACL.put(Arrays.asList(Fields.ACL_USER, Fields.ACL_PERM, Fields.ACL_WSID), Arrays.asList(""));
-		INDEXES.put(COL_WS_ACLS, wsACL);
+		wsACL.add(idxSpec(Fields.ACL_USER, 1, Fields.ACL_PERM, 1, Fields.ACL_WSID, 1));
+		indexes.put(COL_WS_ACLS, wsACL);
 		
 		//workspace object indexes
-		Map<List<String>, List<String>> wsObj = new HashMap<List<String>, List<String>>();
+		final LinkedList<IndexSpecification> wsObj = new LinkedList<>();
 		//find objects by workspace id & name
-		wsObj.put(Arrays.asList(Fields.OBJ_WS_ID, Fields.OBJ_NAME), Arrays.asList(IDX_UNIQ));
+		wsObj.add(idxSpec(Fields.OBJ_WS_ID, 1, Fields.OBJ_NAME, 1, IDX_UNIQ));
 		//find object by workspace id & object id
-		wsObj.put(Arrays.asList(Fields.OBJ_WS_ID, Fields.OBJ_ID), Arrays.asList(IDX_UNIQ));
+		wsObj.add(idxSpec(Fields.OBJ_WS_ID, 1, Fields.OBJ_ID, 1, IDX_UNIQ));
 		//find recently modified objects
-		wsObj.put(Arrays.asList(Fields.OBJ_MODDATE), Arrays.asList(""));
+		wsObj.add(idxSpec(Fields.OBJ_MODDATE, 1));
 		//find object to garbage collect
-		wsObj.put(Arrays.asList(Fields.OBJ_DEL, Fields.OBJ_REFCOUNTS), Arrays.asList(""));
-		INDEXES.put(COL_WORKSPACE_OBJS, wsObj);
+		wsObj.add(idxSpec(Fields.OBJ_DEL, 1, Fields.OBJ_REFCOUNTS, 1));
+		indexes.put(COL_WORKSPACE_OBJS, wsObj);
 
 		//workspace object version indexes
-		Map<List<String>, List<String>> wsVer = new HashMap<List<String>, List<String>>();
-		//find versions
-		wsVer.put(Arrays.asList(Fields.VER_WS_ID, Fields.VER_ID,
-				Fields.VER_VER), Arrays.asList(IDX_UNIQ));
+		final LinkedList<IndexSpecification> wsVer = new LinkedList<>();
+		//find versions (might not be needed any more given next index, but keep around for now)
+		wsVer.add(idxSpec(Fields.VER_WS_ID, 1, Fields.VER_ID, 1, Fields.VER_VER, 1, IDX_UNIQ));
+		//find versions and sort descending on version
+		wsVer.add(idxSpec(Fields.VER_WS_ID, 1, Fields.VER_ID, 1, Fields.VER_VER, -1, IDX_UNIQ));
 		//find versions by data object
-		wsVer.put(Arrays.asList(Fields.VER_TYPE, Fields.VER_CHKSUM), Arrays.asList(""));
+		wsVer.add(idxSpec(Fields.VER_TYPE, 1, Fields.VER_CHKSUM, 1));
+		//find versions by user
+		wsVer.add(idxSpec(Fields.VER_SAVEDBY, 1));
 		//determine whether a particular object is referenced by this object
-		wsVer.put(Arrays.asList(Fields.VER_REF), Arrays.asList(IDX_SPARSE));
+		wsVer.add(idxSpec(Fields.VER_REF, 1, IDX_SPARSE));
 		//determine whether a particular object is included in this object's provenance
-		wsVer.put(Arrays.asList(Fields.VER_PROVREF), Arrays.asList(IDX_SPARSE));
+		wsVer.add(idxSpec(Fields.VER_PROVREF, 1, IDX_SPARSE));
 		//find objects that have the same provenance
-		wsVer.put(Arrays.asList(Fields.VER_PROV), Arrays.asList(""));
+		wsVer.add(idxSpec(Fields.VER_PROV, 1));
 		//find objects by saved date
-		wsVer.put(Arrays.asList(Fields.VER_SAVEDATE), Arrays.asList(""));
+		wsVer.add(idxSpec(Fields.VER_SAVEDATE, 1));
 		//find objects by metadata
-		wsVer.put(Arrays.asList(Fields.VER_META), Arrays.asList(IDX_SPARSE));
-		INDEXES.put(COL_WORKSPACE_VERS, wsVer);
+		wsVer.add(idxSpec(Fields.VER_META, 1, IDX_SPARSE));
+		indexes.put(COL_WORKSPACE_VERS, wsVer);
 		
 		//no indexes needed for provenance since all lookups are by _id
 		
 		//admin indexes
-		Map<List<String>, List<String>> admin = new HashMap<List<String>, List<String>>();
+		final LinkedList<IndexSpecification> admin = new LinkedList<>();
 		//find admins by name
-		admin.put(Arrays.asList(Fields.ADMIN_NAME), Arrays.asList(IDX_UNIQ));
-		INDEXES.put(COL_ADMINS, admin);
+		admin.add(idxSpec(Fields.ADMIN_NAME, 1, IDX_UNIQ));
+		indexes.put(COL_ADMINS, admin);
 		
 		//config indexes
-		Map<List<String>, List<String>> cfg =
-				new HashMap<List<String>, List<String>>();
+		final LinkedList<IndexSpecification> cfg = new LinkedList<>();
 		//ensure only one config object
-		cfg.put(Arrays.asList(Fields.CONFIG_KEY), Arrays.asList(IDX_UNIQ));
-		INDEXES.put(COL_CONFIG, cfg);
-
+		cfg.add(idxSpec(Fields.CONFIG_KEY, 1, IDX_UNIQ));
+		indexes.put(COL_CONFIG, cfg);
+		
+		return indexes;
 	}
 	
 	public MongoWorkspaceDB(final DB workspaceDB, final BlobStore blobStore,
@@ -216,6 +220,55 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		checkConfig();
 	}
 	
+	private static class IndexSpecification {
+		public DBObject index;
+		public DBObject options;
+		
+		private IndexSpecification(final DBObject index, final DBObject options) {
+			this.index = index;
+			this.options = options;
+		}
+	}
+	
+	// 1 for ascending sort, -1 for descending
+	private static IndexSpecification idxSpec(
+			final String field, final int ascendingSort,
+			final String... options) {
+		
+		return new IndexSpecification(new BasicDBObject(field, ascendingSort),
+				getIndexOptions(options));
+	}
+
+	private static IndexSpecification idxSpec(
+			final String field1, final int ascendingSort1,
+			final String field2, final int ascendingSort2,
+			final String... options) {
+		return new IndexSpecification(
+				new BasicDBObject(field1, ascendingSort1)
+						.append(field2, ascendingSort2),
+				getIndexOptions(options));
+	}
+
+	private static IndexSpecification idxSpec(
+			final String field1, final int ascendingSort1,
+			final String field2, final int ascendingSort2,
+			final String field3, final int ascendingSort3,
+			final String... options) {
+		return new IndexSpecification(
+				new BasicDBObject(field1, ascendingSort1)
+					.append(field2, ascendingSort2)
+					.append(field3, ascendingSort3),
+				getIndexOptions(options));
+	}
+	
+	private static DBObject getIndexOptions(final String[] options) {
+		final DBObject opts = new BasicDBObject();
+		for (final String s: options) {
+			opts.put(s, 1);
+		}
+		return opts;
+	}
+
 	public List<DependencyStatus> status() {
 		//note failures are tested manually for now, if you make changes test
 		//things still work
@@ -288,21 +341,12 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 	}
 	
 	private void ensureIndexes() throws CorruptWorkspaceDBException {
-		for (String col: INDEXES.keySet()) {
+		final HashMap<String, List<IndexSpecification>> indexes = getIndexSpecs();
+		for (final String col: indexes.keySet()) {
 //			wsmongo.getCollection(col).resetIndexCache();
-			for (List<String> idx: INDEXES.get(col).keySet()) {
-				final DBObject index = new BasicDBObject();
-				final DBObject opts = new BasicDBObject();
-				for (String field: idx) {
-					index.put(field, 1);
-				}
-				for (String option: INDEXES.get(col).get(idx)) {
-					if (!option.equals("")) {
-						opts.put(option, 1);
-					}
-				}
+			for (final IndexSpecification index: indexes.get(col)) {
 				try {
-					wsmongo.getCollection(col).createIndex(index, opts);
+					wsmongo.getCollection(col).createIndex(index.index, index.options);
 				} catch (DuplicateKeyException dk) {
 					throw new CorruptWorkspaceDBException(
 							"Found duplicate index keys in the database, " +

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -6775,10 +6775,10 @@ public class WorkspaceTest extends WorkspaceTester {
 	private void assertOrdered(final ListObjectsParameters params, final boolean expectOrdered)
 			throws Exception {
 		final List<ObjectInformation> objs = ws.listObjects(params.withShowAllVersions(true));
-		System.out.println("printing sorted objs");
-		for (final ObjectInformation o: objs) {
-			System.out.println(o);
-		}
+//		System.out.println("printing sorted objs");
+//		for (final ObjectInformation o: objs) {
+//			System.out.println(o);
+//		}
 		boolean isOrdered = true;
 		final Iterator<ObjectInformation> iter = objs.iterator();
 		for (int ws = 1; ws < 3; ws++) {

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -6710,6 +6711,96 @@ public class WorkspaceTest extends WorkspaceTester {
 				fail(String.format("ObjectID out of test bounds: %s min %s max %s",
 						oi.getObjectId(), minIDexpected, maxIDexpected));
 			}
+		}
+	}
+	
+	@Test
+	public void listObjectsSort() throws Exception {
+		/* Currently list objects will sort the results if no other filters than the object ID
+		 * filters are active. Test that this is true.
+		 * Sort is wsid asc, objid asc, ver desc.
+		 */
+		WorkspaceUser user = new WorkspaceUser("u");
+		WorkspaceIdentifier wsi1 = new WorkspaceIdentifier("listsort1");
+		ws.createWorkspace(user, wsi1.getName(), false, null, null).getId();
+		WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("listsort2");
+		ws.createWorkspace(user, wsi2.getName(), false, null, null).getId();
+		final Provenance p = new Provenance(user);
+		final Map<String, String> meta = ImmutableMap.of("foo", "bar");
+		
+		// save 6 objects
+		saveObject(user, wsi2, meta, MT_MAP, SAFE_TYPE1, "w2o1", p);
+		saveObject(user, wsi2, meta, MT_MAP, SAFE_TYPE1, "w2o2", p);
+		saveObject(user, wsi2, meta, MT_MAP, SAFE_TYPE1, "w2o3", p);
+		saveObject(user, wsi1, meta, MT_MAP, SAFE_TYPE1, "w1o1", p);
+		saveObject(user, wsi1, meta, MT_MAP, SAFE_TYPE1, "w1o2", p);
+		saveObject(user, wsi1, meta, MT_MAP, SAFE_TYPE1, "w1o3", p);
+		
+		// more or less randomly saved versions on top of the 6 objects
+		saveObject(user, wsi2, meta, MT_MAP, SAFE_TYPE1, "w2o3", p);
+		saveObject(user, wsi2, meta, MT_MAP, SAFE_TYPE1, "w2o1", p);
+		saveObject(user, wsi1, meta, MT_MAP, SAFE_TYPE1, "w1o2", p);
+		saveObject(user, wsi1, meta, MT_MAP, SAFE_TYPE1, "w1o2", p);
+		saveObject(user, wsi2, meta, MT_MAP, SAFE_TYPE1, "w2o3", p);
+		saveObject(user, wsi1, meta, MT_MAP, SAFE_TYPE1, "w1o3", p);
+		saveObject(user, wsi2, meta, MT_MAP, SAFE_TYPE1, "w2o2", p);
+		saveObject(user, wsi1, meta, MT_MAP, SAFE_TYPE1, "w1o1", p);
+		saveObject(user, wsi2, meta, MT_MAP, SAFE_TYPE1, "w2o2", p);
+		saveObject(user, wsi1, meta, MT_MAP, SAFE_TYPE1, "w1o1", p);
+		saveObject(user, wsi1, meta, MT_MAP, SAFE_TYPE1, "w1o3", p);
+		saveObject(user, wsi2, meta, MT_MAP, SAFE_TYPE1, "w2o1", p);
+		
+		// sorted, with and without object id filters
+		assertOrdered(new ListObjectsParameters(Arrays.asList(wsi1, wsi2)), true);
+		assertOrdered(new ListObjectsParameters(Arrays.asList(wsi1, wsi2))
+				.withMaxObjectID(6L).withMinObjectID(1L), true);
+		
+		//unsorted (at least with descending versions)
+		// type filter
+		assertOrdered(new ListObjectsParameters(user, SAFE_TYPE1), false);
+		// after date filter
+		assertOrdered(new ListObjectsParameters(Arrays.asList(wsi1, wsi2))
+				.withAfter(Date.from(Instant.now().minusSeconds(100))), false);
+		// before date filter
+		assertOrdered(new ListObjectsParameters(Arrays.asList(wsi1, wsi2))
+				.withBefore(Date.from(Instant.now())), false);
+		// user filter
+		assertOrdered(new ListObjectsParameters(Arrays.asList(wsi1, wsi2))
+				.withSavers(Arrays.asList(user)), false);
+		// meta filter
+		assertOrdered(new ListObjectsParameters(Arrays.asList(wsi1, wsi2))
+				.withMetadata(new WorkspaceUserMetadata(meta)), false);
+	}
+
+	private void assertOrdered(final ListObjectsParameters params, final boolean expectOrdered)
+			throws Exception {
+		final List<ObjectInformation> objs = ws.listObjects(params.withShowAllVersions(true));
+		System.out.println("printing sorted objs");
+		for (final ObjectInformation o: objs) {
+			System.out.println(o);
+		}
+		boolean isOrdered = true;
+		final Iterator<ObjectInformation> iter = objs.iterator();
+		for (int ws = 1; ws < 3; ws++) {
+			for (int obj = 1; obj < 4; obj++) {
+				for (int ver = 3; ver > 0; ver--) {
+					final ObjectInformation oi = iter.next();
+					if (ws != oi.getWorkspaceId() ||
+							obj != oi.getObjectId() ||
+							ver != oi.getVersion()) {
+						isOrdered = false;
+						if (expectOrdered) {
+							fail(String.format(
+									"Expected ordered list. Failed at %s/%s/%s, got %s/%s/%s",
+									ws, obj, ver,
+									oi.getWorkspaceId(), oi.getObjectId(), oi.getVersion()));
+						}
+					}
+				}
+			}
+		}
+		if (!expectOrdered && isOrdered) {
+			fail("Expected unordered list, was ordered.");
 		}
 	}
 

--- a/test/sorting/LoadSortData.java
+++ b/test/sorting/LoadSortData.java
@@ -62,7 +62,18 @@ public class LoadSortData {
 		}
 		final Duration done = Duration.between(now, Instant.now());
 		System.out.println(String.format("%s.%s sec",
-				done.getSeconds(), done.toNanos() / 1_000_000));
+				done.getSeconds(), first3MillisDigits(done)));
+	}
+
+	private static String first3MillisDigits(final Duration d) {
+		//hack hack hack
+		String pre = ((d.getNano() / 1_000_000_000.0) + "").substring(2);
+		if (pre.length() < 3) {
+			return pre;
+		} else {
+			return pre.substring(0, 3);
+		}
+		
 	}
 
 	private static void saveObject(

--- a/test/sorting/LoadSortData.java
+++ b/test/sorting/LoadSortData.java
@@ -1,0 +1,92 @@
+package sorting;
+
+import java.io.IOException;
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import us.kbase.auth.AuthConfig;
+import us.kbase.auth.AuthToken;
+import us.kbase.auth.ConfigurableAuthService;
+import us.kbase.common.service.JsonClientException;
+import us.kbase.common.service.UObject;
+import us.kbase.workspace.ObjectSaveData;
+import us.kbase.workspace.SaveObjectsParams;
+import us.kbase.workspace.WorkspaceClient;
+
+/** Load objects with varying metadata to test that sorting only occurs when expected and does
+ * not occur in memory.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class LoadSortData {
+	
+	private static final String WS_NAME = "sorttest3";
+	private static final String WS_URL = "http://localhost:20000";
+	private static final int VER_COUNT = 10000;
+	private static final int OBJ_COUNT = 100;
+	private static final String TYPE = "Empty.AType-0.1";
+	private static final String AUTH_URL = "https://ci.kbase.us/services/auth/api/legacy/KBase";
+	
+	private static final String LONG_400;
+	static {
+		final StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 400; i++) {
+			sb.append("a");
+		}
+		LONG_400 = sb.toString();
+	}
+
+	public static void main(String[] args) throws Exception {
+		final ConfigurableAuthService auth = new ConfigurableAuthService(new AuthConfig()
+				.withKBaseAuthServerURL(new URL(AUTH_URL)));
+		final AuthToken token = auth.validateToken(args[0]);
+		System.out.println("loading objects with token from user " + token.getUserName());
+		final Map<String, String> meta = buildBaseMetadata();
+		final WorkspaceClient ws = new WorkspaceClient(new URL(WS_URL), token);
+		ws.setIsInsecureHttpConnectionAllowed(true);
+		final Instant now = Instant.now();
+		for (int i = 0; i < OBJ_COUNT; i++) {
+			// should really batch these into one call but I'm lazy
+			saveObject(ws, "obj" + i, meta);
+		}
+		for (int i = 0; i < VER_COUNT - OBJ_COUNT; i ++) {
+			if (i % 100 == 0) {
+				System.out.println(i);
+			}
+			// should really batch these into one call but I'm still lazy
+			saveObject(ws, "obj" + (int) (Math.random() * OBJ_COUNT), meta);
+		}
+		final Duration done = Duration.between(now, Instant.now());
+		System.out.println(String.format("%s.%s sec",
+				done.getSeconds(), done.toNanos() / 1_000_000));
+	}
+
+	private static void saveObject(
+			final WorkspaceClient ws,
+			final String name,
+			final Map<String, String> meta)
+			throws IOException, JsonClientException {
+		meta.put("sortkey", "" + (Math.random() * VER_COUNT));
+		ws.saveObjects(new SaveObjectsParams()
+				.withWorkspace(WS_NAME)
+				.withObjects(Arrays.asList(new ObjectSaveData()
+						.withData(new UObject(new HashMap<>()))
+						.withMeta(meta)
+						.withName(name)
+						.withType(TYPE))));
+	}
+
+	private static Map<String, String> buildBaseMetadata() {
+		final Map<String, String> ret = new HashMap<>();
+		// adds ~ 10K of metadata
+		for (int i = 0; i < 13; i++) {
+			ret.put(LONG_400 + i, LONG_400);
+		}
+		return ret;
+	}
+
+}

--- a/test/sorting/listObjectsSort.md
+++ b/test/sorting/listObjectsSort.md
@@ -1,4 +1,4 @@
-WS with 100 objects, 99900 versions spread randomly between the objects (e.g. mongo natural ordering of the versions should be random).
+WS with 100 objects, 9900 versions spread randomly between the objects (e.g. mongo natural ordering of the versions should be random).
 Easy to tell whether sorting is active since the order is ascending for versions without explicit sort instructions and descending with sort.
 
 With sort code active:

--- a/test/sorting/listObjectsSort.md
+++ b/test/sorting/listObjectsSort.md
@@ -1,0 +1,12 @@
+WS with 100 objects, 99900 versions spread randomly between the objects (e.g. mongo natural ordering of the versions should be random).
+Easy to tell whether sorting is active since the order is ascending for versions without explicit sort instructions and descending with sort.
+
+With sort code active:
+
+    In 29: %timeit drop = ws.list_objects({'workspaces': ['sorttest3'], 'showAllVersions': 1})
+    1 loop, best of 3: 9.97 s per loop
+
+With sort code commented out:
+
+    In 31: %timeit drop = ws.list_objects({'workspaces': ['sorttest3'], 'showAllVersions': 1})
+    1 loop, best of 3: 10.3 s per loop

--- a/test/sorting/package-info.java
+++ b/test/sorting/package-info.java
@@ -1,0 +1,6 @@
+/** Setup for tests to ensure that sorting doesn't occur in mongo memory, and only occurs
+ * when expected.
+ * @author gaprice@lbl.gov
+ *
+ */
+package sorting;


### PR DESCRIPTION
New indexes in versions collection:
savedby
ws asc, id asc, ver dec

Listing objects will now sort by ws asc, id asc, ver dec if no filters
other than the object ID filters are specified. This makes it simpler to
list all objects in a workspace since you know if you've got all the
versions of an object without having to make another query.

Timing data shows no difference in adding the sort.

Tested with mongo explain() to be sure an index was used for sorting.