### PR TITLE
Use local auth for tests

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -67,6 +67,6 @@
 	<classpathentry kind="lib" path="/jars/lib/jars/bytebuddy/byte-buddy-agent-1.6.8.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/objenesis/objenesis-2.5.1.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/kbase/common/kbase-common-0.0.24.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/kbase/auth2/kbase-auth2test-0.2.3.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/kbase/auth2/kbase-auth2test-0.2.4.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -67,5 +67,6 @@
 	<classpathentry kind="lib" path="/jars/lib/jars/bytebuddy/byte-buddy-agent-1.6.8.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/objenesis/objenesis-2.5.1.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/kbase/common/kbase-common-0.0.24.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/kbase/auth2/kbase-auth2test-0.2.3.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/build.xml
+++ b/build.xml
@@ -97,7 +97,7 @@
     <include name="mysql/mysql-connector-java-5.1.22-bin.jar"/>
     <include name="jsemver/java-semver-0.9.0.jar"/>
     <include name="equalsverifier/equalsverifier-2.2.2.jar"/>
-    <include name="kbase/auth2/kbase-auth2test-0.2.3.jar"/>
+    <include name="kbase/auth2/kbase-auth2test-0.2.4.jar"/>
     <!-- mockito and dependencies -->
     <include name="mockito/mockito-core-2.7.10.jar"/>
     <include name="bytebuddy/byte-buddy-1.6.8.jar"/>

--- a/build.xml
+++ b/build.xml
@@ -97,6 +97,7 @@
     <include name="mysql/mysql-connector-java-5.1.22-bin.jar"/>
     <include name="jsemver/java-semver-0.9.0.jar"/>
     <include name="equalsverifier/equalsverifier-2.2.2.jar"/>
+    <include name="kbase/auth2/kbase-auth2test-0.2.3.jar"/>
     <!-- mockito and dependencies -->
     <include name="mockito/mockito-core-2.7.10.jar"/>
     <include name="bytebuddy/byte-buddy-1.6.8.jar"/>

--- a/src/us/kbase/common/test/TestCommon.java
+++ b/src/us/kbase/common/test/TestCommon.java
@@ -8,7 +8,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -27,9 +26,6 @@ import com.google.common.collect.ImmutableMap;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 
-import us.kbase.auth.AuthException;
-import us.kbase.auth.AuthToken;
-import us.kbase.auth.ConfigurableAuthService;
 import us.kbase.common.test.TestException;
 import us.kbase.typedobj.core.TempFilesManager;
 
@@ -109,38 +105,6 @@ public class TestCommon {
 					TEST_CONFIG_FILE_PROP_NAME));
 		}
 		return Paths.get(testCfgFilePathStr).toAbsolutePath().normalize();
