### PR TITLE
Prep for modularizing ID reference permission updates

### DIFF
--- a/src/us/kbase/workspace/database/WorkspaceObjectData.java
+++ b/src/us/kbase/workspace/database/WorkspaceObjectData.java
@@ -2,8 +2,9 @@ package us.kbase.workspace.database;
 
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
+import java.util.Collections;
 
+import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
 
 /** A package containing (optionally) a workspace object's data along with provenance and
@@ -21,7 +22,8 @@ public class WorkspaceObjectData {
 	private final List<String> references;
 	private Reference copied;
 	private boolean isCopySourceInaccessible = false;
-	private final Map<String, List<String>> extIDs;
+	//TODO CODE make this immutable. Need new map, new lists. Or better yet, use a builder.
+	private final Map<IdReferenceType, List<String>> extIDs;
 
 	/** Create a data package with only the provenance and other metadata.
 	 * @param info information about the object.
@@ -35,7 +37,7 @@ public class WorkspaceObjectData {
 			final Provenance prov,
 			final List<String> references,
 			final Reference copied,
-			final Map<String, List<String>> extIDs) {
+			final Map<IdReferenceType, List<String>> extIDs) {
 		if (info == null || prov == null || references == null) {
 			throw new IllegalArgumentException(
 					"references, prov and info cannot be null");
@@ -44,8 +46,7 @@ public class WorkspaceObjectData {
 		this.prov = prov;
 		this.references = references;
 		this.copied = copied;
-		this.extIDs = extIDs == null ? new HashMap<String, List<String>>() :
-			extIDs;
+		this.extIDs = extIDs == null ? Collections.emptyMap() : extIDs;
 		this.data = null;
 	}
 	
@@ -63,7 +64,7 @@ public class WorkspaceObjectData {
 			final Provenance prov,
 			final List<String> references,
 			final Reference copied,
-			final Map<String, List<String>> extIDs) {
+			final Map<IdReferenceType, List<String>> extIDs) {
 		if (info == null || prov == null || references == null) {
 			throw new IllegalArgumentException(
 					"references, prov and info cannot be null");
@@ -72,7 +73,7 @@ public class WorkspaceObjectData {
 		this.prov = prov;
 		this.references = references;
 		this.copied = copied;
-		this.extIDs = extIDs == null ? new HashMap<String, List<String>>() : extIDs;
+		this.extIDs = extIDs == null ? Collections.emptyMap() : extIDs;
 		this.data = data;
 	}
 
@@ -107,7 +108,7 @@ public class WorkspaceObjectData {
 	/** Returns any external IDs extracted from the object, mapped by the ID type.
 	 * @return 
 	 */
-	public Map<String, List<String>> getExtractedIds() {
+	public Map<IdReferenceType, List<String>> getExtractedIds() {
 		return extIDs;
 		//could make this immutable I suppose
 	}

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.Set;
 
 import org.bson.types.ObjectId;
@@ -2132,14 +2133,13 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 			final Map<String, List<String>> extIDs =
 					(Map<String, List<String>>) vers.get(roi).get(Fields.VER_EXT_IDS);
 			@SuppressWarnings("unchecked")
-			final List<String> refs =
-					(List<String>) vers.get(roi).get(Fields.VER_REF);
+			final List<String> refs = (List<String>) vers.get(roi).get(Fields.VER_REF);
 			final ObjectInformation info = ObjectInfoUtils.generateObjectInfo(
 					roi, vers.get(roi));
 			if (dataMan == null) {
 				ret.put(o, new HashMap<SubsetSelection, WorkspaceObjectData>());
 				ret.get(o).put(SubsetSelection.EMPTY, new WorkspaceObjectData(
-						info, prov, refs, copied, extIDs));
+						info, prov, refs, copied, toExternalIDs(extIDs)));
 			} else {
 				try {
 					if (objs.get(o).isEmpty()) {
@@ -2164,6 +2164,13 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 			}
 		}
 		return ret;
+	}
+
+	private Map<IdReferenceType, List<String>> toExternalIDs(
+			final Map<String, List<String>> extIDs) {
+		return extIDs.keySet().stream().collect(Collectors.toMap(
+				k -> new IdReferenceType(k),
+				k -> extIDs.get(k)));
 	}
 
 	private void checkTotalFileSize(
@@ -2241,7 +2248,7 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 			 */
 			ret.get(o).put(op, new WorkspaceObjectData(getDataSubSet(
 					chksumToData.get(info.getCheckSum()), op, bafcMan),
-					info, prov, refs, copied, extIDs));
+					info, prov, refs, copied, toExternalIDs(extIDs)));
 		} else {
 			final ByteArrayFileCache data;
 			try {
@@ -2270,7 +2277,7 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 			chksumToData.put(info.getCheckSum(), data);
 			ret.get(o).put(op, new WorkspaceObjectData(
 					getDataSubSet(data, op, bafcMan),
-					info, prov, refs, copied, extIDs));
+					info, prov, refs, copied, toExternalIDs(extIDs)));
 		}
 	}
 	

