### PR TITLE
Fix NPE when getting objects saved before v0.4.1

### DIFF
--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -107,7 +107,7 @@ public class WorkspaceServer extends JsonServerServlet {
 	//TODO JAVADOC really low priority, sorry
 	//TODO INIT timestamps for startup script
 
-	private static final String VER = "0.9.0-dev1";
+	private static final String VER = "0.9.0-dev2";
 	private static final String GIT = "https://github.com/kbase/workspace_deluxe";
 
 	private static final long MAX_RPC_PACKAGE_SIZE = 1005000000;

--- a/src/us/kbase/workspace/database/Provenance.java
+++ b/src/us/kbase/workspace/database/Provenance.java
@@ -55,7 +55,8 @@ public class Provenance {
 	}
 	
 	public void setWorkspaceID(final Long wsid) {
-		if (wsid < 1) {
+		// objects saved before version 0.4.1 will have null workspace IDs
+		if (wsid != null && wsid < 1) {
 			throw new IllegalArgumentException("wsid must be > 0");
 		}
 		this.wsid = wsid;

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -2566,7 +2566,7 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		final Provenance ret = new Provenance(
 				new WorkspaceUser((String) p.get(Fields.PROV_USER)),
 				(Date) p.get(Fields.PROV_DATE));
-		// may be null for old workspaces
+		// objects saved before version 0.4.1 will have null workspace IDs
 		ret.setWorkspaceID((Long) p.get(Fields.PROV_WS_ID));
 		
 		@SuppressWarnings("unchecked")

--- a/src/us/kbase/workspace/test/database/mongo/MongoWorkspaceDBTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoWorkspaceDBTest.java
@@ -1,6 +1,7 @@
 package us.kbase.workspace.test.database.mongo;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -126,6 +127,7 @@ public class MongoWorkspaceDBTest {
 		MONGO_DB.getCollection("provenance").update(
 				new BasicDBObject("_id", i),
 				new BasicDBObject("$set", new BasicDBObject("actions.0.externalData", null)
+						.append("wsid", null)
 						.append("actions.0.subActions", null)
 						.append("actions.0.custom", null)
 						.append("actions.0.wsobjs", null)));
@@ -146,7 +148,7 @@ public class MongoWorkspaceDBTest {
 		//TODO TEST add equals methods to provenance classes & test & use here
 		assertThat("incorrect user", pgot.getUser(), is(new WorkspaceUser("u")));
 		assertThat("incorrect date", pgot.getDate(), is(new Date(10000)));
-		assertThat("incorrect wsid", pgot.getWorkspaceID(), is(1L));
+		assertThat("incorrect wsid", pgot.getWorkspaceID(), nullValue());
 		assertThat("incorrect action count", pgot.getActions().size(), is(1));
 		final ProvenanceAction pagot = pgot.getActions().get(0);
 		

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
@@ -92,7 +92,7 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 	
 	@Test
 	public void ver() throws Exception {
-		assertThat("got correct version", CLIENT_NO_AUTH.ver(), is("0.9.0-dev1"));
+		assertThat("got correct version", CLIENT_NO_AUTH.ver(), is("0.9.0-dev2"));
 	}
 	
 	@Test


### PR DESCRIPTION
Previously, Jongo just set the field directly rather than using the
method call.