-	}
-	
-	public static AuthToken getToken(
-			final int user,
-			final ConfigurableAuthService auth) {
-		try {
-			return auth.validateToken(getToken(user));
-		} catch (AuthException | IOException e) {
-			throw new TestException(String.format(
-					"Couldn't log in user #%s with token : %s", user, e.getMessage()), e);
-		}
-	}
-	
-	public static String getToken(final int user) {
-		return getTestProperty(TEST_TOKEN_PREFIX + user);
-	}
-	
-	public static URL getAuthUrl() {
-		return getURL(AUTHSERV);
-	}
-	
-	private static URL getURL(String prop) {
-		try {
-			return new URL(getTestProperty(prop));
-		} catch (MalformedURLException e) {
-			throw new TestException("Property " + prop + " is not a valid url",
-					e);
-		}
-	}
-	
-	public static URL getGlobusUrl() {
-		return getURL(GLOBUS);
 	}
 	
 	public static String getTempDir() {

--- a/src/us/kbase/common/test/TestCommon.java
+++ b/src/us/kbase/common/test/TestCommon.java
@@ -243,55 +243,58 @@ public class TestCommon {
 		return new HashSet<T>(Arrays.asList(objects));
 	}
 	
-    public static void createAuthUser(
-            final URL authURL,
-            final String userName,
-            final String displayName)
-            throws Exception {
-        final URL target = new URL(authURL.toString() + "/api/V2/testmodeonly/user");
-        final HttpURLConnection conn = (HttpURLConnection) target.openConnection();
-        conn.setRequestMethod("POST");
-        conn.setRequestProperty("content-type", "application/json");
-        conn.setRequestProperty("accept", "application/json");
-        conn.setDoOutput(true);
-        
-        final DataOutputStream writer = new DataOutputStream(conn.getOutputStream());
-        writer.writeBytes(new ObjectMapper().writeValueAsString(ImmutableMap.of(
-                "user", userName,
-                "display", displayName)));
-        writer.flush();
-        writer.close();
-        
-        if (conn.getResponseCode() != 200) {
-            final String err = IOUtils.toString(conn.getErrorStream()); 
-            System.out.println(err);
-            throw new TestException(err.substring(1, 200));
-        }
-    }
+	public static void createAuthUser(
+			final URL authURL,
+			final String userName,
+			final String displayName)
+					throws Exception {
+		final URL target = new URL(authURL.toString() + "/api/V2/testmodeonly/user");
+		final HttpURLConnection conn = (HttpURLConnection) target.openConnection();
+		conn.setRequestMethod("POST");
+		conn.setRequestProperty("content-type", "application/json");
+		conn.setRequestProperty("accept", "application/json");
+		conn.setDoOutput(true);
 
-    public static String createLoginToken(final URL authURL, String user) throws Exception {
-        final URL target = new URL(authURL.toString() + "/api/V2/testmodeonly/token");
-        final HttpURLConnection conn = (HttpURLConnection) target.openConnection();
-        conn.setRequestMethod("POST");
-        conn.setRequestProperty("content-type", "application/json");
-        conn.setRequestProperty("accept", "application/json");
-        conn.setDoOutput(true);
-        
-        final DataOutputStream writer = new DataOutputStream(conn.getOutputStream());
-        writer.writeBytes(new ObjectMapper().writeValueAsString(ImmutableMap.of(
-                "user", user,
-                "type", "Login")));
-        writer.flush();
-        writer.close();
-        
-        if (conn.getResponseCode() != 200) {
-            final String err = IOUtils.toString(conn.getErrorStream()); 
-            System.out.println(err);
-            throw new TestException(err.substring(1, 200));
-        }
-        final String out = IOUtils.toString(conn.getInputStream());
-        @SuppressWarnings("unchecked")
-        final Map<String, Object> resp = new ObjectMapper().readValue(out, Map.class);
-        return (String) resp.get("token");
-    }
+		final DataOutputStream writer = new DataOutputStream(conn.getOutputStream());
+		writer.writeBytes(new ObjectMapper().writeValueAsString(ImmutableMap.of(
+				"user", userName,
+				"display", displayName)));
+		writer.flush();
+		writer.close();
+
+		checkForError(conn);
+	}
+
+	private static void checkForError(final HttpURLConnection conn) throws IOException {
+		if (conn.getResponseCode() != 200) {
+			String err = IOUtils.toString(conn.getErrorStream()); 
+			System.out.println(err);
+			if (err.length() > 200) {
+				err = err.substring(0, 200);
+			}
+			throw new TestException(err);
+		}
+	}
+
+	public static String createLoginToken(final URL authURL, String user) throws Exception {
+		final URL target = new URL(authURL.toString() + "/api/V2/testmodeonly/token");
+		final HttpURLConnection conn = (HttpURLConnection) target.openConnection();
+		conn.setRequestMethod("POST");
+		conn.setRequestProperty("content-type", "application/json");
+		conn.setRequestProperty("accept", "application/json");
+		conn.setDoOutput(true);
+
+		final DataOutputStream writer = new DataOutputStream(conn.getOutputStream());
+		writer.writeBytes(new ObjectMapper().writeValueAsString(ImmutableMap.of(
+				"user", user,
+				"type", "Login")));
+		writer.flush();
+		writer.close();
+
+		checkForError(conn);
+		final String out = IOUtils.toString(conn.getInputStream());
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> resp = new ObjectMapper().readValue(out, Map.class);
+		return (String) resp.get("token");
+	}
 }

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -37,14 +37,13 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.slf4j.LoggerFactory;
 
-import us.kbase.auth.AuthConfig;
 import us.kbase.auth.AuthToken;
-import us.kbase.auth.ConfigurableAuthService;
 import us.kbase.common.mongo.GetMongoDB;
 import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.TestException;
 import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.common.test.controllers.shock.ShockController;
+import us.kbase.test.auth2.authcontroller.AuthController;
 import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.TypeDefId;
