### PR TITLE
Make port, jvm memory size and threads configurable at container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 EXPOSE 7058
 ENTRYPOINT [ "/kb/deployment/bin/dockerize" ]
 CMD [ "-template", "/kb/deployment/conf/.templates/deployment.cfg.templ:$KB_DEPLOYMENT_CONFIG", \
+      "-template", "/kb/deployment/conf/.templates/start_workspace.sh.templ:/kb/deployment/bin/start_workspace.sh", \
       "-stdout", "/kb/deployment/services/workspace/glassfish_domain/Workspace/logs/server.log", \
       "/kb/deployment/bin/start_workspace.sh" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,5 @@ ENTRYPOINT [ "/kb/deployment/bin/dockerize" ]
 CMD [ "-template", "/kb/deployment/conf/.templates/deployment.cfg.templ:$KB_DEPLOYMENT_CONFIG", \
       "-template", "/kb/deployment/conf/.templates/start_workspace.sh.templ:/kb/deployment/bin/start_workspace.sh", \
       "-stdout", "/kb/deployment/services/workspace/glassfish_domain/Workspace/logs/server.log", \
-      "/kb/deployment/bin/start_workspace.sh" ]
+      "/bin/bash", "/kb/deployment/bin/start_workspace.sh" ]
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ build-docs:
 docker_image: build-libs build-docs 
 	$(ANT) buildwar
 	cp server_scripts/glassfish_administer_service.py deployment/bin
-	cp administration/initialize.py deployment/bin
 	chmod 755 deployment/bin/glassfish_administer_service.py
 	cp dist/$(WAR) deployment/services/workspace/
 	./build/build_docker_image.sh

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ build-docs:
 docker_image: build-libs build-docs 
 	$(ANT) buildwar
 	cp server_scripts/glassfish_administer_service.py deployment/bin
+	cp administration/initialize.py deployment/bin
 	chmod 755 deployment/bin/glassfish_administer_service.py
 	cp dist/$(WAR) deployment/services/workspace/
 	./build/build_docker_image.sh

--- a/deployment/bin/start_workspace.sh
+++ b/deployment/bin/start_workspace.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env sh
-cd /kb/deployment
-
-bin/glassfish_administer_service.py --verbose --admin $GLASSFISH/bin/asadmin --domain Workspace \
-        --domain-dir /kb/deployment/services/workspace/glassfish_domain \
-        --war /kb/deployment/services/workspace/WorkspaceService.war --port 7058 --threads 20 \
-        --Xms 10000 --Xmx 15000 --properties KB_DEPLOYMENT_CONFIG=$KB_DEPLOYMENT_CONFIG  && \
-tail -n 500 -f /kb/deployment/services/workspace/glassfish_domain/Workspace/logs/server.log

--- a/deployment/conf/.templates/start_workspace.sh.templ
+++ b/deployment/conf/.templates/start_workspace.sh.templ
@@ -5,7 +5,8 @@ cd /kb/deployment
 # the defaults are based on
 bin/glassfish_administer_service.py --verbose --admin $GLASSFISH/bin/asadmin --domain Workspace \
         --domain-dir /kb/deployment/services/workspace/glassfish_domain \
-        --war /kb/deployment/services/workspace/WorkspaceService.war --port {{ default .Env.service_port "7058" }} \
+        --war /kb/deployment/services/workspace/WorkspaceService.war \
+        --port {{ default .Env.service_port "7058" }} --instanceport {{ default .Env.instance_port "32768" }} \
         --threads {{ default .Env.server_threads "20" }} \
         --Xms {{ default .Env.min_memory "10000" }} --Xmx {{ default .Env.max_memory "15000" }} \
         --properties KB_DEPLOYMENT_CONFIG=$KB_DEPLOYMENT_CONFIG  && \

--- a/deployment/conf/.templates/start_workspace.sh.templ
+++ b/deployment/conf/.templates/start_workspace.sh.templ
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+cd /kb/deployment
+
+# Values for port, threads, min/max memory are populated into source template from environment vars
+# the defaults are based on
+bin/glassfish_administer_service.py --verbose --admin $GLASSFISH/bin/asadmin --domain Workspace \
+        --domain-dir /kb/deployment/services/workspace/glassfish_domain \
+        --war /kb/deployment/services/workspace/WorkspaceService.war --port {{ default .Env.service_port "7058" }} \
+        --threads {{ default .Env.server_threads "20" }} \
+        --Xms {{ default .Env.min_memory "10000" }} --Xmx {{ default .Env.max_memory "15000" }} \
+        --properties KB_DEPLOYMENT_CONFIG=$KB_DEPLOYMENT_CONFIG  && \
+tail -n 500 -f /kb/deployment/services/workspace/glassfish_domain/Workspace/logs/server.log

