### PR TITLE
Add AdministratorHandler interface

### DIFF
--- a/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
+++ b/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
@@ -43,6 +43,7 @@ import us.kbase.workspace.database.ResourceUsageConfigurationBuilder;
 import us.kbase.workspace.database.Types;
 import us.kbase.workspace.database.Workspace;
 import us.kbase.workspace.database.WorkspaceDatabase;
+import us.kbase.workspace.database.WorkspaceUser;
 import us.kbase.workspace.database.exceptions.CorruptWorkspaceDBException;
 import us.kbase.workspace.database.exceptions.WorkspaceDBException;
 import us.kbase.workspace.database.mongo.BlobStore;
@@ -50,6 +51,7 @@ import us.kbase.workspace.database.mongo.GridFSBlobStore;
 import us.kbase.workspace.database.mongo.MongoWorkspaceDB;
 import us.kbase.workspace.database.mongo.ShockBlobStore;
 import us.kbase.workspace.kbase.KBaseWorkspaceConfig.ListenerConfig;
+import us.kbase.workspace.kbase.admin.DefaultAdminHandler;
 import us.kbase.workspace.kbase.admin.WorkspaceAdministration;
 import us.kbase.workspace.listener.ListenerInitializationException;
 import us.kbase.workspace.listener.WorkspaceEventListener;