--- a/src/us/kbase/workspace/kbase/ArgUtils.java
+++ b/src/us/kbase/workspace/kbase/ArgUtils.java
@@ -15,6 +15,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.joda.time.DateTime;
@@ -35,6 +36,7 @@ import us.kbase.common.service.Tuple9;
 import us.kbase.common.service.UObject;
 import us.kbase.common.service.UnauthorizedException;
 import us.kbase.handlemngr.HandleMngrClient;
+import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.auth.AuthToken;
 import us.kbase.workspace.ExternalDataUnit;
 import us.kbase.workspace.ObjectData;
@@ -407,13 +409,20 @@ public class ArgUtils {
 						o.getCopyReference().getId())
 					.withCopySourceInaccessible(
 							o.isCopySourceInaccessible() ? 1L: 0L)
-					.withExtractedIds(o.getExtractedIds())
+					.withExtractedIds(toRawExternalIDs(o.getExtractedIds()))
 					.withHandleError(error.error)
 					.withHandleStacktrace(error.stackTrace));
 		}
 		return ret;
 	}
 	
+	private static Map<String, List<String>> toRawExternalIDs(
+			final Map<IdReferenceType, List<String>> extractedIds) {
+		return extractedIds.keySet().stream().collect(Collectors.toMap(
+				k -> k.getType(),
+				k -> extractedIds.get(k)));
+	}
+
 	public static List<List<String>> toObjectPaths(final List<ObjectInformation> ois) {
 		final List<List<String>> ret = new LinkedList<>();
 		for (final ObjectInformation oi: ois) {
@@ -460,7 +469,7 @@ public class ArgUtils {
 						o.getCopyReference().getId())
 					.withCopySourceInaccessible(
 						o.isCopySourceInaccessible() ? 1L: 0L)
-					.withExtractedIds(o.getExtractedIds())
+					.withExtractedIds(toRawExternalIDs(o.getExtractedIds()))
 					.withHandleError(error.error)
 					.withHandleStacktrace(error.stackTrace));
 		}
@@ -498,7 +507,7 @@ public class ArgUtils {
 			final URL handleManagerURL,
 			final AuthToken handleManagertoken) {
 		final List<String> handles = o.getExtractedIds().get(
-				HandleIdHandlerFactory.type.getType());
+				HandleIdHandlerFactory.type);
 		if (handles == null || handles.isEmpty()) {
 			return new HandleError(null, null);
 		}