--- a/server_scripts/glassfish_administer_service.py
+++ b/server_scripts/glassfish_administer_service.py
@@ -76,6 +76,7 @@ class CommandGlassfishDomain(object):
         else:
             print('Creating domain ' + self.domain + p)
             print(self._run_local_command('create-domain', '--nopassword=true',
+                                          '--instanceport=32768',  # move instanceport off 8080
                                           self.domain).rstrip())
         self.adminport = self.get_admin_port()
         self.start_domain()

--- a/server_scripts/glassfish_administer_service.py
+++ b/server_scripts/glassfish_administer_service.py
@@ -36,7 +36,7 @@ def _parseArgs():
     parser.add_argument('-p', '--port', required=True, type=int,
                         help='the port where the application runs.')
     parser.add_argument('-i', '--instanceport', type=int, default=8080,
-                        help='port for glassfish -instanceport option in create-domain')
+                        help='port for glassfish --instanceport option in create-domain')
     parser.add_argument('-t', '--threads', type=int, default=20,
                         help='the number of threads for the application.')
     parser.add_argument('-s', '--Xms', type=int,
@@ -62,7 +62,6 @@ class CommandGlassfishDomain(object):
         self.domain = domain
         self.path = None
         self.verbose = verbose
-        self.instanceport = instanceport
         if (domainpath):
             domaindir = os.path.abspath(os.path.expanduser(domainpath))
             if not os.path.isdir(domaindir):
@@ -79,7 +78,7 @@ class CommandGlassfishDomain(object):
         else:
             print('Creating domain ' + self.domain + p)
             print(self._run_local_command('create-domain', '--nopassword=true',
-                                          '--instanceport='+str(self.instanceport),  # move instanceport off 8080
+                                          '--instanceport=' + str(instanceport),  # move instanceport off 8080
                                           self.domain).rstrip())
         self.adminport = self.get_admin_port()
         self.start_domain()

--- a/server_scripts/glassfish_administer_service.py
+++ b/server_scripts/glassfish_administer_service.py
@@ -35,6 +35,8 @@ def _parseArgs():
                         'glassfish/domains.')
     parser.add_argument('-p', '--port', required=True, type=int,
                         help='the port where the application runs.')
+    parser.add_argument('-i', '--instanceport', type=int, default=8080,
+                        help='port for glassfish -instanceport option in create-domain')
     parser.add_argument('-t', '--threads', type=int, default=20,
                         help='the number of threads for the application.')
     parser.add_argument('-s', '--Xms', type=int,
@@ -55,11 +57,12 @@ def _parseArgs():
 
 class CommandGlassfishDomain(object):
 
-    def __init__(self, asadminpath, domain, domainpath, verbose):
+    def __init__(self, asadminpath, domain, domainpath, verbose, instanceport):
         self.asadminpath = asadminpath
         self.domain = domain
         self.path = None
         self.verbose = verbose
+        self.instanceport = instanceport
         if (domainpath):
             domaindir = os.path.abspath(os.path.expanduser(domainpath))
             if not os.path.isdir(domaindir):
@@ -76,7 +79,7 @@ class CommandGlassfishDomain(object):
         else:
             print('Creating domain ' + self.domain + p)
             print(self._run_local_command('create-domain', '--nopassword=true',
-                                          '--instanceport=32768',  # move instanceport off 8080
+                                          '--instanceport='+str(self.instanceport),  # move instanceport off 8080
                                           self.domain).rstrip())
         self.adminport = self.get_admin_port()
         self.start_domain()
@@ -297,7 +300,7 @@ class CommandGlassfishDomain(object):
 
 if __name__ == '__main__':
     args = _parseArgs()
-    gf = CommandGlassfishDomain(args.admin, args.domain, args.domain_dir, args.verbose)
+    gf = CommandGlassfishDomain(args.admin, args.domain, args.domain_dir, args.verbose, args.instanceport)
     if args.war is None:
         gf.stop_service(args.port)
     else:


### PR DESCRIPTION
Also move default glassfish http listener port off 8080 so that workspace service can use that port if necessary (which we want in order to make container deployments consistent)