@@ -140,6 +139,7 @@ public class WorkspaceTester {
 	
 	private static MongoController mongo = null;
 	private static ShockController shock = null;
+	private static AuthController auth = null;
 	protected static TempFilesManager tfm;
 	
 	protected static final WorkspaceUser SOMEUSER = new WorkspaceUser("auser");
@@ -196,6 +196,9 @@ public class WorkspaceTester {
 		if (shock != null) {
 			shock.destroy(TestCommon.getDeleteTempFiles());
 		}
+		if (auth != null) {
+			auth.destroy(TestCommon.getDeleteTempFiles());
+		}
 		if (mongo != null) {
 			mongo.destroy(TestCommon.getDeleteTempFiles());
 		}
@@ -221,8 +224,10 @@ public class WorkspaceTester {
 	protected final Workspace ws;
 	protected final Types types;
 	
-	public WorkspaceTester(String config, String backend,
-			Integer maxMemoryUsePerCall)
+	public WorkspaceTester(
+			final String config,
+			final String backend,
+			final Integer maxMemoryUsePerCall)
 			throws Exception {
 		if (mongo == null) {
 			mongo = new MongoController(TestCommon.getMongoExe(),
@@ -231,6 +236,16 @@ public class WorkspaceTester {
 			System.out.println("Using Mongo temp dir " + mongo.getTempDir());
 			System.out.println("Started test mongo instance at localhost:" +
 					mongo.getServerPort());
+		}
+		if (auth == null) {
+			final String dbname = WorkspaceTester.class.getSimpleName() + "Auth";
+			auth = new AuthController(
+					TestCommon.getJarsDir(),
+					"localhost:" + mongo.getServerPort(),
+					dbname,
+					Paths.get(TestCommon.getTempDir()));
+			final URL authURL = new URL("http://localhost:" + auth.getServerPort() + "/testmode");
+			System.out.println("started auth server at " + authURL);
 		}
 		if (!CONFIGS.containsKey(config)) {
 			DB wsdb = GetMongoDB.getDB("localhost:" + mongo.getServerPort(),
@@ -271,12 +286,10 @@ public class WorkspaceTester {
 	
 	private WSandTypes setUpShock(DB wsdb, Integer maxMemoryUsePerCall)
 			throws Exception {
-		final ConfigurableAuthService auth = new ConfigurableAuthService(
-				new AuthConfig().withKBaseAuthServerURL(
-						TestCommon.getAuthUrl()));
-		System.out.println(String.format("Logging in shock user at %s",
-				TestCommon.getAuthUrl()));
-		final AuthToken t = TestCommon.getToken(1, auth);
+		final URL authURL = new URL("http://localhost:" + auth.getServerPort() + "/testmode");
+		TestCommon.createAuthUser(authURL, "user1", "display1");
+		final String token1 = TestCommon.createLoginToken(authURL, "user1");
+		final AuthToken t = new AuthToken(token1, "user1");
 		if (shock == null) {
 			shock = new ShockController(
 					TestCommon.getShockExe(),
@@ -287,7 +300,7 @@ public class WorkspaceTester {
 					"WorkspaceTester_ShockDB",
 					"foo",
 					"foo",
-					TestCommon.getGlobusUrl());
+					new URL(authURL.toString() + "/api/legacy/globus"));
 			System.out.println("Shock controller version: " +
 					shock.getVersion());
 			if (shock.getVersion() == null) {

--- a/test.cfg.example
+++ b/test.cfg.example
@@ -2,17 +2,6 @@
 
 [Workspacetest]
 
-# Three tokens for *different* KBase user accounts.
-test.token1 =
-test.token2 =
-test.token3 =
-
-# The KBase authorization server url.
-test.auth.url = https://ci.kbase.us/services/auth/api/legacy/KBase
-
-# The Globus v1 authorization API url.
-test.globus.url = https://ci.kbase.us/services/auth/api/legacy/globus
-
 # The path to the jars dir inside the jars repo, e.g.
 # [path to jars repo]/lib/jars
 test.jars.dir =

--- a/test.cfg.example
+++ b/test.cfg.example
@@ -13,6 +13,10 @@ test.auth.url = https://ci.kbase.us/services/auth/api/legacy/KBase
 # The Globus v1 authorization API url.
 test.globus.url = https://ci.kbase.us/services/auth/api/legacy/globus
 
+# The path to the jars dir inside the jars repo, e.g.
+# [path to jars repo]/lib/jars
+test.jars.dir =
+
 # Shock exe file location 
 test.shock.exe = /kb/deployment/bin/shock-server
 # Shock exe file version


### PR DESCRIPTION
Starts a local instance of the auth service when running tests rather than relying on test accounts in a remote auth service.

This (eventually) enables Travis testing and greatly eases testing future developments using the auth services as a roles manager for the workspace (e.g. admin / read only roles, etc).