@@ -188,8 +190,10 @@ public class InitWorkspaceServer {
 		WorkspaceServerMethods wsmeth = new WorkspaceServerMethods(
 				ws, types, cfg.getHandleServiceURL(), cfg.getHandleManagerURL(),
 				handleMgrToken, maxUniqueIdCountPerCall, auth);
+		final String a = cfg.getWorkspaceAdmin();
+		final WorkspaceUser admin = a == null || a.trim().isEmpty() ? null : new WorkspaceUser(a);
 		WorkspaceAdministration wsadmin = new WorkspaceAdministration(
-				ws, wsmeth, types, cfg.getWorkspaceAdmin());
+				ws, wsmeth, types, new DefaultAdminHandler(ws, admin));
 		final String mem = String.format(
 				"Started workspace server instance %s. Free mem: %s Total mem: %s, Max mem: %s",
 				++instanceCount, Runtime.getRuntime().freeMemory(),

--- a/src/us/kbase/workspace/kbase/admin/AdminRole.java
+++ b/src/us/kbase/workspace/kbase/admin/AdminRole.java
@@ -1,0 +1,18 @@
+package us.kbase.workspace.kbase.admin;
+
+/** An administration role possessed by a user.
+ * @author gaprice@lbl.gov
+ *
+ */
+public enum AdminRole {
+
+	/** Full administration privileges. */
+	ADMIN,
+	
+	/** Read only privileges. */
+	READ_ONLY,
+	
+	/** No administration privileges. */
+	NONE;
+	
+}

--- a/src/us/kbase/workspace/kbase/admin/AdministratorHandler.java
+++ b/src/us/kbase/workspace/kbase/admin/AdministratorHandler.java
@@ -1,0 +1,49 @@
+package us.kbase.workspace.kbase.admin;
+
+import java.util.Set;
+
+import us.kbase.auth.AuthToken;
+import us.kbase.workspace.database.WorkspaceUser;
+
+/** A handler for dealing with workspace administrators.
+ * 
+ * There are two types of expected implementations:
+ * 
+ * 1) an internal implementation, where the workspace itself stores the admin list. This
+ * implementation currently only supports full admins, not read only admins.
+ * 
+ * 2) external implementations that may support read only admins, and probably do not support
+ * any methods other than {@link #getAdminRole(AuthToken)}.
+ * @author gaprice@lbl.gov
+ *
+ */
+public interface AdministratorHandler {
+
+	/** Get the list of workspace admins.
+	 * @return the admins.
+	 * @throws AdministratorHandlerException if the admins could not be returned.
+	 */
+	Set<WorkspaceUser> getAdmins() throws AdministratorHandlerException;
+	
+	// at some point might want to allow setting roles here, but YAGNI.
+	
+	/** Add an administrator to the list of workspace adminstrators with full permissions.
+	 * @param user the user to make an admin
+	 * @throws AdministratorHandlerException if the operation failed.
+	 */
+	void addAdmin(WorkspaceUser user) throws AdministratorHandlerException;
+	
+	/** Remove an admin.
+	 * @param user the user to remove from the admin list.
+	 * @throws AdministratorHandlerException the the operation failed.
+	 */
+	void removeAdmin(WorkspaceUser user) throws AdministratorHandlerException;
+	
+	/** Get the role for an admin.
+	 * @param token the administrator's token.
+	 * @return the administrator's role.
+	 * @throws AdministratorHandlerException if the operation failed.
+	 */
+	AdminRole getAdminRole(AuthToken token) throws AdministratorHandlerException;
+	
+}

--- a/src/us/kbase/workspace/kbase/admin/AdministratorHandlerException.java
+++ b/src/us/kbase/workspace/kbase/admin/AdministratorHandlerException.java
@@ -1,0 +1,18 @@
+package us.kbase.workspace.kbase.admin;
+
+/** An exception thrown from an administrator handler.
+ * @author gaprice@lbl.gov
+ *
+ */
+@SuppressWarnings("serial")
+public class AdministratorHandlerException extends Exception {
+
+	public AdministratorHandlerException(final String message) {
+		super(message);
+	}
+	
+	public AdministratorHandlerException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/src/us/kbase/workspace/kbase/admin/DefaultAdminHandler.java
+++ b/src/us/kbase/workspace/kbase/admin/DefaultAdminHandler.java
@@ -1,0 +1,90 @@
+package us.kbase.workspace.kbase.admin;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.common.base.Optional;
+
+import us.kbase.auth.AuthToken;
+import us.kbase.workspace.database.Workspace;
+import us.kbase.workspace.database.WorkspaceUser;
+import us.kbase.workspace.database.exceptions.WorkspaceCommunicationException;
+
+/** The standard workspace administrator handler, where the administrators are stored within
+ * the workspace database.
+ * 
+ * Only supports the {@link AdminRole#ADMIN} role.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class DefaultAdminHandler implements AdministratorHandler {
+
+	private final Workspace ws;
+	private final Optional<WorkspaceUser> startupAdmin;
+	
+	//should eventually change this so it doesn't depend on the Workspace class and has a separate DB. YAGNI for now.
+	
+	/** Create the handler.
+	 * @param ws the workspace instance.
+	 * @param startupAdmin a bootstrap admin that can be used to add other admins the first time
+	 * the workspace starts up.
+	 */
+	public DefaultAdminHandler(final Workspace ws, final WorkspaceUser startupAdmin) {
+		checkNotNull(ws, "ws");
+		this.ws = ws;
+		this.startupAdmin = Optional.fromNullable(startupAdmin);
+	}
+	
+	@Override
+	public Set<WorkspaceUser> getAdmins() throws AdministratorHandlerException {
+		final Set<WorkspaceUser> strAdm = new HashSet<>();
+		try {
+			strAdm.addAll(ws.getAdmins());
+		} catch (WorkspaceCommunicationException e) {
+			throw new AdministratorHandlerException(
+					"Couldn't retrieve list of administrators: " + e.getMessage(), e);
+		}
+		if (startupAdmin.isPresent()) {
+			strAdm.add(startupAdmin.get());
+		}
+		return strAdm;
+	}
+
+	@Override
+	public void addAdmin(final WorkspaceUser user) throws AdministratorHandlerException {
+		try {
+			ws.addAdmin(user);
+		} catch (WorkspaceCommunicationException e) {
+			throw new AdministratorHandlerException(
+					"Couldn't add administrator: " + e.getMessage(), e);
+		}
+	}
+
+	@Override
+	public void removeAdmin(final WorkspaceUser user) throws AdministratorHandlerException {
+		try {
+			ws.removeAdmin(user);
+		} catch (WorkspaceCommunicationException e) {
+			throw new AdministratorHandlerException(
+					"Couldn't remove administrator: " + e.getMessage(), e);
+		}
+	}
+
+	@Override
+	public AdminRole getAdminRole(final AuthToken token) throws AdministratorHandlerException {
+		checkNotNull(token, "token");
+		if (startupAdmin.isPresent() && token.getUserName().equals(startupAdmin.get().getUser())) {
+			return AdminRole.ADMIN;
+		}
+		try {
+			return ws.isAdmin(new WorkspaceUser(token.getUserName())) ?
+					AdminRole.ADMIN : AdminRole.NONE;
+		} catch (WorkspaceCommunicationException e) {
+			throw new AdministratorHandlerException(
+					"Couldn't verify administrator: " + e.getMessage(), e);
+		}
+	}
+
+}

--- a/src/us/kbase/workspace/test/kbase/LoggingTest.java
+++ b/src/us/kbase/workspace/test/kbase/LoggingTest.java
@@ -73,7 +73,7 @@ public class LoggingTest {
 	private static final String SERV =
 			"us.kbase.workspace.WorkspaceServer";
 	private static final String ADMIN =
-			"us.kbase.workspace.kbase.WorkspaceAdministration";
+			"us.kbase.workspace.kbase.admin.WorkspaceAdministration";
 	
 	private static final String DB_WS_NAME = "LoggingTest";
 	private static final String DB_TYPE_NAME = "LoggingTest_Types";

--- a/src/us/kbase/workspace/test/kbase/admin/DefaultAdminHandlerTest.java
+++ b/src/us/kbase/workspace/test/kbase/admin/DefaultAdminHandlerTest.java
@@ -1,0 +1,195 @@
+package us.kbase.workspace.test.kbase.admin;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static us.kbase.common.test.TestCommon.set;
+
+import org.junit.Test;
+
+import us.kbase.auth.AuthToken;
+import us.kbase.common.test.TestCommon;
+import us.kbase.workspace.database.Workspace;
+import us.kbase.workspace.database.WorkspaceUser;
+import us.kbase.workspace.database.exceptions.WorkspaceCommunicationException;
+import us.kbase.workspace.kbase.admin.AdminRole;
+import us.kbase.workspace.kbase.admin.AdministratorHandlerException;
+import us.kbase.workspace.kbase.admin.DefaultAdminHandler;
+
+public class DefaultAdminHandlerTest {
+	
+	@Test
+	public void failConstruct() {
+		try {
+			new DefaultAdminHandler(null, null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("ws"));
+		}
+	}
+	
+	@Test
+	public void listAdminsNoStartupAdmin() throws Exception {
+		final Workspace ws = mock(Workspace.class);
+		final DefaultAdminHandler dah = new DefaultAdminHandler(ws, null);
+		
+		when(ws.getAdmins()).thenReturn(set(new WorkspaceUser("foo"), new WorkspaceUser("bar")));
+		
+		assertThat("incorrect admins", dah.getAdmins(), is(
+				set(new WorkspaceUser("foo"), new WorkspaceUser("bar"))));
+	}
+	
+	@Test
+	public void listAdminsWithStartupAdmin() throws Exception {
+		final Workspace ws = mock(Workspace.class);
+		final DefaultAdminHandler dah = new DefaultAdminHandler(ws, new WorkspaceUser("baz"));
+		
+		when(ws.getAdmins()).thenReturn(set(new WorkspaceUser("foo"), new WorkspaceUser("bar")));
+		
+		assertThat("incorrect admins", dah.getAdmins(), is(
+				set(new WorkspaceUser("foo"), new WorkspaceUser("bar"),
+						new WorkspaceUser("baz"))));
+	}
+	
+	@Test
+	public void failListAdmins() throws Exception {
+		final Workspace ws = mock(Workspace.class);
+		final DefaultAdminHandler dah = new DefaultAdminHandler(ws, new WorkspaceUser("baz"));
+		
+		when(ws.getAdmins()).thenThrow(new WorkspaceCommunicationException("whee"));
+		
+		try {
+			dah.getAdmins();
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new AdministratorHandlerException(
+					"Couldn't retrieve list of administrators: whee"));
+		}
+	}
+	
+	@Test
+	public void addAdmin() throws Exception {
+		final Workspace ws = mock(Workspace.class);
+		final DefaultAdminHandler dah = new DefaultAdminHandler(ws, new WorkspaceUser("baz"));
+		
+		dah.addAdmin(new WorkspaceUser("foo"));
+		
+		verify(ws).addAdmin(new WorkspaceUser("foo"));
+	}
+	
+	@Test
+	public void failAddAdmin() throws Exception {
+		final Workspace ws = mock(Workspace.class);
+		final DefaultAdminHandler dah = new DefaultAdminHandler(ws, new WorkspaceUser("baz"));
+		
+		doThrow(new WorkspaceCommunicationException("foo"))
+				.when(ws).addAdmin(new WorkspaceUser("foo"));
+		
+		try {
+			dah.addAdmin(new WorkspaceUser("foo"));
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new AdministratorHandlerException(
+					"Couldn't add administrator: foo"));
+		}
+	}
+	
+	@Test
+	public void removeAdmin() throws Exception {
+		final Workspace ws = mock(Workspace.class);
+		final DefaultAdminHandler dah = new DefaultAdminHandler(ws, new WorkspaceUser("baz"));
+		
+		dah.removeAdmin(new WorkspaceUser("foo"));
+		
+		verify(ws).removeAdmin(new WorkspaceUser("foo"));
+	}
+
+	@Test
+	public void failRemoveAdmin() throws Exception {
+		final Workspace ws = mock(Workspace.class);
+		final DefaultAdminHandler dah = new DefaultAdminHandler(ws, new WorkspaceUser("baz"));
+		
+		doThrow(new WorkspaceCommunicationException("foo"))
+				.when(ws).removeAdmin(new WorkspaceUser("foo"));
+		
+		try {
+			dah.removeAdmin(new WorkspaceUser("foo"));
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new AdministratorHandlerException(
+					"Couldn't remove administrator: foo"));
+		}
+	}
+	
+	@Test
+	public void getAdminRoleWithMatchingStartupAdmin() throws Exception {
+		final Workspace ws = mock(Workspace.class);
+		final DefaultAdminHandler dah = new DefaultAdminHandler(ws, new WorkspaceUser("baz"));
+		
+		assertThat("incorrect role", dah.getAdminRole(new AuthToken("fake", "baz")),
+				is(AdminRole.ADMIN));
+	}
+	
+	@Test
+	public void getAdminRoleWithoutMatchingStartupAdmin() throws Exception {
+		final Workspace ws = mock(Workspace.class);
+		final DefaultAdminHandler dah = new DefaultAdminHandler(ws, new WorkspaceUser("baz"));
+		
+		when(ws.isAdmin(new WorkspaceUser("bar"))).thenReturn(true);
+		
+		assertThat("incorrect role", dah.getAdminRole(new AuthToken("fake", "bar")),
+				is(AdminRole.ADMIN));
+	}
+	
+	@Test
+	public void getAdminRoleWithoutStartupAdmin() throws Exception {
+		final Workspace ws = mock(Workspace.class);
+		final DefaultAdminHandler dah = new DefaultAdminHandler(ws, null);
+		
+		when(ws.isAdmin(new WorkspaceUser("bar"))).thenReturn(true);
+		
+		assertThat("incorrect role", dah.getAdminRole(new AuthToken("fake", "bar")),
+				is(AdminRole.ADMIN));
+	}
+	
+	@Test
+	public void getAdminRoleWithNoneRole() throws Exception {
+		final Workspace ws = mock(Workspace.class);
+		final DefaultAdminHandler dah = new DefaultAdminHandler(ws, new WorkspaceUser("baz"));
+		
+		when(ws.isAdmin(new WorkspaceUser("bar"))).thenReturn(false);
+		
+		assertThat("incorrect role", dah.getAdminRole(new AuthToken("fake", "bar")),
+				is(AdminRole.NONE));
+	}
+	
+	@Test
+	public void getAdminRoleFail() throws Exception {
+		final Workspace ws = mock(Workspace.class);
+		final DefaultAdminHandler dah = new DefaultAdminHandler(ws, null);
+		
+		failGetAdminRole(dah, null, new NullPointerException("token"));
+		
+		when(ws.isAdmin(new WorkspaceUser("baz")))
+				.thenThrow(new WorkspaceCommunicationException("arrg"));
+		failGetAdminRole(dah, new AuthToken("fake", "baz"), new AdministratorHandlerException(
+				"Couldn't verify administrator: arrg"));
+	}
+
+	private void failGetAdminRole(
+			final DefaultAdminHandler dah,
+			final AuthToken token,
+			final Exception expected) {
+		try {
+			dah.getAdminRole(token);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+	
+}


### PR DESCRIPTION
Allows different sources of administrators. Currently only workspace
internal admin list is supported.

Also allows for read only admin role.

Next step is implementing the interface for auth2 roles.