### PR TITLE
Move creation of ID handlers to the service build stage

### DIFF
--- a/performance/us/kbase/workspace/performance/refsearch/GetReferencedObjectWithBFS.java
+++ b/performance/us/kbase/workspace/performance/refsearch/GetReferencedObjectWithBFS.java
@@ -23,6 +23,7 @@ import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.db.MongoTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIDWithRefPath;
 import us.kbase.workspace.database.ObjectIdentifier;
@@ -144,7 +145,8 @@ public class GetReferencedObjectWithBFS {
 	private static void runBranchedReferencesTest() throws Exception {
 		WorkspaceUser u1 = new WorkspaceUser("brcu1");
 		WorkspaceUser u2 = new WorkspaceUser("brcu2");
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(10);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(10).build().getFactory(null);
 		Provenance p = new Provenance(u1);
 		WorkspaceIdentifier read = new WorkspaceIdentifier("brcread");
 		WorkspaceIdentifier priv = new WorkspaceIdentifier("brcpriv");
@@ -180,7 +182,8 @@ public class GetReferencedObjectWithBFS {
 			List<ObjectInformation> increfs,
 			int breadth) 
 			throws Exception {
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(100000);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(100000).build().getFactory(null);
 		Provenance p = new Provenance(user);
 		List<WorkspaceSaveObject> objs = new LinkedList<WorkspaceSaveObject>();
 		for (ObjectInformation oi: increfs) {
@@ -212,7 +215,8 @@ public class GetReferencedObjectWithBFS {
 		WorkspaceIdentifier read = new WorkspaceIdentifier("linread");
 		WS.createWorkspace(u1, read.getName(), true, null, null);
 		
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(10000);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(10000).build().getFactory(null);
 		Provenance p = new Provenance(u1);
 		ObjectInformation o = WS.saveObjects(u1, priv, Arrays.asList(
 				new WorkspaceSaveObject(getRandomName(), new HashMap<String, String>(), LEAF_TYPE,
@@ -244,7 +248,8 @@ public class GetReferencedObjectWithBFS {
 		String ref = o.getWorkspaceId() + "/" + o.getObjectId() + "/" + o.getVersion();
 		Map<String, List<String>> refdata = new HashMap<String, List<String>>();
 		refdata.put("refs", Arrays.asList(ref));
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(10000);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(10000).build().getFactory(null);
 		Provenance p = new Provenance(u1);
 		return WS.saveObjects(u1, priv, Arrays.asList(
 				new WorkspaceSaveObject(getRandomName(), refdata, REF_TYPE, null, p, false)), fac)

--- a/performance/us/kbase/workspace/performance/refsearch/v0_3_5/GetReferencedObjectWithBFS.java
+++ b/performance/us/kbase/workspace/performance/refsearch/v0_3_5/GetReferencedObjectWithBFS.java
@@ -21,6 +21,7 @@ import us.kbase.typedobj.core.TypeDefName;
 //import us.kbase.typedobj.db.MongoTypeStorage;
 //import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 //import us.kbase.workspace.database.DefaultReferenceParser;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIdentifier;
@@ -150,7 +151,8 @@ public class GetReferencedObjectWithBFS {
 	private static void runBranchedReferencesTest() throws Exception {
 		WorkspaceUser u1 = new WorkspaceUser("brcu1");
 		WorkspaceUser u2 = new WorkspaceUser("brcu2");
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(10);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(10).build().getFactory(null);
 		Provenance p = new Provenance(u1);
 		WorkspaceIdentifier read = new WorkspaceIdentifier("brcread");
 		WorkspaceIdentifier priv = new WorkspaceIdentifier("brcpriv");
@@ -187,7 +189,8 @@ public class GetReferencedObjectWithBFS {
 			List<ObjectInformation> increfs,
 			int breadth) 
 			throws Exception {
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(100000);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(100000).build().getFactory(null);
 		Provenance p = new Provenance(user);
 		List<WorkspaceSaveObject> objs = new LinkedList<WorkspaceSaveObject>();
 		for (ObjectInformation oi: increfs) {
@@ -220,7 +223,8 @@ public class GetReferencedObjectWithBFS {
 		WorkspaceIdentifier read = new WorkspaceIdentifier("linread");
 		WS.createWorkspace(u1, read.getName(), true, null, null);
 		
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(10000);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(10000).build().getFactory(null);
 		Provenance p = new Provenance(u1);
 		ObjectInformation o = WS.saveObjects(u1, priv, Arrays.asList(
 				new WorkspaceSaveObject(getRandomName(), new HashMap<String, String>(), LEAF_TYPE,
@@ -251,7 +255,8 @@ public class GetReferencedObjectWithBFS {
 		String ref = o.getWorkspaceId() + "/" + o.getObjectId() + "/" + o.getVersion();
 		Map<String, List<String>> refdata = new HashMap<String, List<String>>();
 		refdata.put("refs", Arrays.asList(ref));
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(10000);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(10000).build().getFactory(null);
 		Provenance p = new Provenance(u1);
 		return WS.saveObjects(u1, priv, Arrays.asList(
 				new WorkspaceSaveObject(getRandomName(), refdata, REF_TYPE, null, p, false)), fac)

--- a/src/us/kbase/typedobj/core/IdRefTokenSequenceProvider.java
+++ b/src/us/kbase/typedobj/core/IdRefTokenSequenceProvider.java
@@ -57,9 +57,6 @@ public class IdRefTokenSequenceProvider implements TokenSequenceProvider {
 		if (jts == null) {
 			throw new NullPointerException("jts");
 		}
-		if (idhandlers == null) {
-			throw new NullPointerException("idhandlers");
-		}
 		this.jts = jts;
 		this.schemaLoc = new ArrayList<JsonTokenValidationSchema>(
 				Arrays.asList(schema));
@@ -167,11 +164,10 @@ public class IdRefTokenSequenceProvider implements TokenSequenceProvider {
 			final IdReferenceType idType = s.getIdReferenceType();
 			final List<String> attribs = s.getIdReferenceAttributes();
 			if (ref != null) {
-				if (ref.equals(new IdReference<String>(
-						idType, ret, attribs))) {
+				if (ref.equals(new IdReference<String>(idType, ret, attribs))) {
 					foundPath = new JsonDocumentLocation(path);
 				}
-			} else if (handlers.hasHandler(idType)) {
+			} else if (handlers != null && handlers.hasHandler(idType)) {
 				return handlers.getRemappedId(idType, ret).getId();
 			}
 		}

--- a/src/us/kbase/typedobj/core/ValidatedTypedObject.java
+++ b/src/us/kbase/typedobj/core/ValidatedTypedObject.java
@@ -26,7 +26,6 @@ import us.kbase.common.utils.sortjson.UTF8JsonSorterFactory;
 import us.kbase.typedobj.exceptions.ExceededMaxMetadataSizeException;
 import us.kbase.typedobj.idref.IdReference;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
-import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -402,10 +401,7 @@ public class ValidatedTypedObject implements Restreamable {
 			final IdReference<?> ref)
 					throws IOException {
 		JsonTokenStream jts = tokenStreamProvider.getPlacedStream();
-		IdRefTokenSequenceProvider idSubst =
-				new IdRefTokenSequenceProvider(jts, schema,
-						new IdReferenceHandlerSetFactory(0)
-							.createHandlers(String.class));
+		IdRefTokenSequenceProvider idSubst = new IdRefTokenSequenceProvider(jts, schema, null);
 		idSubst.setFindMode(ref);
 		try {
 			new JsonTokenStreamWriter().writeTokens(

--- a/src/us/kbase/typedobj/idref/IdReference.java
+++ b/src/us/kbase/typedobj/idref/IdReference.java
@@ -18,8 +18,7 @@ public class IdReference<T> {
 	public IdReference(final IdReferenceType type, final T id,
 			List<String> attributes) {
 		if (type == null || id == null) {
-			throw new NullPointerException(
-					"type, id, and location cannot be null");
+			throw new NullPointerException("type and id cannot be null");
 		}
 		this.type = type;
 		this.id = id;

--- a/src/us/kbase/typedobj/idref/IdReferenceHandlerSet.java
+++ b/src/us/kbase/typedobj/idref/IdReferenceHandlerSet.java
@@ -159,7 +159,8 @@ public class IdReferenceHandlerSet<T> {
 		public abstract IdReferenceType getIdType();
 	}
 
-	protected IdReferenceHandlerSet(final int maxUniqueIdCount,
+	protected IdReferenceHandlerSet(
+			final int maxUniqueIdCount,
 			final Map<IdReferenceType, IdReferenceHandler<T>> handlers) {
 		this.maxUniqueIdCount = maxUniqueIdCount;
 		this.handlers = new HashMap<IdReferenceType, IdReferenceHandler<T>>(

--- a/src/us/kbase/typedobj/idref/IdReferenceHandlerSetFactoryBuilder.java
+++ b/src/us/kbase/typedobj/idref/IdReferenceHandlerSetFactoryBuilder.java
@@ -1,0 +1,112 @@
+package us.kbase.typedobj.idref;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+import us.kbase.auth.AuthToken;
+import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandler;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFactory;
+
+/** A builder for a factory for a set of {@link IdReferenceHandler}s.
+ * 
+ * The reason for all this indirection is to allow the set of ID reference handlers to be
+ * configured early in the build process of an application, thus allowing for dependency injection.
+ * However, user credentials can not always be configured at the beginning of the process, so
+ * the builder allows for creating the factory at a later stage. For example, in the case of a
+ * server, the builder would probably be configured during the service build step, which
+ * happens once, and the factory created once for each service call, using the user credentials
+ * from that call. Finally, the factory can be used to create the actual set of handlers at
+ * at later stage of the application (for example when control of the service call has been
+ * handed off to an application library that has no knowledge of the service layer or user
+ * credentials, and that later stage can configure the handlers using
+ * {@link IdReferenceHandlerSetFactory#createHandlers(Class)} to determine what type of object will
+ * be used to categorized IDs.
+ * 
+ * @see IdReferenceHandlerSetFactory
+ * @see IdReferenceHandlerSet
+ * @see IdReferenceHandlerFactory
+ * @author gaprice@lbl.gov
+ *
+ */
+public class IdReferenceHandlerSetFactoryBuilder {
+	
+	private final Map<IdReferenceType, IdReferenceHandlerFactory> factories;
+	private final int maxUniqueIdCount;
+	
+	private IdReferenceHandlerSetFactoryBuilder(
+			final Map<IdReferenceType, IdReferenceHandlerFactory> factories,
+			final int maxUniqueIdCount) {
+		this.factories = factories;
+		this.maxUniqueIdCount = maxUniqueIdCount;
+	}
+	
+	// deliberately not implementing hashcode & equals
+	
+	/** Get a handler factory from this builder.
+	 * @param userToken the token for the user requesting processing of the IDs. The token
+	 * may be used to lookup and/or process information in authenticated resources. The token
+	 * may be null in the case where all the registered {@link IdReferenceHandlerFactory}s
+	 * do not require a token (see {@link Builder#withFactory(IdReferenceHandlerFactory)}.
+	 * @return a handler factory.
+	 */
+	public IdReferenceHandlerSetFactory getFactory(final AuthToken userToken) {
+		return new IdReferenceHandlerSetFactory(maxUniqueIdCount, factories, userToken);
+	}
+
+	/** Get a builder for a {@link IdReferenceHandlerSetFactoryBuilder}.
+	 * @param maxUniqueIdCount - the maximum number of unique IDs allowed in
+	 * this handler. The handler implementation defines what non-unique means,
+	 * but generally the definition is that the IDs are associated with the
+	 * same object and are the same ID.
+	 * @return a new builder.
+	 */
+	public static final Builder getBuilder(final int maxUniqueIdCount) {
+		return new Builder(maxUniqueIdCount);
+	}
+	
+	/** A builder for a {@link IdReferenceHandlerSetFactoryBuilder}.
+	 * @author gaprice@lbl.gov
+	 *
+	 */
+	public static class Builder {
+
+		private final int maxUniqueIdCount;
+		private final Map<IdReferenceType,IdReferenceHandlerFactory> factories = new HashMap<>();
+
+		private Builder(final int maxUniqueIdCount) {
+			if (maxUniqueIdCount < 0) {
+				throw new IllegalArgumentException(
+						"maxUniqueIdCount must be at least 0");
+			}
+			this.maxUniqueIdCount = maxUniqueIdCount;
+		}
+		
+		/** Add a factory to the builder. If the type of the factory is the same as the type
+		 * of a previously added factory, it will overwrite the older factory.
+		 * Factories can be added at a later stage of the build using
+		 * {@link IdReferenceHandlerSetFactory#addFactory(IdReferenceHandlerFactory)}.
+		 * @param factory the new factory.
+		 * @return this builder.
+		 */
+		public Builder withFactory(final IdReferenceHandlerFactory factory) {
+			if (factory == null) {
+				throw new NullPointerException("factory cannot be null");
+			}
+			if (factory.getIDType() == null) {
+				throw new NullPointerException("factory returned null for ID type");
+			}
+			factories.put(factory.getIDType(), factory);
+			return this;
+		}
+		
+		/** Build the factory builder.
+		 * @return the new factory builder.
+		 */
+		public IdReferenceHandlerSetFactoryBuilder build() {
+			return new IdReferenceHandlerSetFactoryBuilder(factories, maxUniqueIdCount);
+		}
+	}
+	
+
+}

--- a/src/us/kbase/typedobj/test/BasicValidationTest.java
+++ b/src/us/kbase/typedobj/test/BasicValidationTest.java
@@ -43,6 +43,7 @@ import us.kbase.typedobj.db.FileTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 
 
 /**
@@ -223,7 +224,8 @@ public class BasicValidationTest {
 	@Test
 	public void testInstance() throws Exception {
 		
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(6);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(6).build().getFactory(null);
 		IdReferenceHandlerSet<String> handler = fac.createHandlers(String.class);
 		handler.associateObject("foo");
 		

--- a/src/us/kbase/typedobj/test/DetailedValidationTest.java
+++ b/src/us/kbase/typedobj/test/DetailedValidationTest.java
@@ -47,6 +47,7 @@ import us.kbase.typedobj.db.FileTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 
 
 /**
@@ -230,7 +231,8 @@ public class DetailedValidationTest {
 		if(VERBOSE) System.out.println("  -TEST ("+resource.resourceName+") - instance of '"+typeName+"' expected result: "+expectedResult+".");
 		// actually perform the test and verify we get what is expected
 		
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(6);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(6).build().getFactory(null);
 		IdReferenceHandlerSet<String> handler = fac.createHandlers(String.class);
 		handler.associateObject("foo");
 		

--- a/src/us/kbase/typedobj/test/DummyIdHandlerFactory.java
+++ b/src/us/kbase/typedobj/test/DummyIdHandlerFactory.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import us.kbase.auth.AuthToken;
 import us.kbase.common.exceptions.UnimplementedException;
 import us.kbase.common.utils.Counter;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.HandlerLockedException;
@@ -106,7 +107,9 @@ public class DummyIdHandlerFactory implements IdReferenceHandlerFactory {
 	}
 
 	@Override
-	public <T> IdReferenceHandler<T> createHandler(final Class<T> clazz) {
+	public <T> IdReferenceHandler<T> createHandler(
+			final Class<T> clazz,
+			final AuthToken userToken) {
 		return new DummyIdHandler<T>(idMapping, foundIds);
 	}
 

--- a/src/us/kbase/typedobj/test/DummyValidatedTypedObject.java
+++ b/src/us/kbase/typedobj/test/DummyValidatedTypedObject.java
@@ -11,7 +11,7 @@ import us.kbase.common.service.UObject;
 import us.kbase.typedobj.core.AbsoluteTypeDefId;
 import us.kbase.typedobj.core.JsonTokenValidationSchema;
 import us.kbase.typedobj.core.ValidatedTypedObject;
-import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 
 /**
  * for testing, you can instantiate this report without running any validation code.
@@ -31,8 +31,8 @@ public class DummyValidatedTypedObject extends
 		super(data, type, Collections.<String>emptyList(), null,
 				JsonTokenValidationSchema.parseJsonSchema(
 						"{\"id\": \"foo\", \"type\": \"string\", \"original-type\": \"foo\"}"),
-				new IdReferenceHandlerSetFactory(6)
-					.createHandlers(String.class).processIDs());
+				IdReferenceHandlerSetFactoryBuilder.getBuilder(6).build().getFactory(null)
+						.createHandlers(String.class).processIDs());
 		this.data = data;
 	}
 	

--- a/src/us/kbase/typedobj/test/IdProcessingTest.java
+++ b/src/us/kbase/typedobj/test/IdProcessingTest.java
@@ -52,6 +52,7 @@ import us.kbase.typedobj.db.FileTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.typedobj.idref.IdReferenceType;
 
 /**
@@ -242,7 +243,8 @@ public class IdProcessingTest {
 				idsRootNode.get("ids-found"), Map.class); 
 		
 		Map<String, Integer> foundIDs = new HashMap<String, Integer>();
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(100);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(100).build().getFactory(null);
 		fac.addFactory(new DummyIdHandlerFactory(new IdReferenceType("ws"),
 				absoluteIdMapping, foundIDs));
 		fac.addFactory(new DummyIdHandlerFactory(new IdReferenceType("intid"),
@@ -271,7 +273,8 @@ public class IdProcessingTest {
 				.readTree(report.getInputStream());
 		
 		// now we revalidate the instance, and ensure that the labels have been renamed
-		IdReferenceHandlerSetFactory dummyfac = new IdReferenceHandlerSetFactory(0);
+		final IdReferenceHandlerSetFactory dummyfac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(0).build().getFactory(null);
 		ValidatedTypedObject report2 = validator.validate(relabeledInstance, new TypeDefId(new TypeDefName(instance.moduleName,instance.typeName)),
 				dummyfac.createHandlers(String.class).associateObject("foo"));
 		List <String> mssgs2 = report2.getErrorMessages();

--- a/src/us/kbase/typedobj/test/JsonTokenValidatorTester.java
+++ b/src/us/kbase/typedobj/test/JsonTokenValidatorTester.java
@@ -27,6 +27,7 @@ import us.kbase.typedobj.db.TypeStorage;
 import us.kbase.typedobj.db.test.TypeRegisteringTest;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 
 public class JsonTokenValidatorTester {
 	private static final long seed = 1234567890L;
@@ -65,8 +66,8 @@ public class JsonTokenValidatorTester {
 			jgen.close();
 			long time = System.currentTimeMillis();
 			JsonTokenStream jp = new JsonTokenStream(f);  //, buffer);
-			IdReferenceHandlerSetFactory fac =
-					new IdReferenceHandlerSetFactory(6);
+			final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+					.getBuilder(6).build().getFactory(null);
 			IdReferenceHandlerSet<String> han = fac.createHandlers(String.class);
 			han.associateObject("foo");
 			ValidatedTypedObject report = new TypedObjectValidator(

--- a/src/us/kbase/typedobj/test/MetadataExtractionTest.java
+++ b/src/us/kbase/typedobj/test/MetadataExtractionTest.java
@@ -49,6 +49,7 @@ import us.kbase.typedobj.db.FileTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 
 /**
  * Tests that ensure the proper subset is extracted from a typed object instance
@@ -213,7 +214,8 @@ public class MetadataExtractionTest {
 		if(maxMetadataSize!=null)
 			maxMetadataSizeLong = maxMetadataSize.asLong();
 		
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(6);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(6).build().getFactory(null);
 		IdReferenceHandlerSet<String> han =
 				fac.createHandlers(String.class).associateObject("foo");
 		ValidatedTypedObject report = 

--- a/src/us/kbase/typedobj/test/ProfileBasicValidation.java
+++ b/src/us/kbase/typedobj/test/ProfileBasicValidation.java
@@ -36,6 +36,7 @@ import us.kbase.typedobj.db.TypeStorage;
 import us.kbase.typedobj.db.test.TypeRegisteringTest;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 
 public class ProfileBasicValidation {
 	private final static String TEST_DB_LOCATION = "test/typedobj_test_files/t1";
@@ -180,8 +181,8 @@ public class ProfileBasicValidation {
 	}
 
 	private static void test(TestInstanceInfo instance) {
-		IdReferenceHandlerSetFactory fac =
-				new IdReferenceHandlerSetFactory(6);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(6).build().getFactory(null);
 		IdReferenceHandlerSet<String> han = fac.createHandlers(String.class);
 		han.associateObject("foo");
 		if(instance.isValid) {

--- a/src/us/kbase/typedobj/test/TypedObjectValidationReportTest.java
+++ b/src/us/kbase/typedobj/test/TypedObjectValidationReportTest.java
@@ -40,6 +40,7 @@ import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReference;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.typedobj.idref.IdReferenceType;
 
 public class TypedObjectValidationReportTest {
@@ -106,11 +107,16 @@ public class TypedObjectValidationReportTest {
 		
 	}
 
+	private IdReferenceHandlerSetFactory getFac(final int maxIds) {
+		return IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(maxIds).build().getFactory(null);
+	}
+	
 	@Test
 	public void errors() throws Exception {
 		String json = "{\"m\": {\"z\": 1, \"b\": []}}";
 		
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(100);
+		IdReferenceHandlerSetFactory fac = getFac(100);
 		ValidatedTypedObject tovr = validator.validate(json,
 				new TypeDefId("TestIDMap.IDMap"),
 				fac.createHandlers(String.class).associateObject("foo"));
@@ -140,7 +146,7 @@ public class TypedObjectValidationReportTest {
 	public void noSortFac() throws Exception {
 		String json = "{\"m\": {\"z\": \"a\", \"b\": \"d\"}}";
 		
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(100);
+		IdReferenceHandlerSetFactory fac = getFac(100);
 		fac.addFactory(new DummyIdHandlerFactory(new IdReferenceType("ws"),
 						new HashMap<String, String>()));
 		IdReferenceHandlerSet<String> handlers =
@@ -175,7 +181,7 @@ public class TypedObjectValidationReportTest {
 						"\"att2\":[\"b1\", 3, \"b2\", \"b3\", \"b4\"]}";
 		ValidatedTypedObject tovr = validator.validate(json,
 				new TypeDefId("TestIDMap.IDMap"), 
-				new IdReferenceHandlerSetFactory(1).createHandlers(String.class));
+				getFac(1).createHandlers(String.class));
 		
 		IdReferenceType wsType = new IdReferenceType("ws");
 		IdReferenceType foo1Type = new IdReferenceType("foo1");
@@ -242,8 +248,7 @@ public class TypedObjectValidationReportTest {
 		refmap.put("c", "c");
 		refmap.put("a", "a");
 		
-		IdReferenceHandlerSetFactory fac =
-				new IdReferenceHandlerSetFactory(100);
+		IdReferenceHandlerSetFactory fac = getFac(100);
 		fac.addFactory(new DummyIdHandlerFactory(
 				new IdReferenceType("ws"), refmap));
 		IdReferenceHandlerSet<String> handlers =
@@ -303,8 +308,7 @@ public class TypedObjectValidationReportTest {
 		String json = "{\"z\": \"a\", \"b\": \"d\"}";
 		String expectedJson = "{\"b\":\"d\",\"z\":\"a\"}";
 
-		IdReferenceHandlerSetFactory fac =
-				new IdReferenceHandlerSetFactory(100);
+		IdReferenceHandlerSetFactory fac = getFac(100);
 		IdReferenceHandlerSet<String> handlers =
 				fac.createHandlers(String.class).associateObject("foo");
 
@@ -333,7 +337,7 @@ public class TypedObjectValidationReportTest {
 		refmap.put("a", "a");
 		refmap.put("w", "w");
 		
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(100);
+		IdReferenceHandlerSetFactory fac = getFac(100);
 		fac.addFactory(new DummyIdHandlerFactory(new IdReferenceType("ws"), refmap));
 		IdReferenceHandlerSet<String> handlers =
 				fac.createHandlers(String.class).associateObject("foo");
@@ -361,7 +365,7 @@ public class TypedObjectValidationReportTest {
 		refmap.put("b", "b");
 		refmap.put("a", "a");
 		
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(100);
+		IdReferenceHandlerSetFactory fac = getFac(100);
 		fac.addFactory(new DummyIdHandlerFactory(new IdReferenceType("ws"), refmap));
 		IdReferenceHandlerSet<String> handlers =
 				fac.createHandlers(String.class).associateObject("foo");
@@ -392,8 +396,7 @@ public class TypedObjectValidationReportTest {
 		refmap.put("a", "a");
 		refmap.put("b", "b");
 		
-		IdReferenceHandlerSetFactory fac =
-				new IdReferenceHandlerSetFactory(100);
+		IdReferenceHandlerSetFactory fac = getFac(100);
 		fac.addFactory(new DummyIdHandlerFactory(new IdReferenceType("ws"),
 				refmap));
 		IdReferenceHandlerSet<String> handlers =
@@ -477,8 +480,7 @@ public class TypedObjectValidationReportTest {
 	public void keySize() throws Exception {
 		String json = "{\"z\":\"a\",\"b\":\"d\"}";
 		
-		IdReferenceHandlerSetFactory hfac =
-				new IdReferenceHandlerSetFactory(100);
+		IdReferenceHandlerSetFactory hfac = getFac(100);
 		IdReferenceHandlerSet<String> handlers =
 				hfac.createHandlers(String.class).associateObject("foo");
 		ValidatedTypedObject tovr = validator.validate(json,

--- a/src/us/kbase/typedobj/test/idref/IdReferenceHandlerSetFactoryBuilderTest.java
+++ b/src/us/kbase/typedobj/test/idref/IdReferenceHandlerSetFactoryBuilderTest.java
@@ -1,0 +1,135 @@
+package us.kbase.typedobj.test.idref;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static us.kbase.common.test.TestCommon.set;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import us.kbase.auth.AuthToken;
+import us.kbase.common.test.TestCommon;
+import us.kbase.typedobj.idref.IdReference;
+import us.kbase.typedobj.idref.IdReferenceHandlerSet;
+import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandler;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
+import us.kbase.typedobj.idref.IdReferenceType;
+
+public class IdReferenceHandlerSetFactoryBuilderTest {
+	
+	@Test
+	public void buildEmpty() throws Exception {
+		final IdReferenceHandlerSetFactoryBuilder b = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(0).build();
+		
+		final IdReferenceHandlerSetFactory f = b.getFactory(null);
+		
+		final IdReferenceHandlerSet<String> s = f.createHandlers(String.class);
+		
+		assertThat("incorrect types", s.getIDTypes(), is(set()));
+		assertThat("incorrect size", s.size(), is(0));
+		assertThat("incorrect max size", s.getMaximumIdCount(), is(0));
+	}
+	
+	@Test
+	public void buildWithFactoriesWithToken() throws Exception {
+		buildWithFactories(new AuthToken("token", "fake"));
+	}
+	
+	@Test
+	public void buildWithFactoriesWithNullToken() throws Exception {
+		buildWithFactories(null);
+	}
+
+	private void buildWithFactories(final AuthToken token) throws Exception {
+		final IdReferenceHandlerFactory fac1 = mock(IdReferenceHandlerFactory.class);
+		final IdReferenceHandlerFactory fac2 = mock(IdReferenceHandlerFactory.class);
+		final IdReferenceHandlerFactory fac3 = mock(IdReferenceHandlerFactory.class);
+		
+		@SuppressWarnings("unchecked")
+		final IdReferenceHandler<Long> h1 = mock(IdReferenceHandler.class);
+		@SuppressWarnings("unchecked")
+		final IdReferenceHandler<Long> h2 = mock(IdReferenceHandler.class);
+		@SuppressWarnings("unchecked")
+		final IdReferenceHandler<Long> h3 = mock(IdReferenceHandler.class);
+		
+		when(fac1.getIDType()).thenReturn(new IdReferenceType("t1"));
+		when(fac2.getIDType()).thenReturn(new IdReferenceType("t2"));
+		when(fac3.getIDType()).thenReturn(new IdReferenceType("t2")); // test overwrite
+		
+		final IdReferenceHandlerSetFactoryBuilder b = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(8)
+				.withFactory(fac1)
+				.withFactory(fac2)
+				.withFactory(fac3)
+				.build();
+		
+		final IdReferenceHandlerSetFactory f = b.getFactory(token);
+
+		when(fac1.createHandler(Long.class, token)).thenReturn(h1);
+		when(fac2.createHandler(Long.class, token)).thenReturn(h2);
+		when(fac3.createHandler(Long.class, token)).thenReturn(h3);
+		
+		final IdReferenceHandlerSet<Long> s = f.createHandlers(Long.class);
+		
+		assertThat("incorrect types", s.getIDTypes(),
+				is(set(new IdReferenceType("t1"), new IdReferenceType("t2"))));
+		assertThat("incorrect size", s.size(), is(0));
+		assertThat("incorrect max size", s.getMaximumIdCount(), is(8));
+		
+		s.associateObject(8L);
+		s.addStringId(new IdReference<String>(new IdReferenceType("t2"), "whee", null));
+		s.addStringId(new IdReference<String>(
+				new IdReferenceType("t1"), "whoo", Arrays.asList("a1", "a2")));
+		
+		verifyNoMoreInteractions(h2); // overwritten
+		verify(h1).addId(8L, "whoo", Arrays.asList("a1", "a2"));
+		verify(h3).addId(8L, "whee", Collections.emptyList());
+	}
+	
+	@Test
+	public void getBuilderFail() throws Exception {
+		try {
+			IdReferenceHandlerSetFactoryBuilder.getBuilder(-1);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got,
+					new IllegalArgumentException("maxUniqueIdCount must be at least 0"));
+		}
+	}
+	
+	@Test
+	public void withFactoryFail() throws Exception {
+		final IdReferenceHandlerSetFactoryBuilder.Builder b = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(1);
+		
+		withFactoryFail(b, null, new NullPointerException("factory cannot be null"));
+		
+		final IdReferenceHandlerFactory fac = mock(IdReferenceHandlerFactory.class);
+		when(fac.getIDType()).thenReturn(null);
+		
+		withFactoryFail(b, fac, new NullPointerException("factory returned null for ID type"));
+	}
+	
+	private void withFactoryFail(
+			final IdReferenceHandlerSetFactoryBuilder.Builder b,
+			final IdReferenceHandlerFactory fac,
+			final Exception expected) {
+		try {
+			b.withFactory(fac);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+
+}

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -24,6 +24,7 @@ import com.google.common.base.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
+import us.kbase.auth.AuthToken;
 import us.kbase.common.utils.sortjson.KeyDuplicationException;
 import us.kbase.common.utils.sortjson.TooManyKeysException;
 import us.kbase.common.utils.sortjson.UTF8JsonSorterFactory;
@@ -1696,8 +1697,7 @@ public class Workspace {
 		return new WorkspaceIDHandlerFactory(user);
 	}
 	
-	private class WorkspaceIDHandlerFactory
-			implements IdReferenceHandlerFactory {
+	private class WorkspaceIDHandlerFactory implements IdReferenceHandlerFactory {
 
 		private final WorkspaceUser user;
 		
@@ -1710,7 +1710,9 @@ public class Workspace {
 		}
 
 		@Override
-		public <T> IdReferenceHandler<T> createHandler(final Class<T> clazz) {
+		public <T> IdReferenceHandler<T> createHandler(
+				final Class<T> clazz,
+				final AuthToken token) { // unused, really don't like even having to import it
 			return new WorkspaceIDHandler<T>(user);
 		}
 

--- a/src/us/kbase/workspace/kbase/ArgUtils.java
+++ b/src/us/kbase/workspace/kbase/ArgUtils.java
@@ -491,6 +491,7 @@ public class ArgUtils {
 		
 	}
 
+	//TODO NOW refactor this into a class that gets passed into wsmethods, add to Idrefhandler
 	private static HandleError makeHandlesReadable(
 			final WorkspaceObjectData o,
 			final WorkspaceUser user,

--- a/src/us/kbase/workspace/kbase/HandleIdHandlerFactory.java
+++ b/src/us/kbase/workspace/kbase/HandleIdHandlerFactory.java
@@ -1,5 +1,7 @@
 package us.kbase.workspace.kbase;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
@@ -27,29 +29,23 @@ import us.kbase.typedobj.idref.RemappedId;
 public class HandleIdHandlerFactory implements IdReferenceHandlerFactory {
 
 	//TODO TEST unit tests
+	//TODO JAVADOC
 	
 	public static final IdReferenceType type = new IdReferenceType("handle");
 	private final URL handleService;
-	private final AuthToken userToken;
 	
 	/** pass in null for the handle service URL to cause an exception to be
 	 * thrown if a handle id is encountered
 	 */
-	public HandleIdHandlerFactory(
-			final URL handleServiceURL,
-			final AuthToken userToken) {
-		
-		if (userToken == null) {
-			throw new NullPointerException(
-					"userToken cannot be null");
-		}
+	public HandleIdHandlerFactory(final URL handleServiceURL) {
 		this.handleService = handleServiceURL;
-		this.userToken = userToken;
 	}
 	
 	@Override
-	public <T> IdReferenceHandler<T> createHandler(Class<T> clazz) {
-		return new HandleIdHandler<T>();
+	public <T> IdReferenceHandler<T> createHandler(
+			final Class<T> clazz,
+			final AuthToken userToken) {
+		return new HandleIdHandler<T>(requireNonNull(userToken, "userToken"));
 	}
 
 	@Override
@@ -58,11 +54,13 @@ public class HandleIdHandlerFactory implements IdReferenceHandlerFactory {
 	}
 	
 	public class HandleIdHandler<T> extends IdReferenceHandler<T> {
-		// seems like this might be a candidate for an abstract class, lock/processed/null checking common code
 
 		private final Map<T, Set<String>> ids = new HashMap<T, Set<String>>();
+		private final AuthToken userToken;
 		
-		private HandleIdHandler() {}
+		private HandleIdHandler(final AuthToken userToken) {
+			this.userToken = userToken;
+		}
 		
 		@Override
 		protected boolean addIdImpl(final T associatedObject, final String id,

--- a/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
+++ b/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
@@ -41,6 +41,7 @@ import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.db.MongoTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.exceptions.TypeStorageException;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder;
 import us.kbase.workspace.database.Types;
 import us.kbase.workspace.database.Workspace;
@@ -199,9 +200,13 @@ public class InitWorkspaceServer {
 		rep.reportInfo(String.format("Initialized %s backend",
 				wsdeps.backendType));
 		Types types = new Types(wsdeps.typeDB);
+		final IdReferenceHandlerSetFactoryBuilder builder = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(maxUniqueIdCountPerCall)
+				.withFactory(new HandleIdHandlerFactory(cfg.getHandleServiceURL()))
+				.build();
 		WorkspaceServerMethods wsmeth = new WorkspaceServerMethods(
-				ws, types, cfg.getHandleServiceURL(), cfg.getHandleManagerURL(),
-				handleMgrToken, maxUniqueIdCountPerCall, auth);
+				ws, types, builder, cfg.getHandleServiceURL(), cfg.getHandleManagerURL(),
+				handleMgrToken, auth);
 		WorkspaceAdministration wsadmin = new WorkspaceAdministration(
 				ws, wsmeth, types, ah,
 				ADMIN_CACHE_MAX_SIZE, ADMIN_CACHE_EXP_TIME_MS);

--- a/src/us/kbase/workspace/kbase/WorkspaceServerMethods.java
+++ b/src/us/kbase/workspace/kbase/WorkspaceServerMethods.java
@@ -44,6 +44,7 @@ import us.kbase.typedobj.exceptions.TypedObjectExtractionException;
 import us.kbase.typedobj.exceptions.TypedObjectSchemaException;
 import us.kbase.typedobj.exceptions.TypedObjectValidationException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.workspace.CreateWorkspaceParams;
 import us.kbase.workspace.GetObjectInfo3Params;
 import us.kbase.workspace.GetObjectInfo3Results;
@@ -97,21 +98,21 @@ public class WorkspaceServerMethods {
 	final private URL handleServiceUrl;
 	final private URL handleManagerUrl;
 	final private AuthToken handleManagerToken;
-	final private int maximumIDCount;
 	final private ConfigurableAuthService auth;
+	private final IdReferenceHandlerSetFactoryBuilder idFacBuilder;
 	
 	public WorkspaceServerMethods(
 			final Workspace ws,
 			final Types types,
+			final IdReferenceHandlerSetFactoryBuilder idFacBuilder,
 			final URL handleServiceUrl,
 			final URL handleManagerUrl,
 			final AuthToken handleMgrToken,
-			final int maximumIDCount,
 			final ConfigurableAuthService auth) {
 		this.ws = ws;
 		this.types = types;
+		this.idFacBuilder = idFacBuilder;
 		this.handleServiceUrl = handleServiceUrl;
-		this.maximumIDCount = maximumIDCount;
 		this.auth = auth;
 		this.handleManagerUrl = handleManagerUrl;
 		this.handleManagerToken = handleMgrToken;
@@ -388,10 +389,7 @@ public class WorkspaceServerMethods {
 			count++;
 		}
 		params.setObjects(null); 
-		final IdReferenceHandlerSetFactory fac =
-				new IdReferenceHandlerSetFactory(maximumIDCount);
-		fac.addFactory(new HandleIdHandlerFactory(handleServiceUrl, token));
-		
+		final IdReferenceHandlerSetFactory fac = idFacBuilder.getFactory(token);
 		final List<ObjectInformation> meta = ws.saveObjects(user, wsi, woc, fac); 
 		return objInfoToTuple(meta, true);
 	}

--- a/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
@@ -29,7 +29,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import us.kbase.common.mongo.GetMongoDB;
 import us.kbase.common.service.UObject;
 import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.controllers.mongo.MongoController;
@@ -45,6 +44,7 @@ import us.kbase.typedobj.db.MongoTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.exceptions.TypedObjectExtractionException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
 import us.kbase.typedobj.test.DummyValidatedTypedObject;
@@ -99,8 +99,8 @@ public class MongoInternalsTest {
 	private static MongoController mongo;
 	private static MongoClient mongoClient;
 	
-	private static final IdReferenceHandlerSetFactory fac =
-			new IdReferenceHandlerSetFactory(100);
+	private static final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+			.getBuilder(100).build().getFactory(null);
 	
 	public static final TypeDefId SAFE_TYPE =
 			new TypeDefId(new TypeDefName("SomeModule", "AType"), 0, 1);

--- a/src/us/kbase/workspace/test/kbase/HandleTest.java
+++ b/src/us/kbase/workspace/test/kbase/HandleTest.java
@@ -51,6 +51,7 @@ import us.kbase.typedobj.idref.IdReference;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.TooManyIdsException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.workspace.CreateWorkspaceParams;
 import us.kbase.workspace.GetObjects2Params;
@@ -610,9 +611,10 @@ public class HandleTest {
 	@Test
 	public void idCount() throws Exception {
 		IdReferenceType type = HandleIdHandlerFactory.type;
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(4);
+		IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder.getBuilder(4)
+				.build().getFactory(CLIENT1.getToken());
 		fac.addFactory(new HandleIdHandlerFactory(new URL("http://localhost:"
-				+ HANDLE.getHandleServerPort()), CLIENT1.getToken()));
+				+ HANDLE.getHandleServerPort())));
 		IdReferenceHandlerSet<String> handlers = fac.createHandlers(String.class);
 		handlers.associateObject("foo");
 		handlers.addStringId(new IdReference<String>(type, "KBH_1", null));

--- a/src/us/kbase/workspace/test/workspace/TestIDReferenceHandlerFactory.java
+++ b/src/us/kbase/workspace/test/workspace/TestIDReferenceHandlerFactory.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import us.kbase.auth.AuthToken;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.HandlerLockedException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdParseException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceException;
@@ -27,7 +28,7 @@ public class TestIDReferenceHandlerFactory implements IdReferenceHandlerFactory 
 	}
 
 	@Override
-	public <T> IdReferenceHandler<T> createHandler(Class<T> clazz) {
+	public <T> IdReferenceHandler<T> createHandler(Class<T> clazz, final AuthToken userToken) {
 		return new TestIDReferenceHandler<T>();
 	}
 

--- a/src/us/kbase/workspace/test/workspace/WorkspaceListenerTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceListenerTest.java
@@ -31,6 +31,7 @@ import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.core.ValidatedTypedObject;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.workspace.database.AllUsers;
 import us.kbase.workspace.database.CopyResult;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
@@ -1051,7 +1052,8 @@ public class WorkspaceListenerTest {
 		final WorkspaceUser user = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ugh", false, false);
-		final IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(100000);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(100000).build().getFactory(null);
 		final WorkspaceSaveObject wso1 = new WorkspaceSaveObject(
 				new ObjectIDNoWSNoVer("foo1"),
 				new HashMap<>(),
@@ -1123,7 +1125,8 @@ public class WorkspaceListenerTest {
 		final WorkspaceUser user = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ugh", false, false);
-		final IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(100000);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(100000).build().getFactory(null);
 		final WorkspaceSaveObject wso1 = new WorkspaceSaveObject(
 				new ObjectIDNoWSNoVer("foo1"),
 				new HashMap<>(),

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -2862,7 +2862,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		Provenance mtprov = new Provenance(user);
 		objs.add(new WorkspaceSaveObject(new ObjectIDNoWSNoVer("auto1"), d, SAFE_TYPE1, null,
 				mtprov, false));
-		ws.saveObjects(user, wsi, objs, new IdReferenceHandlerSetFactory(0));
+		ws.saveObjects(user, wsi, objs, getIdFactory(0));
 		
 		Provenance p = new Provenance(user).addAction(new ProvenanceAction()
 				.withWorkspaceObjects(Arrays.asList(
@@ -3089,7 +3089,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		ws.createWorkspace(user, wsi.getName(), false, null, null).getId();
 		Provenance emptyprov = new Provenance(user);
 		List<WorkspaceSaveObject> objs = new LinkedList<WorkspaceSaveObject>();
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(3);
+		IdReferenceHandlerSetFactory fac = getIdFactory(3);
 		
 		Map<String, Object> mt = new HashMap<String, Object>();
 		objs.add(new WorkspaceSaveObject(new ObjectIDNoWSNoVer("t1"), mt, type1, null, emptyprov, false));
@@ -3315,7 +3315,7 @@ public class WorkspaceTest extends WorkspaceTester {
 
 	private IdReferenceHandlerSetFactory makeFacForMaxIDTests(List<String> idtypes,
 			WorkspaceUser user, int max) {
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(max);
+		IdReferenceHandlerSetFactory fac = getIdFactory(max);
 //				.addFactory(ws.getHandlerFactory(user));
 		for (String idtype: idtypes) {
 			fac.addFactory(new TestIDReferenceHandlerFactory(
@@ -3875,7 +3875,7 @@ public class WorkspaceTest extends WorkspaceTester {
 			resolvedRefs.add(rrefs);
 		}
 		final List<ObjectInformation> ois = ws.saveObjects(
-				u1, testws, objs, new IdReferenceHandlerSetFactory(100000));
+				u1, testws, objs, getIdFactory());
 		final List<ObjectIdentifier> idents = new LinkedList<>();
 		for (final ObjectInformation oi: ois) {
 			// should probably add a ref -> oi method
@@ -4715,9 +4715,8 @@ public class WorkspaceTest extends WorkspaceTester {
 		data.add(new WorkspaceSaveObject(getRandomName(), new HashMap<String, Object>(),
 				SAFE_TYPE1, null, emptyprov1, false));
 		
-		ws.saveObjects(user1, wsiSource1, data, new IdReferenceHandlerSetFactory(0));
-		ws.saveObjects(user1, wsiSource2, setRandomNames(data),
-				new IdReferenceHandlerSetFactory(0));
+		ws.saveObjects(user1, wsiSource1, data, getIdFactory(0));
+		ws.saveObjects(user1, wsiSource2, setRandomNames(data), getIdFactory(0));
 		final ObjectIdentifier source1 = new ObjectIdentifier(wsiSource1, 1);
 		final ObjectIdentifier source2 = new ObjectIdentifier(wsiSource2, 1);
 		ObjectIdentifier copied1 = new ObjectIdentifier(wsiCid, "foo");
@@ -4727,25 +4726,24 @@ public class WorkspaceTest extends WorkspaceTester {
 		copied1 = new ObjectIdentifier(wsiCid, 1, 1);
 		copied2 = new ObjectIdentifier(wsiCid, 2, 1);
 		
-		ws.saveObjects(user2, wsiCopied, setRandomNames(data),
-				new IdReferenceHandlerSetFactory(0));
+		ws.saveObjects(user2, wsiCopied, setRandomNames(data), getIdFactory(0));
 		final ObjectIdentifier nocopy = new ObjectIdentifier(wsiCid, 3, 1);
 
 		data.clear();
 		Map<String, Object> ref = new HashMap<String, Object>();
 		ref.put("refs", Arrays.asList(wsiCopied.getName() + "/foo"));
 		data.add(new WorkspaceSaveObject(getRandomName(), ref, REF_TYPE, null, emptyprov2, false));
-		ws.saveObjects(user2, wsiCopied, data, new IdReferenceHandlerSetFactory(1));
+		ws.saveObjects(user2, wsiCopied, data, getIdFactory(1));
 		ObjectIDWithRefPath copyoc1 = new ObjectIDWithRefPath(new ObjectIdentifier(wsiCopied, 4L),
 				Arrays.asList(copied1));
 		
 		ref.put("refs", Arrays.asList(wsiCopied.getName() + "/foo1"));
-		ws.saveObjects(user2, wsiCopied, setRandomNames(data), new IdReferenceHandlerSetFactory(1));
+		ws.saveObjects(user2, wsiCopied, setRandomNames(data), getIdFactory(1));
 		ObjectIDWithRefPath copyoc2 = new ObjectIDWithRefPath(new ObjectIdentifier(wsiCopied, 5L),
 				Arrays.asList(copied2));
 		
 		ref.put("refs", Arrays.asList(wsiCopied.getName() + "/3"));
-		ws.saveObjects(user2, wsiCopied, setRandomNames(data), new IdReferenceHandlerSetFactory(1));
+		ws.saveObjects(user2, wsiCopied, setRandomNames(data), getIdFactory(1));
 		ObjectIDWithRefPath nocopyoc = new ObjectIDWithRefPath(new ObjectIdentifier(wsiCopied, 6L),
 				Arrays.asList(nocopy));
 		
@@ -6650,7 +6648,7 @@ public class WorkspaceTest extends WorkspaceTester {
 			objs.add(new WorkspaceSaveObject(getRandomName(), new HashMap<String, String>(),
 					SAFE_TYPE1, null, new Provenance(user), false));
 		}
-		ws.saveObjects(user, wsi, objs, new IdReferenceHandlerSetFactory(0));
+		ws.saveObjects(user, wsi, objs, getIdFactory(0));
 
 		//simple tests on full object ranges, depends on natural mongo ordering
 		checkObjectLimit(user, wsi, 0, 1, 200);
@@ -6669,7 +6667,7 @@ public class WorkspaceTest extends WorkspaceTester {
 					new WorkspaceUserMetadata(meta), new Provenance(user),
 					false));
 		}
-		ws.saveObjects(user, wsi, objs, new IdReferenceHandlerSetFactory(0));
+		ws.saveObjects(user, wsi, objs, getIdFactory(0));
 		
 		//test versions
 		//skips over the old versions internally since they're interleaved in the last 20 objects
@@ -6686,7 +6684,7 @@ public class WorkspaceTest extends WorkspaceTester {
 			objs.add(new WorkspaceSaveObject(getRandomName(), new HashMap<String, String>(),
 					SAFE_TYPE1, null, new Provenance(user), false));
 		}
-		ws.saveObjects(user, wsi, objs, new IdReferenceHandlerSetFactory(0));
+		ws.saveObjects(user, wsi, objs, getIdFactory(0));
 		
 		List<ObjectIdentifier> loi = new LinkedList<ObjectIdentifier>();
 		loi.add(new ObjectIdentifier(wsi, 5));
@@ -6703,7 +6701,7 @@ public class WorkspaceTest extends WorkspaceTester {
 			objs.add(new WorkspaceSaveObject(getRandomName(), new HashMap<String, String>(),
 					SAFE_TYPE1, null, new Provenance(user), false));
 		}
-		ws.saveObjects(user, wsi, objs, new IdReferenceHandlerSetFactory(0));
+		ws.saveObjects(user, wsi, objs, getIdFactory(0));
 		
 		//test object pagination with deleted and hidden objects
 		checkObjectLimit(user, wsi, 5, 1, 6, nums(5));
@@ -6725,7 +6723,7 @@ public class WorkspaceTest extends WorkspaceTester {
 			objs.add(new WorkspaceSaveObject(getRandomName(), new HashMap<String, String>(),
 					SAFE_TYPE1, null, new Provenance(user), false));
 		}
-		ws.saveObjects(user, wsi, objs, new IdReferenceHandlerSetFactory(0));
+		ws.saveObjects(user, wsi, objs, getIdFactory(0));
 		
 		for (int i = 1; i < 251; i++) {
 			List<ObjectIdentifier> oi =
@@ -6741,7 +6739,7 @@ public class WorkspaceTest extends WorkspaceTester {
 			objs.add(new WorkspaceSaveObject(getRandomName(), new HashMap<String, String>(),
 					SAFE_TYPE1, null, new Provenance(user), false));
 		}
-		ws.saveObjects(user, wsi, objs, new IdReferenceHandlerSetFactory(0));
+		ws.saveObjects(user, wsi, objs, getIdFactory(0));
 		
 		//test several rounds of retrieving objects (the minimum # of objects
 		//pulled from mongo at a time is 100)
@@ -6773,8 +6771,8 @@ public class WorkspaceTest extends WorkspaceTester {
 			objs.add(new WorkspaceSaveObject(getRandomName(), new HashMap<String, String>(),
 					SAFE_TYPE1, null, new Provenance(user), false));
 		}
-		ws.saveObjects(user, wsi1, objs, new IdReferenceHandlerSetFactory(0));
-		ws.saveObjects(user, wsi2, objs, new IdReferenceHandlerSetFactory(0));
+		ws.saveObjects(user, wsi1, objs, getIdFactory(0));
+		ws.saveObjects(user, wsi2, objs, getIdFactory(0));
 		
 		checkObjectFilter(user, Arrays.asList(wsi1, wsi2), -1L, -1L, 1, 10);
 		checkObjectFilter(user, Arrays.asList(wsi1, wsi2), 1L, 11L, 1, 10);

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -51,6 +51,7 @@ import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.db.MongoTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.workspace.database.AllUsers;
 import us.kbase.workspace.database.ListObjectsParameters;
 import us.kbase.workspace.database.ObjIDWithRefPathAndSubset;
@@ -472,7 +473,10 @@ public class WorkspaceTester {
 	}
 	
 	protected IdReferenceHandlerSetFactory getIdFactory() {
-		return new IdReferenceHandlerSetFactory(100000);
+		return getIdFactory(100000);
+	}
+	protected IdReferenceHandlerSetFactory getIdFactory(final int maxIDs) {
+		return IdReferenceHandlerSetFactoryBuilder.getBuilder(maxIDs).build().getFactory(null);
 	}
 	
 	protected Object getData(final WorkspaceObjectData wod) throws Exception {
@@ -1602,10 +1606,9 @@ public class WorkspaceTester {
 			Map<String, String> meta, Map<String, ? extends Object> data,
 			TypeDefId type, String name, Provenance prov, boolean hide)
 			throws Exception {
-		final IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(100000);
 		return ws.saveObjects(user, wsi, Arrays.asList(
 				new WorkspaceSaveObject(new ObjectIDNoWSNoVer(name), data,
-						type, new WorkspaceUserMetadata(meta), prov, hide)), fac)
+						type, new WorkspaceUserMetadata(meta), prov, hide)), getIdFactory())
 				.get(0);
 	}
 

--- a/test/performance/ConfigurationsAndThreads.java
+++ b/test/performance/ConfigurationsAndThreads.java
@@ -42,6 +42,7 @@ import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.db.MongoTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.workspace.CreateWorkspaceParams;
 import us.kbase.workspace.ObjectData;
 import us.kbase.workspace.ObjectIdentity;
@@ -429,7 +430,9 @@ public class ConfigurationsAndThreads {
 		@Override
 		public int performWrites() throws Exception {
 			for (JsonNode o: objs) {
-				final IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(1);
+				final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+						.getBuilder(1).build().getFactory(null);
+//				final IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(1);
 //				fac.addFactory(ws.getHandlerFactory(foo));
 				wsids.add(ws.saveObjects(foo, new WorkspaceIdentifier(workspace),
 						Arrays.asList(new WorkspaceSaveObject(

--- a/test/performance/GetObjectsLibSpeedTest.java
+++ b/test/performance/GetObjectsLibSpeedTest.java
@@ -35,6 +35,7 @@ import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.db.MongoTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIdentifier;
@@ -106,7 +107,8 @@ public class GetObjectsLibSpeedTest {
 		ws.createWorkspace(user, "fake", false, null, null);
 		WorkspaceIdentifier wsi = new WorkspaceIdentifier("fake");
 		TypeDefId td = new TypeDefId(new TypeDefName(module, type));
-		IdReferenceHandlerSetFactory fac = new IdReferenceHandlerSetFactory(1);
+		final IdReferenceHandlerSetFactory fac = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(1).build().getFactory(null);
 //		fac.addFactory(ws.getHandlerFactory(user));
 		ws.saveObjects(user, wsi, Arrays.asList(
 				new WorkspaceSaveObject(//added obj name when autonaming removed


### PR DESCRIPTION
This makes it easier to add a new ID handler to the service, and means
configuration parameters for the handlers don't need to be passed all
over the place.