### PR TITLE
SCT-636 MIME corruption fix pt1: Restreamable input

### DIFF
--- a/src/us/kbase/typedobj/core/Restreamable.java
+++ b/src/us/kbase/typedobj/core/Restreamable.java
@@ -1,0 +1,19 @@
+package us.kbase.typedobj.core;
+
+import java.io.InputStream;
+
+/** A source of input streams that can be streamed multiple times, as opposed to a general input
+ * stream, which is exhausted when used. Each invocation of {@link #getInputStream()} produces
+ * a new input stream, which has the same contents as any other input stream produced from the
+ * method.
+ * @author gaprice@lbl.gov
+ *
+ */
+public interface Restreamable {
+
+	/** Generate an input stream from the source data.
+	 * @return the input stream.
+	 */
+	InputStream getInputStream();
+	
+}

--- a/src/us/kbase/typedobj/core/ValidatedTypedObject.java
+++ b/src/us/kbase/typedobj/core/ValidatedTypedObject.java
@@ -43,7 +43,7 @@ import com.fasterxml.jackson.databind.JsonNode;
  * @author rsutormin
  * @author gaprice@lbl.gov
  */
-public class ValidatedTypedObject {
+public class ValidatedTypedObject implements Restreamable {
 
 	/**
 	 * The list of errors found during validation.  If the object is not valid, this must be non-empty, (although
@@ -153,6 +153,7 @@ public class ValidatedTypedObject {
 	 * The caller of this method is responsible for closing the stream.
 	 * @return an object input stream.
 	 */
+	@Override
 	public InputStream getInputStream() {
 		if (byteCache == null && fileCache == null) {
 			throw new IllegalStateException(

--- a/src/us/kbase/workspace/database/mongo/BlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/BlobStore.java
@@ -1,9 +1,9 @@
 package us.kbase.workspace.database.mongo;
 
-import java.io.InputStream;
 import java.util.List;
 
 import us.kbase.typedobj.core.MD5;
+import us.kbase.typedobj.core.Restreamable;
 import us.kbase.workspace.database.ByteArrayFileCacheManager;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
 import us.kbase.workspace.database.DependencyStatus;
@@ -26,7 +26,7 @@ public interface BlobStore {
 	 * @throws BlobStoreCommunicationException if a communication error with
 	 * the blob store backend occurs.
 	 */
-	public void saveBlob(MD5 md5, InputStream data, boolean sorted)
+	public void saveBlob(MD5 md5, Restreamable data, boolean sorted)
 			throws BlobStoreAuthorizationException,
 			BlobStoreCommunicationException;
 	

--- a/src/us/kbase/workspace/database/mongo/GridFSBlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/GridFSBlobStore.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.slf4j.LoggerFactory;
 
 import us.kbase.typedobj.core.MD5;
+import us.kbase.typedobj.core.Restreamable;
 import us.kbase.workspace.database.ByteArrayFileCacheManager;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
 import us.kbase.workspace.database.DependencyStatus;
@@ -30,13 +31,12 @@ public class GridFSBlobStore implements BlobStore {
 	
 	private final GridFS gfs;
 	
-	public GridFSBlobStore(DB mongodb) {
+	public GridFSBlobStore(final DB mongodb) {
 		gfs = new GridFS(mongodb);
 	}
 
 	@Override
-	public void saveBlob(final MD5 md5, final InputStream data,
-			final boolean sorted)
+	public void saveBlob(final MD5 md5, final Restreamable data, final boolean sorted)
 			throws BlobStoreCommunicationException {
 		if(data == null || md5 == null) {
 			throw new NullPointerException("Arguments cannot be null");
@@ -44,7 +44,7 @@ public class GridFSBlobStore implements BlobStore {
 		if (getFile(md5) != null) {
 			return; //already exists
 		}
-		final GridFSInputFile gif = gfs.createFile(data, true);
+		final GridFSInputFile gif = gfs.createFile(data.getInputStream(), true);
 		gif.setId(md5.getMD5());
 		gif.setFilename(md5.getMD5());
 		gif.put(Fields.GFS_SORTED, sorted);

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -4,7 +4,6 @@ import static us.kbase.workspace.database.mongo.ObjectInfoUtils.metaMongoArrayTo
 import static us.kbase.workspace.database.mongo.ObjectInfoUtils.metaHashToMongoArray;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2046,8 +2045,8 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		try {
 			for (ObjectSavePackage p: data) {
 				final String md5 = p.wo.getRep().getMD5().getMD5();
-				try (final InputStream is = p.wo.getRep().getInputStream()) {
-					blob.saveBlob(new MD5(md5), is, true); //always sorted in 0.2.0+
+				try {
+					blob.saveBlob(new MD5(md5), p.wo.getRep(), true); //always sorted in 0.2.0+
 				} catch (BlobStoreCommunicationException e) {
 					throw new WorkspaceCommunicationException(
 							e.getLocalizedMessage(), e);
@@ -2055,11 +2054,6 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 					throw new WorkspaceCommunicationException(
 							"Authorization error communicating with the backend storage system",
 							e);
-				} catch (IOException ioe) {
-					// closing the input stream failed - nothing can be done.
-					// CAUTION - if you change this method, make sure you
-					// don't add any actions that throw IOEs or they'll be
-					// ignored here.
 				}
 			}
 		} finally {

--- a/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
@@ -15,6 +15,7 @@ import us.kbase.shock.client.ShockNodeId;
 import us.kbase.shock.client.exceptions.InvalidShockUrlException;
 import us.kbase.shock.client.exceptions.ShockHttpException;
 import us.kbase.typedobj.core.MD5;
+import us.kbase.typedobj.core.Restreamable;
 import us.kbase.workspace.database.ByteArrayFileCacheManager;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
 import us.kbase.workspace.database.DependencyStatus;
@@ -96,7 +97,7 @@ public class ShockBlobStore implements BlobStore {
 	}
 	
 	@Override
-	public void saveBlob(final MD5 md5, final InputStream data,
+	public void saveBlob(final MD5 md5, final Restreamable data,
 			final boolean sorted)
 			throws BlobStoreAuthorizationException,
 			BlobStoreCommunicationException {
@@ -110,8 +111,8 @@ public class ShockBlobStore implements BlobStore {
 			//go ahead, need to save
 		}
 		final ShockNode sn;
-		try {
-			sn = client.addNode(data, "workspace_" + md5.getMD5(), "JSON");
+		try (final InputStream is = data.getInputStream()) {
+			sn = client.addNode(is, "workspace_" + md5.getMD5(), "JSON");
 		} catch (JsonProcessingException jpe) {
 			//this should be impossible
 			throw new RuntimeException("Attribute serialization failed: "

--- a/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
@@ -97,10 +97,8 @@ public class ShockBlobStore implements BlobStore {
 	}
 	
 	@Override
-	public void saveBlob(final MD5 md5, final Restreamable data,
-			final boolean sorted)
-			throws BlobStoreAuthorizationException,
-			BlobStoreCommunicationException {
+	public void saveBlob(final MD5 md5, final Restreamable data, final boolean sorted)
+			throws BlobStoreAuthorizationException, BlobStoreCommunicationException {
 		if (md5 == null || data == null) {
 			throw new NullPointerException("Arguments cannot be null");
 		}

--- a/src/us/kbase/workspace/test/database/mongo/GridFSBlobStoreTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/GridFSBlobStoreTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.InputStream;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -23,6 +24,7 @@ import com.mongodb.gridfs.GridFSInputFile;
 import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.typedobj.core.MD5;
+import us.kbase.typedobj.core.Restreamable;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.workspace.database.ByteArrayFileCacheManager;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
@@ -73,7 +75,7 @@ public class GridFSBlobStoreTest {
 		}
 		
 		try {
-			gfsb.saveBlob(null, IOUtils.toInputStream("foo"), true);
+			gfsb.saveBlob(null, new StringRestreamable("foo"), true);
 		} catch (NullPointerException npe) {
 			assertThat("correct excepction message", npe.getLocalizedMessage(),
 					is("Arguments cannot be null"));
@@ -97,11 +99,24 @@ public class GridFSBlobStoreTest {
 		gfsb.removeBlob(md5);
 	}
 	
+	private static class StringRestreamable implements Restreamable {
+
+		private final String data;
+		
+		public StringRestreamable(final String data) {
+			this.data = data;
+		}
+		@Override
+		public InputStream getInputStream() {
+			return IOUtils.toInputStream(data);
+		}
+	}
+	
 	@Test
 	public void saveAndGetBlob() throws Exception {
 		MD5 md1 = new MD5("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1");
 		String data = "this is a blob yo";
-		gfsb.saveBlob(md1, IOUtils.toInputStream(data), true);
+		gfsb.saveBlob(md1, new StringRestreamable(data), true);
 		MD5 md1copy = new MD5("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1");
 		ByteArrayFileCache d = gfsb.getBlob(md1copy, 
 				new ByteArrayFileCacheManager(16000000, 2000000000L, tfm));
@@ -109,16 +124,16 @@ public class GridFSBlobStoreTest {
 		String returned = IOUtils.toString(d.getJSON());
 		assertThat("Didn't get same data back from store", returned, is(data));
 		assertTrue("GridFS has no external ID", gfsb.getExternalIdentifier(md1copy) == null);
-		gfsb.saveBlob(md1, IOUtils.toInputStream(data), true); //should be able to save the same thing twice with no error
+		gfsb.saveBlob(md1, new StringRestreamable(data), true); //should be able to save the same thing twice with no error
 		
-		gfsb.saveBlob(md1, IOUtils.toInputStream(data), false); //this should do nothing
+		gfsb.saveBlob(md1, new StringRestreamable(data), false); //this should do nothing
 		assertThat("sorted still true", gfsb.getBlob(md1copy,
 				new ByteArrayFileCacheManager(16000000, 2000000000L, tfm))
 					.isSorted(), is(true));
 		
 		MD5 md2 = new MD5("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2");
 		String data2 = "this is also a blob yo";
-		gfsb.saveBlob(md2, IOUtils.toInputStream(data2), false);
+		gfsb.saveBlob(md2, new StringRestreamable(data2), false);
 		d = gfsb.getBlob(md2,
 				new ByteArrayFileCacheManager(16000000, 2000000000L, tfm));
 		assertThat("data returned marked as unsorted", d.isSorted(), is(false));

--- a/test/performance/ConfigurationsAndThreads.java
+++ b/test/performance/ConfigurationsAndThreads.java
@@ -35,6 +35,7 @@ import us.kbase.shock.client.BasicShockClient;
 import us.kbase.shock.client.ShockNode;
 import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.MD5;
+import us.kbase.typedobj.core.Restreamable;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.typedobj.core.TypedObjectValidator;
@@ -296,9 +297,15 @@ public class ConfigurationsAndThreads {
 		return new Perf(writeNanoSec, readNanoSec, errors);
 	}
 	
-	private static InputStream treeToWritable(final JsonNode value) {
+	private static Restreamable treeToWritable(final JsonNode value) {
 		//NOTE no idea if this was a good change or not, just made it compile
-		return IOUtils.toInputStream(value.toString());
+		return new Restreamable() {
+			
+			@Override
+			public InputStream getInputStream() {
+				return IOUtils.toInputStream(value.toString());
+			}
+		};
 	}
 
 	public static class WorkspaceJsonRPCShock extends AbstractReadWriteTest {


### PR DESCRIPTION
The MIME corruption fix will require streaming the input to Shock
multiple times, so a regular InputStream input won't work.