### PR TITLE
SCT-636 MIME corruption fix pt2: Dependency injection for shock client

### DIFF
--- a/performance/us/kbase/workspace/performance/workspace/GetObjectsMongoWSDB.java
+++ b/performance/us/kbase/workspace/performance/workspace/GetObjectsMongoWSDB.java
@@ -14,6 +14,7 @@ import com.mongodb.DB;
 import com.mongodb.MongoClient;
 
 import us.kbase.auth.AuthService;
+import us.kbase.shock.client.BasicShockClient;
 import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.workspace.database.ByteArrayFileCacheManager;
@@ -49,7 +50,7 @@ public class GetObjectsMongoWSDB {
 		
 		final BlobStore blob = new ShockBlobStore(
 				db.getCollection(InitWorkspaceServer.COL_SHOCK_NODES),
-				new URL(SHOCK_URL), AuthService.validateToken(token));
+				new BasicShockClient(new URL(SHOCK_URL), AuthService.validateToken(token)));
 		final TempFilesManager tfm = new TempFilesManager(new File("temp_getobjmongoWS"));
 		final MongoWorkspaceDB mws = new MongoWorkspaceDB(db, blob, tfm);
 		

--- a/performance/us/kbase/workspace/performance/workspace/ShockBackendTiming.java
+++ b/performance/us/kbase/workspace/performance/workspace/ShockBackendTiming.java
@@ -11,6 +11,7 @@ import com.mongodb.DB;
 import com.mongodb.MongoClient;
 
 import us.kbase.auth.AuthService;
+import us.kbase.shock.client.BasicShockClient;
 import us.kbase.workspace.database.mongo.BlobStore;
 import us.kbase.workspace.database.mongo.ShockBlobStore;
 import us.kbase.workspace.kbase.InitWorkspaceServer;
@@ -35,7 +36,7 @@ public class ShockBackendTiming {
 		
 		final BlobStore blob = new ShockBlobStore(
 				db.getCollection(InitWorkspaceServer.COL_SHOCK_NODES),
-				new URL(SHOCK_URL), AuthService.validateToken(token));
+				new BasicShockClient(new URL(SHOCK_URL), AuthService.validateToken(token)));
 		final List<Long> shocktimes = getObjects(blob, md5s, BATCH_SIZE);
 		printStats(shocktimes);
 	}

--- a/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -105,7 +106,7 @@ public class ShockBlobStoreTest {
 		URL url = new URL("http://localhost:" + shock.getServerPort());
 		System.out.println("Testing workspace shock backend pointed at: " + url);
 		System.out.println("Using auth url: " + globusURL);
-		sb = new ShockBlobStore(mongo.getCollection(COLLECTION), url, token);
+		sb = new ShockBlobStore(mongo.getCollection(COLLECTION), new BasicShockClient(url, token));
 		client = new BasicShockClient(url, token);
 	}
 	
@@ -141,19 +142,19 @@ public class ShockBlobStoreTest {
 	
 	@Test
 	public void badInit() throws Exception {
-		DBCollection col = mongo.getCollection(COLLECTION);
-		failInit(null, new URL("http://foo.com"), token);
-		failInit(col, null, token);
-		failInit(col, new URL("http://foo.com"), null);
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		
+		failInit(null, client);
+		failInit(col, null);
 	}
 	
 	private void failInit(
 			final DBCollection collection,
-			final URL url,
-			final AuthToken tp)
+			final BasicShockClient client)
 			throws Exception {
 		try {
-			new ShockBlobStore(collection, url, tp);
+			new ShockBlobStore(collection, client);
 		} catch (NullPointerException npe) {
 			assertThat("correct exception message", npe.getLocalizedMessage(),
 					is("Arguments cannot be null"));

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -43,6 +43,7 @@ import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.TestException;
 import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.common.test.controllers.shock.ShockController;
+import us.kbase.shock.client.BasicShockClient;
 import us.kbase.test.auth2.authcontroller.AuthController;
 import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.TempFilesManager;
@@ -310,7 +311,8 @@ public class WorkspaceTester {
 			System.out.println("Using Shock temp dir " + shock.getTempDir());
 		}
 		URL shockUrl = new URL("http://localhost:" + shock.getServerPort());
-		BlobStore bs = new ShockBlobStore(wsdb.getCollection("shock_nodes"), shockUrl, t);
+		BlobStore bs = new ShockBlobStore(
+				wsdb.getCollection("shock_nodes"), new BasicShockClient(shockUrl, t));
 		return setUpWorkspaces(wsdb, bs, maxMemoryUsePerCall);
 	}
 	

--- a/test/performance/ConfigurationsAndThreads.java
+++ b/test/performance/ConfigurationsAndThreads.java
@@ -396,8 +396,9 @@ public class ConfigurationsAndThreads {
 			TypedObjectValidator val = new TypedObjectValidator(
 					new LocalTypeProvider(typeDefDB));
 			MongoWorkspaceDB mwdb = new MongoWorkspaceDB(db,
-					new ShockBlobStore(db.getCollection("shock_map"), shockURL,
-							AuthService.validateToken("foo")), tfm);
+					new ShockBlobStore(db.getCollection("shock_map"),
+							new BasicShockClient(shockURL,
+							AuthService.validateToken("foo"))), tfm);
 			ws = new Workspace(mwdb, new ResourceUsageConfigurationBuilder().build(), val);
 			workspace = "SupahFake" + new String("" + Math.random()).substring(2)
 					.replace("-", ""); //in case it's E-X
@@ -457,7 +458,7 @@ public class ConfigurationsAndThreads {
 		public void initialize(int writes, int id) throws Exception {
 			Random rand = new Random();
 			this.sb = new ShockBlobStore(GetMongoDB.getDB(MONGO_HOST, MONGO_DB, 0, 0).getCollection(
-					"temp_shock_node_map"), shockURL, token);
+					"temp_shock_node_map"), new BasicShockClient(shockURL, token));
 			for (int i = 0; i < writes; i++) {
 				byte[] r = new byte[16]; //128 bit
 				rand.nextBytes(r);

--- a/test/performance/GetObjectsLibSpeedTest.java
+++ b/test/performance/GetObjectsLibSpeedTest.java
@@ -26,6 +26,7 @@ import us.kbase.auth.AuthService;
 import us.kbase.common.mongo.GetMongoDB;
 import us.kbase.common.service.JsonTokenStream;
 import us.kbase.common.test.TestCommon;
+import us.kbase.shock.client.BasicShockClient;
 import us.kbase.typedobj.core.LocalTypeProvider;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.TypeDefId;
@@ -87,7 +88,8 @@ public class GetObjectsLibSpeedTest {
 				new LocalTypeProvider(typeDefDB));
 		MongoWorkspaceDB mwdb = new MongoWorkspaceDB(db,
 				new ShockBlobStore(db.getCollection("shock_map"),
-						new URL(shockurl), AuthService.validateToken(shocktoken)),
+						new BasicShockClient(
+								new URL(shockurl), AuthService.validateToken(shocktoken))),
 				tfm);
 		Workspace ws = new Workspace(mwdb, new ResourceUsageConfigurationBuilder().build(), val);
 		Types types = new Types(typeDefDB);


### PR DESCRIPTION
Make the shock client injectable so that responses from Shock can be
mocked for cases where we don't know how to reproduce the behavior (e.g.
appending MIME headers to data)