### PR TITLE
SCT-636 Fix for MIME header corruption in shock nodes

### DIFF
--- a/docsource/releasenotes.rst
+++ b/docsource/releasenotes.rst
@@ -1,6 +1,16 @@
 Workspace service release notes
 ===============================
 
+VERSION: 0.8.1 (Released TBD)
+-----------------------------
+
+UPDATED FEATURES / MAJOR BUG FIXES:
+
+* Added a workaround for a bug where, when using Shock as a file backend, MIME headers would
+  very rarely (~1/100,000 saves) be appended to the data, corrupting it. The current workaround
+  checks that the Workspace MD5 and the Shock MD5 are equal, and if not, deletes the newly created
+  Shock node and starts over. The root cause of the data corruption is as yet unknown.
+
 VERSION: 0.8.0 (Released 1/30/18)
 ---------------------------------
 

--- a/src/us/kbase/workspace/database/DependencyStatus.java
+++ b/src/us/kbase/workspace/database/DependencyStatus.java
@@ -16,7 +16,6 @@ public class DependencyStatus {
 			final String status,
 			final String name,
 			final String version) {
-		super();
 		this.ok = ok;
 		this.status = status;
 		this.name = name;
@@ -38,4 +37,71 @@ public class DependencyStatus {
 	public String getVersion() {
 		return version;
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + (ok ? 1231 : 1237);
+		result = prime * result + ((status == null) ? 0 : status.hashCode());
+		result = prime * result + ((version == null) ? 0 : version.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		DependencyStatus other = (DependencyStatus) obj;
+		if (name == null) {
+			if (other.name != null) {
+				return false;
+			}
+		} else if (!name.equals(other.name)) {
+			return false;
+		}
+		if (ok != other.ok) {
+			return false;
+		}
+		if (status == null) {
+			if (other.status != null) {
+				return false;
+			}
+		} else if (!status.equals(other.status)) {
+			return false;
+		}
+		if (version == null) {
+			if (other.version != null) {
+				return false;
+			}
+		} else if (!version.equals(other.version)) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("DependencyStatus [ok=");
+		builder.append(ok);
+		builder.append(", status=");
+		builder.append(status);
+		builder.append(", name=");
+		builder.append(name);
+		builder.append(", version=");
+		builder.append(version);
+		builder.append("]");
+		return builder.toString();
+	}
+	
+	
 }

--- a/src/us/kbase/workspace/test/database/DependencyStatusTest.java
+++ b/src/us/kbase/workspace/test/database/DependencyStatusTest.java
@@ -1,0 +1,42 @@
+package us.kbase.workspace.test.database;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import us.kbase.workspace.database.DependencyStatus;
+
+public class DependencyStatusTest {
+	
+	@Test
+	public void equals() {
+		EqualsVerifier.forClass(DependencyStatus.class).usingGetClass().verify();
+	}
+	
+	@Test
+	public void constructTrue() {
+		final DependencyStatus dep = new DependencyStatus(true, "status", "my name", "my version");
+		
+		assertThat("incorrect ok", dep.isOk(), is(true));
+		assertThat("incorrect status", dep.getStatus(), is("status"));
+		assertThat("incorrect my name", dep.getName(), is("my name"));
+		assertThat("incorrect my version", dep.getVersion(), is("my version"));
+		assertThat("incorrect toString", dep.toString(), is(
+				"DependencyStatus [ok=true, status=status, name=my name, version=my version]"));
+	}
+	
+	@Test
+	public void constructFalseWithNulls() {
+		final DependencyStatus dep = new DependencyStatus(false, null, null, null);
+		
+		assertThat("incorrect ok", dep.isOk(), is(false));
+		assertThat("incorrect status", dep.getStatus(), is((String) null));
+		assertThat("incorrect my name", dep.getName(), is((String) null));
+		assertThat("incorrect my version", dep.getVersion(), is((String) null));
+		assertThat("incorrect toString", dep.toString(), is(
+				"DependencyStatus [ok=false, status=null, name=null, version=null]"));
+	}
+
+}

--- a/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreIntegrationTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreIntegrationTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -22,7 +21,6 @@ import org.junit.Test;
 import com.github.zafarkhaja.semver.Version;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
-import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 
@@ -124,44 +122,6 @@ public class ShockBlobStoreIntegrationTest {
 	}
 	
 	@Test
-	public void badInput() throws Exception {
-		try {
-			sb.saveBlob(new MD5(A32), null, true);
-		} catch (NullPointerException npe) {
-			assertThat("correct excepction message", npe.getLocalizedMessage(),
-					is("Arguments cannot be null"));
-		}
-		
-		try {
-			sb.saveBlob(null, new StringRestreamable("foo"), true);
-		} catch (NullPointerException npe) {
-			assertThat("correct excepction message", npe.getLocalizedMessage(),
-					is("Arguments cannot be null"));
-		}
-	}
-	
-	@Test
-	public void badInit() throws Exception {
-		final DBCollection col = mock(DBCollection.class);
-		final BasicShockClient client = mock(BasicShockClient.class);
-		
-		failInit(null, client);
-		failInit(col, null);
-	}
-	
-	private void failInit(
-			final DBCollection collection,
-			final BasicShockClient client)
-			throws Exception {
-		try {
-			new ShockBlobStore(collection, client);
-		} catch (NullPointerException npe) {
-			assertThat("correct exception message", npe.getLocalizedMessage(),
-					is("Arguments cannot be null"));
-		}
-	}
-	
-	@Test
 	public void dataWithoutSortMarker() throws Exception {
 		String s = "pootypoot";
 		ShockNode sn = client.addNode(new ByteArrayInputStream(s.getBytes("UTF-8")), A32, "JSON");
@@ -178,7 +138,7 @@ public class ShockBlobStoreIntegrationTest {
 		sb.removeBlob(md5);
 	}
 	
-	private static class StringRestreamable implements Restreamable {
+	static class StringRestreamable implements Restreamable {
 
 		private final String data;
 		
@@ -193,7 +153,7 @@ public class ShockBlobStoreIntegrationTest {
 	
 	@Test
 	public void saveAndGetBlob() throws Exception {
-		MD5 md1 = new MD5("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1");
+		MD5 md1 = new MD5("5e498cecc4017dad15313bb009b0ef49");
 		String data = "this is a blob yo";
 		sb.saveBlob(md1, new StringRestreamable(data), true);
 		ShockNodeId id = new ShockNodeId(sb.getExternalIdentifier(md1));
@@ -201,7 +161,7 @@ public class ShockBlobStoreIntegrationTest {
 				UUID.matcher(id.getId()).matches());
 		assertThat("Ext id is the shock node", id.getId(),
 				is(sb.getExternalIdentifier(md1)));
-		MD5 md1copy = new MD5("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1");
+		MD5 md1copy = new MD5("5e498cecc4017dad15313bb009b0ef49");
 		ByteArrayFileCache d = sb.getBlob(md1copy, 
 				new ByteArrayFileCacheManager(16000000, 2000000000L, tfm));
 		assertThat("data returned marked as sorted", d.isSorted(), is(true));
@@ -214,7 +174,7 @@ public class ShockBlobStoreIntegrationTest {
 				new ByteArrayFileCacheManager(16000000, 2000000000L, tfm))
 				.isSorted(), is(true));
 		
-		MD5 md2 = new MD5("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2");
+		MD5 md2 = new MD5("78afe93c486269db5b49d9017e850103");
 		String data2 = "this is also a blob yo";
 		sb.saveBlob(md2, new StringRestreamable(data2), false);
 		d = sb.getBlob(md2,
@@ -246,7 +206,7 @@ public class ShockBlobStoreIntegrationTest {
 	@Test
 	public void removeNonExistantBlob() throws Exception {
 		sb.removeBlob(new MD5(A32)); //should silently not remove anything
-		MD5 md1 = new MD5("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1");
+		MD5 md1 = new MD5("5e498cecc4017dad15313bb009b0ef49");
 		String data = "this is a blob yo";
 		sb.saveBlob(md1, new StringRestreamable(data), true);
 		sb.removeAllBlobs();
@@ -255,7 +215,7 @@ public class ShockBlobStoreIntegrationTest {
 	
 	@Test
 	public void removeAllBlobs() throws Exception {
-		MD5 md1 = new MD5("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1");
+		MD5 md1 = new MD5("5e498cecc4017dad15313bb009b0ef49");
 		String data = "this is a blob yo";
 		sb.saveBlob(md1, new StringRestreamable(data), true);
 		sb.removeAllBlobs();

--- a/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreTest.java
@@ -1,0 +1,541 @@
+package us.kbase.workspace.test.database.mongo;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.MongoException;
+
+import us.kbase.common.test.TestCommon;
+import us.kbase.shock.client.BasicShockClient;
+import us.kbase.shock.client.ShockFileInformation;
+import us.kbase.shock.client.ShockNode;
+import us.kbase.shock.client.ShockNodeId;
+import us.kbase.shock.client.ShockVersionStamp;
+import us.kbase.shock.client.exceptions.InvalidShockUrlException;
+import us.kbase.shock.client.exceptions.ShockHttpException;
+import us.kbase.typedobj.core.MD5;
+import us.kbase.typedobj.core.Restreamable;
+import us.kbase.workspace.database.DependencyStatus;
+import us.kbase.workspace.database.mongo.ShockBlobStore;
+import us.kbase.workspace.database.mongo.exceptions.BlobStoreCommunicationException;
+import us.kbase.workspace.test.database.mongo.ShockBlobStoreIntegrationTest.StringRestreamable;
+
+public class ShockBlobStoreTest {
+
+	/* This is strictly for unit tests. */
+	
+	@Test
+	public void constructFail() {
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		
+		failConstruct(null, client);
+		failConstruct(col, null);
+	}
+	
+	private void failConstruct(
+			final DBCollection collection,
+			final BasicShockClient client) {
+		try {
+			new ShockBlobStore(collection, client);
+		} catch (NullPointerException npe) {
+			assertThat("correct exception message", npe.getLocalizedMessage(),
+					is("Arguments cannot be null"));
+		}
+	}
+	
+	@Test
+	public void constructVerify() throws Exception {
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		
+		new ShockBlobStore(col, client);
+		
+		final DBObject dbo = new BasicDBObject();
+		dbo.put("chksum", 1);
+		final DBObject opts = new BasicDBObject();
+		opts.put("unique", 1);
+		
+		verify(col).createIndex(dbo, opts);
+	}
+	
+	@Test
+	public void status() throws Exception {
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		when(client.getRemoteVersion()).thenReturn("my version");
+		
+		assertThat("incorrect status", sbs.status(),
+				is(Arrays.asList(new DependencyStatus(true, "OK", "Shock", "my version"))));
+	}
+	
+	@Test
+	public void statusFailIOException() throws Exception {
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		when(client.getRemoteVersion()).thenThrow(new IOException("foo"));
+		
+		assertThat("incorrect status", sbs.status(),
+				is(Arrays.asList(new DependencyStatus(
+						false, "Cannot connect to Shock: foo", "Shock", "Unknown"))));
+	}
+	
+	@Test
+	public void statusFailURLException() throws Exception {
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		when(client.getRemoteVersion()).thenThrow(new InvalidShockUrlException("url"));
+		
+		assertThat("incorrect status", sbs.status(),
+				is(Arrays.asList(new DependencyStatus(
+						false, "Invalid Shock URL: url", "Shock", "Unknown"))));
+	}
+	
+	@Test
+	public void saveBlobFailInput() throws Exception {
+		failSaveBlob(null, new StringRestreamable("foo"),
+				new NullPointerException("Arguments cannot be null"));
+		failSaveBlob(new MD5("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"), null,
+				new NullPointerException("Arguments cannot be null"));
+	}
+	
+	private void failSaveBlob(final MD5 md5, final Restreamable stream, final Exception expected) {
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		try {
+			new ShockBlobStore(col, client).saveBlob(md5, stream, true);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+	
+	@Test
+	public void saveBlobNoop() throws Exception {
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		when(col.findOne(new BasicDBObject("chksum", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1")))
+				.thenReturn(new BasicDBObject("node", "foo"));
+		
+		sbs.saveBlob(
+				new MD5("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"), new StringRestreamable("foo"), true);
+		
+		verifyZeroInteractions(client);
+	}
+	
+	@Test
+	public void saveBlob() throws Exception {
+		final String md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		final Restreamable res = mock(Restreamable.class);
+		// normally you shouldn't mock value classes but these can't be instantiated
+		// because I'm a dummy
+		final ShockNode sn = mock(ShockNode.class);
+		final ShockFileInformation sfi = mock(ShockFileInformation.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		when(col.findOne(new BasicDBObject("chksum", md5))).thenReturn(null);
+		
+		final InputStream stream = new ByteArrayInputStream("foo".getBytes());
+		
+		when(res.getInputStream()).thenReturn(stream);
+		
+		when(client.addNode(stream, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
+				.thenReturn(sn);
+		
+		when(sn.getId()).thenReturn(new ShockNodeId("ca4a4b5a-b676-4090-9a7d-9690189e29be"));
+		when(sn.getVersion()).thenReturn(
+				new ShockVersionStamp("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2"));
+		when(sn.getFileInformation()).thenReturn(sfi);
+		when(sfi.getChecksum("md5")).thenReturn(md5);
+		
+		sbs.saveBlob(new MD5(md5), res, true);
+		
+		verify(col).update(new BasicDBObject("chksum", md5),
+				new BasicDBObject("chksum", md5)
+					.append("node", "ca4a4b5a-b676-4090-9a7d-9690189e29be")
+					.append("ver", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2")
+					.append("sorted", true),
+				true, false);
+	}
+	
+	@Test
+	public void saveBlob4AttemptsAndSortedFalse() throws Exception {
+		final String md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		final Restreamable res = mock(Restreamable.class);
+		// normally you shouldn't mock value classes but these can't be instantiated
+		// because I'm a dummy
+		final ShockNode sn1 = mock(ShockNode.class);
+		final ShockNode sn2 = mock(ShockNode.class);
+		final ShockNode sn3 = mock(ShockNode.class);
+		final ShockNode sn4 = mock(ShockNode.class);
+		final ShockNode sn5 = mock(ShockNode.class);
+		final ShockFileInformation sfi1 = mock(ShockFileInformation.class);
+		final ShockFileInformation sfi2 = mock(ShockFileInformation.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		when(col.findOne(new BasicDBObject("chksum", md5))).thenReturn(null);
+		
+		final InputStream stream = new ByteArrayInputStream("foo".getBytes());
+		
+		when(res.getInputStream()).thenReturn(stream);
+		
+		when(client.addNode(stream, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
+				.thenReturn(sn1, sn2, sn3, sn4, sn5);
+		
+		when(sfi1.getChecksum("md5")).thenReturn("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3");
+		when(sfi2.getChecksum("md5")).thenReturn(md5);
+		
+		when(sn1.getId()).thenReturn(new ShockNodeId("ca4a4b5a-b676-4090-9a7d-9690189e29be"));
+		when(sn1.getFileInformation()).thenReturn(sfi1);
+		when(sn2.getId()).thenReturn(new ShockNodeId("5da17b70-bfc1-41d3-8180-a0f2610d9609"));
+		when(sn2.getFileInformation()).thenReturn(sfi1);
+		when(sn3.getId()).thenReturn(new ShockNodeId("d73e0326-900f-44db-a359-4f297e6270a8"));
+		when(sn3.getFileInformation()).thenReturn(sfi1);
+		when(sn4.getId()).thenReturn(new ShockNodeId("3d82bbee-1c4b-44f6-982f-d4e5db8533b4"));
+		when(sn4.getFileInformation()).thenReturn(sfi1);
+		
+		when(sn5.getId()).thenReturn(new ShockNodeId("b6ce18d4-fc39-45c0-9918-d4d5800a8f43"));
+		when(sn5.getFileInformation()).thenReturn(sfi2);
+		when(sn5.getVersion()).thenReturn(
+				new ShockVersionStamp("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2"));
+		
+		sbs.saveBlob(new MD5(md5), res, false);
+		
+		verify(client).deleteNode(new ShockNodeId("ca4a4b5a-b676-4090-9a7d-9690189e29be"));
+		verify(client).deleteNode(new ShockNodeId("5da17b70-bfc1-41d3-8180-a0f2610d9609"));
+		verify(client).deleteNode(new ShockNodeId("d73e0326-900f-44db-a359-4f297e6270a8"));
+		verify(client).deleteNode(new ShockNodeId("3d82bbee-1c4b-44f6-982f-d4e5db8533b4"));
+		
+		verify(col).update(new BasicDBObject("chksum", md5),
+				new BasicDBObject("chksum", md5)
+					.append("node", "b6ce18d4-fc39-45c0-9918-d4d5800a8f43")
+					.append("ver", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2")
+					.append("sorted", false),
+				true, false);
+	}
+	
+	@Test
+	public void saveBlobFailOn5Attempts() throws Exception {
+		final String md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		final Restreamable res = mock(Restreamable.class);
+		// normally you shouldn't mock value classes but these can't be instantiated
+		// because I'm a dummy
+		final ShockNode sn1 = mock(ShockNode.class);
+		final ShockNode sn2 = mock(ShockNode.class);
+		final ShockNode sn3 = mock(ShockNode.class);
+		final ShockNode sn4 = mock(ShockNode.class);
+		final ShockNode sn5 = mock(ShockNode.class);
+		final ShockFileInformation sfi1 = mock(ShockFileInformation.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		when(col.findOne(new BasicDBObject("chksum", md5))).thenReturn(null);
+		
+		final InputStream stream = new ByteArrayInputStream("foo".getBytes());
+		
+		when(res.getInputStream()).thenReturn(stream);
+		
+		when(client.addNode(stream, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
+				.thenReturn(sn1, sn2, sn3, sn4, sn5);
+		
+		when(sfi1.getChecksum("md5")).thenReturn("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3");
+		
+		when(sn1.getId()).thenReturn(new ShockNodeId("ca4a4b5a-b676-4090-9a7d-9690189e29be"));
+		when(sn1.getFileInformation()).thenReturn(sfi1);
+		when(sn2.getId()).thenReturn(new ShockNodeId("5da17b70-bfc1-41d3-8180-a0f2610d9609"));
+		when(sn2.getFileInformation()).thenReturn(sfi1);
+		when(sn3.getId()).thenReturn(new ShockNodeId("d73e0326-900f-44db-a359-4f297e6270a8"));
+		when(sn3.getFileInformation()).thenReturn(sfi1);
+		when(sn4.getId()).thenReturn(new ShockNodeId("3d82bbee-1c4b-44f6-982f-d4e5db8533b4"));
+		when(sn4.getFileInformation()).thenReturn(sfi1);
+		when(sn5.getId()).thenReturn(new ShockNodeId("b6ce18d4-fc39-45c0-9918-d4d5800a8f43"));
+		when(sn5.getFileInformation()).thenReturn(sfi1);
+		
+		failSaveBlob(sbs, new MD5(md5), res, false,
+				new BlobStoreCommunicationException(
+						"Blob save failed with non-matching md5 five times. " +
+						"Workspace: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1, " +
+						"Shock: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3"));
+		
+		verify(client).deleteNode(new ShockNodeId("ca4a4b5a-b676-4090-9a7d-9690189e29be"));
+		verify(client).deleteNode(new ShockNodeId("5da17b70-bfc1-41d3-8180-a0f2610d9609"));
+		verify(client).deleteNode(new ShockNodeId("d73e0326-900f-44db-a359-4f297e6270a8"));
+		verify(client).deleteNode(new ShockNodeId("3d82bbee-1c4b-44f6-982f-d4e5db8533b4"));
+		verify(client).deleteNode(new ShockNodeId("b6ce18d4-fc39-45c0-9918-d4d5800a8f43"));
+	}
+
+	private void failSaveBlob(
+			final ShockBlobStore sbs,
+			final MD5 md5,
+			final Restreamable res,
+			final boolean sorted,
+			final Exception expected) {
+		try {
+			sbs.saveBlob(md5, res, sorted);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+	
+	@Test
+	public void saveBlobFailMongoOnGet() {
+		final String md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		final Restreamable res = mock(Restreamable.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		when(col.findOne(new BasicDBObject("chksum", md5))).thenThrow(new MongoException("foo"));
+		
+		failSaveBlob(sbs, new MD5(md5), res, true, new BlobStoreCommunicationException(
+				"Could not read from the mongo database"));
+	}
+	
+	@Test
+	public void saveBlobFailOnSaveNode() throws Exception {
+		saveBlobFailOnSaveNode(new JsonMappingException("foo"),
+				new RuntimeException("Attribute serialization failed: foo"));
+		saveBlobFailOnSaveNode(new IOException("bar"), new BlobStoreCommunicationException(
+				"Could not connect to the shock backend: bar"));
+		saveBlobFailOnSaveNode(new ShockHttpException(1, "baz"),
+				new BlobStoreCommunicationException("Failed to create shock node: baz"));
+	}
+
+	private void saveBlobFailOnSaveNode(final Exception thrown, final Exception expected)
+			throws Exception {
+		final String md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		final Restreamable res = mock(Restreamable.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		when(col.findOne(new BasicDBObject("chksum", md5))).thenReturn(null);
+		
+		final InputStream stream = new ByteArrayInputStream("foo".getBytes());
+		
+		when(res.getInputStream()).thenReturn(stream);
+		
+		when(client.addNode(stream, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
+				.thenThrow(thrown);
+		
+		failSaveBlob(sbs, new MD5(md5), res, true, expected);
+	}
+	
+	@Test
+	public void saveBlobFailOnMongoWrite() throws Exception {
+		final String md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		final Restreamable res = mock(Restreamable.class);
+		// normally you shouldn't mock value classes but these can't be instantiated
+		// because I'm a dummy
+		final ShockNode sn = mock(ShockNode.class);
+		final ShockFileInformation sfi = mock(ShockFileInformation.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		when(col.findOne(new BasicDBObject("chksum", md5))).thenReturn(null);
+		
+		final InputStream stream = new ByteArrayInputStream("foo".getBytes());
+		
+		when(res.getInputStream()).thenReturn(stream);
+		
+		when(client.addNode(stream, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
+				.thenReturn(sn);
+		
+		when(sn.getId()).thenReturn(new ShockNodeId("ca4a4b5a-b676-4090-9a7d-9690189e29be"));
+		when(sn.getVersion()).thenReturn(
+				new ShockVersionStamp("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2"));
+		when(sn.getFileInformation()).thenReturn(sfi);
+		when(sfi.getChecksum("md5")).thenReturn(md5);
+		
+		when(col.update(new BasicDBObject("chksum", md5),
+				new BasicDBObject("chksum", md5)
+					.append("node", "ca4a4b5a-b676-4090-9a7d-9690189e29be")
+					.append("ver", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2")
+					.append("sorted", true),
+				true, false))
+				.thenThrow(new MongoException("baz"));
+		
+		failSaveBlob(sbs, new MD5(md5), res, true, new BlobStoreCommunicationException(
+				"Could not write to the mongo database"));
+	}
+	
+	@Test
+	public void saveBlobFailOnDeleteNode() throws Exception {
+		saveBlobFailOnDeleteNode(new IOException("foo"), new BlobStoreCommunicationException(
+				"Could not connect to the Shock backend: foo"));
+		saveBlobFailOnDeleteNode(new ShockHttpException(1, "bar"),
+				new BlobStoreCommunicationException("Failed to delete Shock node: bar"));
+	}
+
+	private void saveBlobFailOnDeleteNode(final Exception thrown, final Exception expected)
+			throws Exception {
+		final String md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		final Restreamable res = mock(Restreamable.class);
+		// normally you shouldn't mock value classes but these can't be instantiated
+		// because I'm a dummy
+		final ShockNode sn1 = mock(ShockNode.class);
+		final ShockFileInformation sfi1 = mock(ShockFileInformation.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		when(col.findOne(new BasicDBObject("chksum", md5))).thenReturn(null);
+		
+		final InputStream stream = new ByteArrayInputStream("foo".getBytes());
+		
+		when(res.getInputStream()).thenReturn(stream);
+		
+		when(client.addNode(stream, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
+				.thenReturn(sn1);
+		
+		when(sfi1.getChecksum("md5")).thenReturn("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3");
+		
+		when(sn1.getId()).thenReturn(new ShockNodeId("ca4a4b5a-b676-4090-9a7d-9690189e29be"));
+		when(sn1.getFileInformation()).thenReturn(sfi1);
+		
+		doThrow(thrown)
+				.when(client).deleteNode(new ShockNodeId("ca4a4b5a-b676-4090-9a7d-9690189e29be"));
+		
+		failSaveBlob(sbs, new MD5(md5), res, true, expected);
+	}
+	
+	@Test
+	public void removeBlobNoop() throws Exception {
+		final String md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		final DBObject dbo = new BasicDBObject();
+		dbo.put("chksum", 1);
+		final DBObject opts = new BasicDBObject();
+		opts.put("unique", 1);
+		// need to verify so verifyNoMoreInteractions() works
+		verify(col).createIndex(dbo, opts);
+		
+		when(col.findOne(new BasicDBObject("chksum", md5))).thenReturn(null);
+		
+		sbs.removeBlob(new MD5(md5));
+		// same as the when() above
+		verify(col).findOne(new BasicDBObject("chksum", md5));
+		
+		verifyZeroInteractions(client);
+		verifyNoMoreInteractions(col);
+	}
+	
+	@Test
+	public void removeBlob() throws Exception {
+		final String md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		when(col.findOne(new BasicDBObject("chksum", md5))).thenReturn(
+				new BasicDBObject("node", "ca4a4b5a-b676-4090-9a7d-9690189e29be"));
+		
+		sbs.removeBlob(new MD5(md5));
+		
+		verify(col).remove(new BasicDBObject("chksum", md5));
+		verify(client).deleteNode(new ShockNodeId("ca4a4b5a-b676-4090-9a7d-9690189e29be"));
+	}
+	
+	@Test
+	public void removeBlobFailReadMongo() throws Exception {
+		final String md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		when(col.findOne(new BasicDBObject("chksum", md5))).thenThrow(new MongoException("foo"));
+		
+		failRemoveBlob(sbs, new MD5(md5), new BlobStoreCommunicationException(
+				"Could not read from the mongo database"));
+	}
+
+	private void failRemoveBlob(
+			final ShockBlobStore sbs,
+			final MD5 md5,
+			final Exception expected) {
+		try {
+			sbs.removeBlob(md5);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+	
+	@Test
+	public void removeBlobFailOnDeleteNode() throws Exception {
+		removeBlobFailOnDeleteNode(new IOException("foo"), new BlobStoreCommunicationException(
+				"Could not connect to the Shock backend: foo"));
+		removeBlobFailOnDeleteNode(new ShockHttpException(1, "bar"),
+				new BlobStoreCommunicationException("Failed to delete Shock node: bar"));
+	}
+
+	private void removeBlobFailOnDeleteNode(final Exception thrown, final Exception expected)
+			throws Exception {
+		final String md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+		final DBCollection col = mock(DBCollection.class);
+		final BasicShockClient client = mock(BasicShockClient.class);
+		
+		final ShockBlobStore sbs = new ShockBlobStore(col, client);
+		
+		when(col.findOne(new BasicDBObject("chksum", md5))).thenReturn(
+				new BasicDBObject("node", "ca4a4b5a-b676-4090-9a7d-9690189e29be"));
+		
+		doThrow(thrown)
+				.when(client).deleteNode(new ShockNodeId("ca4a4b5a-b676-4090-9a7d-9690189e29be"));
+		
+		failRemoveBlob(sbs, new MD5(md5), expected);
+	}
+	
+	// TODO TEST getBlob, removeAllBlobs, getExternalIdentifier tests
+}
+


### PR DESCRIPTION
More of a workaround than a fix - just checks that the MD5 is the same
between shock and the workspace, and if not, deletes the node and tries
again.

The actual changes to the logic are pretty small; most of the PR is adding unit tests. Only integration tests existed before, which couldn't reproduce the bug.