### PR TITLE
SCT-223 Add cache for admin role to workspace administration method

### DIFF
--- a/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
+++ b/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
@@ -64,6 +64,8 @@ public class InitWorkspaceServer {
 	private static final String COL_SETTINGS = InitConstants.COL_SETTINGS;
 	public static final String COL_SHOCK_NODES = InitConstants.COL_SHOCK_NODES;
 	
+	private static final int ADMIN_CACHE_MAX_SIZE = 100; // seems like more than enough admins
+	private static final int ADMIN_CACHE_EXP_TIME_MS = 5 * 60 * 1000; // cache admin role for 5m
 	
 	private static int maxUniqueIdCountPerCall = 100000;
 
@@ -192,7 +194,8 @@ public class InitWorkspaceServer {
 		final String a = cfg.getWorkspaceAdmin();
 		final WorkspaceUser admin = a == null || a.trim().isEmpty() ? null : new WorkspaceUser(a);
 		WorkspaceAdministration wsadmin = new WorkspaceAdministration(
-				ws, wsmeth, types, new DefaultAdminHandler(ws, admin));
+				ws, wsmeth, types, new DefaultAdminHandler(ws, admin),
+				ADMIN_CACHE_MAX_SIZE, ADMIN_CACHE_EXP_TIME_MS);
 		final String mem = String.format(
 				"Started workspace server instance %s. Free mem: %s Total mem: %s, Max mem: %s",
 				++instanceCount, Runtime.getRuntime().freeMemory(),

--- a/src/us/kbase/workspace/kbase/admin/KBaseAuth2AdminHandler.java
+++ b/src/us/kbase/workspace/kbase/admin/KBaseAuth2AdminHandler.java
@@ -34,11 +34,8 @@ import us.kbase.workspace.database.WorkspaceUser;
  */
 public class KBaseAuth2AdminHandler implements AdministratorHandler {
 	
-	//TODO DOCS
-	//TODO NEWAUTH read only mode for admin
-	//TODO NEWAUTH unit tests for admin
+	//TODO NEWAUTH DOCS
 	//TODO NEWAUTH add to build - need 2 new config items
-	//TODO NEWAUTH add token cache in admin class (not in handler classes)
 	//TODO NEWAUTH integration tests
 	//TODO CODE retries for gets (should handled to some extent by the http client)
 


### PR DESCRIPTION
Since the workpace administration call is used by search and other
services to retrieve data, we cache the administration role of a user
for 5 minutes to reduce load on the admin role source (basically the
auth server) and speed up the calls. No point in fetching the user data
over and over every millisecond.

The token is already cached by the auth client, but the user info is not.

TODO
add to build - need 2 new config items
integration tests
docs