--- a/src/us/kbase/workspace/kbase/WorkspaceServerMethods.java
+++ b/src/us/kbase/workspace/kbase/WorkspaceServerMethods.java
@@ -125,6 +125,8 @@ public class WorkspaceServerMethods {
 	public URL getHandleServiceURL() {
 		return handleServiceUrl;
 	}
+	
+	// TODO CODE move this into the WorkspaceServer class and remove HS url 
 	public DependencyStatus checkHandleService() {
 		try {
 			ServiceChecker.checkService(handleServiceUrl);

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -2878,16 +2878,16 @@ public class WorkspaceTest extends WorkspaceTester {
 	@Test
 	public void genericIdExtraction() throws Exception {
 		
-		String idtype1 = "someid";
-		String idtype2 = "someid2";
+		final IdReferenceType idtype1 = new IdReferenceType("someid");
+		final IdReferenceType idtype2 = new IdReferenceType("someid2");
 //		String idtypeint = "someintid";
 		String mod = "TestIDExtraction";
 		String type = "IdType";
 		final String idSpec =
 				"module " + mod + " {\n" +
-					"/* @id " + idtype1 + " */\n" +
+					"/* @id " + idtype1.getType() + " */\n" +
 					"typedef string some_id;\n" +
-					"/* @id " + idtype2 + " */\n" +
+					"/* @id " + idtype2.getType() + " */\n" +
 					"typedef string some_id2;\n" +
 //					"/* @id " + idtypeint + " */" +
 //					"typedef int int_id;" +
@@ -2921,7 +2921,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 
 		IdReferenceHandlerSetFactory fac = getIdFactory().addFactory(
-				new TestIDReferenceHandlerFactory(new IdReferenceType(idtype1)));
+				new TestIDReferenceHandlerFactory(idtype1));
 
 		data.add(new WorkspaceSaveObject(new ObjectIDNoWSNoVer("auto2"),
 				iddata, idtype, null, emptyprov, false));
@@ -2929,7 +2929,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		iddata.put("an_id2", "foo");
 //		iddata.put("an_int_id", 34);
 		ws.saveObjects(user, wsi, data, fac); //should work
-		Map<String, List<String>> expected = new HashMap<String, List<String>>();
+		Map<IdReferenceType, List<String>> expected = new HashMap<>();
 		ObjectIdentifier obj1 = new ObjectIdentifier(wsi, "auto1");
 		checkExternalIds(user, obj1, expected);
 		
@@ -2937,7 +2937,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		ObjectIdentifier obj2 = new ObjectIdentifier(wsi, "auto2");
 		checkExternalIds(user, obj2, expected);
 		
-		fac.addFactory(new TestIDReferenceHandlerFactory(new IdReferenceType(idtype2)));
+		fac.addFactory(new TestIDReferenceHandlerFactory(idtype2));
 		data.set(0, renameWSO(data.get(0), "auto3"));
 		data.set(1, renameWSO(data.get(1), "auto4"));
 		ws.saveObjects(user, wsi, data, fac); //should work

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -52,6 +52,7 @@ import us.kbase.typedobj.db.MongoTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
+import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.workspace.database.AllUsers;
 import us.kbase.workspace.database.ListObjectsParameters;
 import us.kbase.workspace.database.ObjIDWithRefPathAndSubset;
@@ -2033,14 +2034,14 @@ public class WorkspaceTester {
 	}
 
 	protected void checkExternalIds(WorkspaceUser user, ObjectIdentifier obj,
-			Map<String, List<String>> expected)
+			Map<IdReferenceType, List<String>> expected)
 			throws Exception {
 		List<ObjectIdentifier> o = Arrays.asList(obj);
 		WorkspaceObjectData wod = ws.getObjects(user, o).get(0);
 		wod.destroy(); // don't need the actual data
 		WorkspaceObjectData woi = ws.getObjects(user, o, true).get(0);
 		
-		assertThat("get objs correct ext ids", new HashMap<>(wod.getExtractedIds()), is(expected));
-		assertThat("get prov correct ext ids", new HashMap<>(woi.getExtractedIds()), is(expected));
+		assertThat("get objs correct ext ids", wod.getExtractedIds(), is(expected));
+		assertThat("get prov correct ext ids", woi.getExtractedIds(), is(expected));
 	}
 }


### PR DESCRIPTION
Wrap the ID reference type in its proper class

This will be useful for a) the update to the new handle manager and b)
adding new ID types (like links directly to shock or the new data
stsore)