### PR TITLE
Refactor the id handling on fetch object

### DIFF
--- a/src/us/kbase/typedobj/idref/IdReferenceHandlerSet.java
+++ b/src/us/kbase/typedobj/idref/IdReferenceHandlerSet.java
@@ -352,16 +352,6 @@ public class IdReferenceHandlerSet<T> {
 	}
 	
 	@SuppressWarnings("serial")
-	public static class NoSuchIdReferenceHandlerException
-			extends RuntimeException {
-
-		public NoSuchIdReferenceHandlerException(String message) {
-			super(message);
-		}
-		
-	}
-	
-	@SuppressWarnings("serial")
 	public static class NoSuchIdException extends RuntimeException {
 
 		public NoSuchIdException(String message) {

--- a/src/us/kbase/typedobj/idref/IdReferenceHandlerSetFactory.java
+++ b/src/us/kbase/typedobj/idref/IdReferenceHandlerSetFactory.java
@@ -6,6 +6,7 @@ import java.util.Map.Entry;
 
 import us.kbase.auth.AuthToken;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandler;
+import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
 
 /** Builds a set of ID handlers for handling IDs found while validating a
  * typed object. The handler could, for example, check the ID format, check
@@ -44,6 +45,23 @@ public class IdReferenceHandlerSetFactory {
 		public <T> IdReferenceHandler<T> createHandler(
 				final Class<T> clazz,
 				final AuthToken userToken);
+		
+		/** Create a permission handler for the ID type that makes data associated with any
+		 * IDs publicly readable.
+		 * @return the new handler.
+		 */
+		public IdReferencePermissionHandler createPermissionHandler();
+		
+		/** Create a permission handler for the ID type.
+		 * @param userName the user that will be granted permissions to the data associated with
+		 * a set of IDs.
+		 * @return the new handler.
+		 */
+		public IdReferencePermissionHandler createPermissionHandler(final String userName);
+		
+		/** Get the type of IDs this factory supports.
+		 * @return the ID type.
+		 */
 		public IdReferenceType getIDType();
 	}
 	

--- a/src/us/kbase/typedobj/idref/IdReferenceHandlerSetFactoryBuilder.java
+++ b/src/us/kbase/typedobj/idref/IdReferenceHandlerSetFactoryBuilder.java
@@ -1,5 +1,6 @@
 package us.kbase.typedobj.idref;
 
+import static java.util.Objects.requireNonNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -7,6 +8,7 @@ import java.util.Map;
 import us.kbase.auth.AuthToken;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandler;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFactory;
+import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
 
 /** A builder for a factory for a set of {@link IdReferenceHandler}s.
  * 
@@ -52,6 +54,32 @@ public class IdReferenceHandlerSetFactoryBuilder {
 	 */
 	public IdReferenceHandlerSetFactory getFactory(final AuthToken userToken) {
 		return new IdReferenceHandlerSetFactory(maxUniqueIdCount, factories, userToken);
+	}
+	
+	/** Create a permission handler set that makes data associated with any
+	 * IDs publicly readable.
+	 * @return the new handler.
+	 */
+	public IdReferencePermissionHandlerSet createPermissionHandler() {
+		final Map<IdReferenceType, IdReferencePermissionHandler> handlers = new HashMap<>();
+		for (final IdReferenceType t: factories.keySet()) {
+			handlers.put(t, factories.get(t).createPermissionHandler());
+		}
+		return new IdReferencePermissionHandlerSet(handlers);
+	}
+	
+	/** Create a permission handler set.
+	 * @param userName the user that will be granted permissions to the data associated with
+	 * a set of IDs.
+	 * @return the new handler.
+	 */
+	public IdReferencePermissionHandlerSet createPermissionHandler(final String userName) {
+		requireNonNull(userName, "userName");
+		final Map<IdReferenceType, IdReferencePermissionHandler> handlers = new HashMap<>();
+		for (final IdReferenceType t: factories.keySet()) {
+			handlers.put(t, factories.get(t).createPermissionHandler(userName));
+		}
+		return new IdReferencePermissionHandlerSet(handlers);
 	}
 
 	/** Get a builder for a {@link IdReferenceHandlerSetFactoryBuilder}.

--- a/src/us/kbase/typedobj/idref/IdReferencePermissionHandlerSet.java
+++ b/src/us/kbase/typedobj/idref/IdReferencePermissionHandlerSet.java
@@ -1,0 +1,99 @@
+package us.kbase.typedobj.idref;
+
+import static java.util.Objects.requireNonNull;
+import static us.kbase.workspace.database.Util.checkNoNullsOrEmpties;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/** A set of {@link IdReferencePermissionHandler}s.
+ * Created by {@link IdReferenceHandlerSetFactoryBuilder#createPermissionHandler()} or
+ * {@link IdReferenceHandlerSetFactoryBuilder#createPermissionHandler(String)}.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class IdReferencePermissionHandlerSet {
+	
+	private final Map<IdReferenceType, IdReferencePermissionHandler> handlers;
+	
+	/** A handler that modifies permissions on a set of IDs.
+	 * @author gaprice@lbl.gov
+	 *
+	 */
+	public interface IdReferencePermissionHandler {
+		
+		/** Add read permission to the data associated with the given IDs.
+		 * Null or empty collections are ignored.
+		 * @param ids the IDs to modify.
+		 * @throws IdReferencePermissionHandlerException if adding read permissions fails.
+		 */
+		public void addReadPermission(final Collection<String> ids)
+				throws IdReferencePermissionHandlerException;
+		
+	}
+
+	/** Create the permission handler set.
+	 * @param handlers the handlers.
+	 */
+	protected IdReferencePermissionHandlerSet(
+			final Map<IdReferenceType, IdReferencePermissionHandler> handlers) {
+		this.handlers = new HashMap<IdReferenceType, IdReferencePermissionHandler>(
+				handlers);
+	}
+
+	/** Returns true if this handler set contains a handler for the ID type
+	 * specified.
+	 * @param idType the type of ID to check.
+	 * @return true if this handler set contains a handler for the ID type
+	 * specified.
+	 */
+	public boolean hasHandler(final IdReferenceType idType) {
+		return handlers.containsKey(requireNonNull(idType, "idType"));
+	}
+	
+	
+	/** Get the id types with registered handlers.
+	 * @return the id types with handlers that have been added to this handler
+	 * set.
+	 */
+	public Set<IdReferenceType> getIDTypes() {
+		return handlers.keySet();
+	}
+	
+	/** Add read permission to data associated with a set of IDs.
+	 * @param idType the type of the IDs. This determines which
+	 * {@link IdReferencePermissionHandler} will handle the request.
+	 * @param ids the IDs to modify.
+	 * @throws IdReferencePermissionHandlerException if an error occurs setting the permissions.
+	 */
+	public void addReadPermission(final IdReferenceType idType, final Collection<String> ids)
+			throws IdReferencePermissionHandlerException {
+		if (!hasHandler(idType)) {
+			throw new NoSuchIdReferenceHandlerException(
+					"There is no handler registered for the ID type " + idType.getType());
+		}
+		checkNoNullsOrEmpties(ids, "ids");
+		// may want to catch and rethrow a multi-exception at the end. YAGNI for now.
+		handlers.get(idType).addReadPermission(ids);
+	}
+	
+	/** A general permission handler exception.
+	 * @author gaprice@lbl.gov
+	 *
+	 */
+	@SuppressWarnings("serial")
+	public static class IdReferencePermissionHandlerException extends Exception {
+
+		public IdReferencePermissionHandlerException(final String message) {
+			super(message);
+		}
+		
+		public IdReferencePermissionHandlerException(final String message, final Throwable cause) {
+			super(message, cause);
+		}
+		
+	}
+	
+}

--- a/src/us/kbase/typedobj/idref/NoSuchIdReferenceHandlerException.java
+++ b/src/us/kbase/typedobj/idref/NoSuchIdReferenceHandlerException.java
@@ -1,0 +1,11 @@
+package us.kbase.typedobj.idref;
+
+@SuppressWarnings("serial")
+public class NoSuchIdReferenceHandlerException
+		extends RuntimeException {
+
+	public NoSuchIdReferenceHandlerException(final String message) {
+		super(message);
+	}
+	
+}

--- a/src/us/kbase/typedobj/test/DummyIdHandlerFactory.java
+++ b/src/us/kbase/typedobj/test/DummyIdHandlerFactory.java
@@ -13,6 +13,7 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSet.HandlerLockedException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandler;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandlerException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFactory;
+import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
 import us.kbase.typedobj.idref.DefaultRemappedId;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
@@ -116,6 +117,16 @@ public class DummyIdHandlerFactory implements IdReferenceHandlerFactory {
 	@Override
 	public IdReferenceType getIDType() {
 		return type;
+	}
+
+	@Override
+	public IdReferencePermissionHandler createPermissionHandler() {
+		return null;
+	}
+
+	@Override
+	public IdReferencePermissionHandler createPermissionHandler(String userName) {
+		return null;
 	}
 
 }

--- a/src/us/kbase/typedobj/test/idref/IdReferencePermissionHandlerSetTest.java
+++ b/src/us/kbase/typedobj/test/idref/IdReferencePermissionHandlerSetTest.java
@@ -1,0 +1,160 @@
+package us.kbase.typedobj.test.idref;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static us.kbase.common.test.TestCommon.set;
+
+import java.util.Collection;
+
+import org.junit.Test;
+
+import us.kbase.common.test.TestCommon;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFactory;
+import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
+import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet;
+import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
+import us.kbase.typedobj.idref.IdReferenceType;
+import us.kbase.typedobj.idref.NoSuchIdReferenceHandlerException;
+
+public class IdReferencePermissionHandlerSetTest {
+	
+	@Test
+	public void emptySet() throws Exception {
+		final IdReferencePermissionHandlerSet s = IdReferenceHandlerSetFactoryBuilder.getBuilder(1)
+				.build().createPermissionHandler();
+		
+		assertThat("incorrect types", s.getIDTypes(), is(set()));
+	}
+	
+	@Test
+	public void emptySetWithUser() throws Exception {
+		final IdReferencePermissionHandlerSet s = IdReferenceHandlerSetFactoryBuilder.getBuilder(1)
+				.build().createPermissionHandler("foo");
+		
+		assertThat("incorrect types", s.getIDTypes(), is(set()));
+	}
+	
+	@Test
+	public void withHandlers() throws Exception {
+		final IdReferenceHandlerFactory fac1 = mock(IdReferenceHandlerFactory.class);
+		final IdReferenceHandlerFactory fac2 = mock(IdReferenceHandlerFactory.class);
+		when(fac1.getIDType()).thenReturn(new IdReferenceType("handle"));
+		when(fac2.getIDType()).thenReturn(new IdReferenceType("shock"));
+		
+		final IdReferencePermissionHandler h1 = mock(IdReferencePermissionHandler.class);
+		final IdReferencePermissionHandler h2 = mock(IdReferencePermissionHandler.class);
+		when(fac1.createPermissionHandler()).thenReturn(h1);
+		when(fac2.createPermissionHandler()).thenReturn(h2);
+		
+		final IdReferencePermissionHandlerSet s = IdReferenceHandlerSetFactoryBuilder.getBuilder(1)
+				.withFactory(fac1)
+				.withFactory(fac2)
+				.build().createPermissionHandler();
+		
+		assertThat("incorrect types", s.getIDTypes(),
+				is(set(new IdReferenceType("handle"), new IdReferenceType("shock"))));
+		assertThat("incorrect has type", s.hasHandler(new IdReferenceType("handle")), is(true));
+		assertThat("incorrect has type", s.hasHandler(new IdReferenceType("shock")), is(true));
+		assertThat("incorrect has type", s.hasHandler(new IdReferenceType("shocky")), is(false));
+		
+		s.addReadPermission(new IdReferenceType("handle"),
+				set("KBHNDLE_1", "KBHNDLE_6", "KBHNDLE_78"));
+		
+		verify(h1).addReadPermission(set("KBHNDLE_1", "KBHNDLE_6", "KBHNDLE_78"));
+		verifyZeroInteractions(h2);
+	}
+	
+	@Test
+	public void withHandlersWithUser() throws Exception {
+		final IdReferenceHandlerFactory fac1 = mock(IdReferenceHandlerFactory.class);
+		final IdReferenceHandlerFactory fac2 = mock(IdReferenceHandlerFactory.class);
+		when(fac1.getIDType()).thenReturn(new IdReferenceType("handle"));
+		when(fac2.getIDType()).thenReturn(new IdReferenceType("shock"));
+		
+		final IdReferencePermissionHandler h1 = mock(IdReferencePermissionHandler.class);
+		final IdReferencePermissionHandler h2 = mock(IdReferencePermissionHandler.class);
+		when(fac1.createPermissionHandler("user1")).thenReturn(h1);
+		when(fac2.createPermissionHandler("user1")).thenReturn(h2);
+		
+		final IdReferencePermissionHandlerSet s = IdReferenceHandlerSetFactoryBuilder.getBuilder(1)
+				.withFactory(fac1)
+				.withFactory(fac2)
+				.build().createPermissionHandler("user1");
+		
+		assertThat("incorrect types", s.getIDTypes(),
+				is(set(new IdReferenceType("handle"), new IdReferenceType("shock"))));
+		assertThat("incorrect has type", s.hasHandler(new IdReferenceType("handle")), is(true));
+		assertThat("incorrect has type", s.hasHandler(new IdReferenceType("shock")), is(true));
+		assertThat("incorrect has type", s.hasHandler(new IdReferenceType("shocky")), is(false));
+		
+		s.addReadPermission(new IdReferenceType("handle"),
+				set("KBHNDLE_1", "KBHNDLE_6", "KBHNDLE_78"));
+		
+		verify(h1).addReadPermission(set("KBHNDLE_1", "KBHNDLE_6", "KBHNDLE_78"));
+		verifyZeroInteractions(h2);
+	}
+	
+	@Test
+	public void addReadPermissionFailBadArgs() throws Exception {
+		final IdReferenceHandlerFactory fac1 = mock(IdReferenceHandlerFactory.class);
+		when(fac1.getIDType()).thenReturn(new IdReferenceType("handle"));
+		
+		final IdReferencePermissionHandler h1 = mock(IdReferencePermissionHandler.class);
+		when(fac1.createPermissionHandler()).thenReturn(h1);
+		
+		final IdReferencePermissionHandlerSet s = IdReferenceHandlerSetFactoryBuilder.getBuilder(1)
+				.withFactory(fac1)
+				.build().createPermissionHandler();
+		
+		final IdReferenceType h = new IdReferenceType("handle");
+		
+		addReadPermissionFail(s, null, set(), new NullPointerException("idType"));
+		addReadPermissionFail(s, new IdReferenceType("shock"), set(),
+				new NoSuchIdReferenceHandlerException(
+						"There is no handler registered for the ID type shock"));
+		addReadPermissionFail(s, h, null, new NullPointerException("ids"));
+		addReadPermissionFail(s, h, set("foo", null), new IllegalArgumentException(
+				"Null or whitespace only string in collection ids"));
+		addReadPermissionFail(s, h, set("foo", "   \t    "), new IllegalArgumentException(
+				"Null or whitespace only string in collection ids"));
+	}
+	
+	private void addReadPermissionFail(
+			final IdReferencePermissionHandlerSet s,
+			final IdReferenceType type,
+			final Collection<String> ids,
+			final Exception expected) {
+		try {
+			s.addReadPermission(type, ids);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+	
+	@Test
+	public void hasTypeFailNull() throws Exception {
+		final IdReferenceHandlerFactory fac1 = mock(IdReferenceHandlerFactory.class);
+		when(fac1.getIDType()).thenReturn(new IdReferenceType("handle"));
+		
+		final IdReferencePermissionHandler h1 = mock(IdReferencePermissionHandler.class);
+		when(fac1.createPermissionHandler()).thenReturn(h1);
+		
+		final IdReferencePermissionHandlerSet s = IdReferenceHandlerSetFactoryBuilder.getBuilder(1)
+				.withFactory(fac1)
+				.build().createPermissionHandler();
+		
+		try {
+			s.hasHandler(null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("idType"));
+		}
+	}
+
+}

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -23,8 +23,6 @@ import static us.kbase.workspace.kbase.ArgUtils.getGlobalWSPerm;
 import static us.kbase.workspace.kbase.ArgUtils.wsInfoToTuple;
 import static us.kbase.workspace.kbase.ArgUtils.wsInfoToMetaTuple;
 import static us.kbase.workspace.kbase.ArgUtils.objInfoToMetaTuple;
-import static us.kbase.workspace.kbase.ArgUtils.translateObjectProvInfo;
-import static us.kbase.workspace.kbase.ArgUtils.translateObjectData;
 import static us.kbase.workspace.kbase.ArgUtils.objInfoToTuple;
 import static us.kbase.workspace.kbase.ArgUtils.translateObjectInfoList;
 import static us.kbase.workspace.kbase.ArgUtils.longToBoolean;
@@ -121,7 +119,6 @@ public class WorkspaceServer extends JsonServerServlet {
 	private final WorkspaceAdministration wsadmin;
 	
 	private final URL handleManagerUrl;
-	private final AuthToken handleMgrToken;
 	
 	private ThreadLocal<List<WorkspaceObjectData>> resourcesToDelete =
 			new ThreadLocal<List<WorkspaceObjectData>>();
@@ -228,7 +225,6 @@ public class WorkspaceServer extends JsonServerServlet {
 		Types types = null;
 		WorkspaceAdministration wsadmin = null;
 		URL handleManagerUrl = null;
-		AuthToken handleMgrToken = null;
 		//TODO TEST add server startup tests
 		if (cfg.hasErrors()) {
 			logErr("Workspace server configuration has errors - all calls will fail");
@@ -236,7 +232,6 @@ public class WorkspaceServer extends JsonServerServlet {
 					"Workspace server configuration has errors - all calls will fail");
 			startupFailed();
 		} else {
-
 			final WorkspaceInitReporter rep = new WorkspaceInitReporter();
 			final WorkspaceInitResults res =
 					InitWorkspaceServer.initWorkspaceServer(cfg, rep);
@@ -247,7 +242,6 @@ public class WorkspaceServer extends JsonServerServlet {
 				types = res.getTypes();
 				wsadmin = res.getWsAdmin();
 				handleManagerUrl = res.getHandleManagerUrl();
-				handleMgrToken = res.getHandleMgrToken();
 				setRpcDiskCacheTempDir(ws.getTempFilesManager().getTempDir());
 			}
 		}
@@ -256,7 +250,6 @@ public class WorkspaceServer extends JsonServerServlet {
 		this.types = types;
 		this.wsadmin = wsadmin;
 		this.handleManagerUrl = handleManagerUrl;
-		this.handleMgrToken = handleMgrToken;
         //END_CONSTRUCTOR
     }
 
@@ -641,10 +634,9 @@ public class WorkspaceServer extends JsonServerServlet {
         List<ObjectProvenanceInfo> returnVal = null;
         //BEGIN get_object_provenance
 		final List<ObjectIdentifier> loi = processObjectIdentifiers(objectIds);
-		returnVal = translateObjectProvInfo(
+		returnVal = wsmeth.translateObjectProvInfo(
 				ws.getObjects(wsmeth.getUser(authPart), loi, true),
-						wsmeth.getUser(authPart), handleManagerUrl,
-						handleMgrToken, true);
+				wsmeth.getUser(authPart), true);
         //END get_object_provenance
         return returnVal;
     }
@@ -667,8 +659,7 @@ public class WorkspaceServer extends JsonServerServlet {
 		final List<WorkspaceObjectData> objects =
 				ws.getObjects(wsmeth.getUser(authPart), loi);
 		resourcesToDelete.set(objects);
-		returnVal = translateObjectData(objects, wsmeth.getUser(authPart),
-					handleManagerUrl, handleMgrToken, true);
+		returnVal = wsmeth.translateObjectData(objects, wsmeth.getUser(authPart), true);
         //END get_objects
         return returnVal;
     }
@@ -720,8 +711,7 @@ public class WorkspaceServer extends JsonServerServlet {
 		final List<WorkspaceObjectData> objects =
 				ws.getObjects(wsmeth.getUser(authPart), loi);
 		resourcesToDelete.set(objects);
-		returnVal = translateObjectData(objects, wsmeth.getUser(authPart),
-				handleManagerUrl, handleMgrToken, true);
+		returnVal = wsmeth.translateObjectData(objects, wsmeth.getUser(authPart), true);
         //END get_object_subset
         return returnVal;
     }
@@ -845,8 +835,7 @@ public class WorkspaceServer extends JsonServerServlet {
 		final List<WorkspaceObjectData> objects = ws.getObjects(
 				wsmeth.getUser(authPart), chains);
 		resourcesToDelete.set(objects);
-		returnVal = translateObjectData(objects, wsmeth.getUser(authPart),
-					handleManagerUrl, handleMgrToken, true);
+		returnVal = wsmeth.translateObjectData(objects, wsmeth.getUser(authPart), true);
         //END get_referenced_objects
         return returnVal;
     }

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -51,6 +51,7 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSet.NoSuchIdException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.TooManyIdsException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFactory;
+import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
 import us.kbase.workspace.database.ObjectResolver.ObjectResolution;
@@ -1719,6 +1720,18 @@ public class Workspace {
 		@Override
 		public IdReferenceType getIDType() {
 			return WS_ID_TYPE;
+		}
+
+		@Override
+		public IdReferencePermissionHandler createPermissionHandler() {
+			// unused
+			return null;
+		}
+
+		@Override
+		public IdReferencePermissionHandler createPermissionHandler(String userName) {
+			// usused
+			return null;
 		}
 	}
 	

--- a/src/us/kbase/workspace/test/kbase/HandleIdHandlerFactoryTest.java
+++ b/src/us/kbase/workspace/test/kbase/HandleIdHandlerFactoryTest.java
@@ -1,0 +1,181 @@
+package us.kbase.workspace.test.kbase;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static us.kbase.common.test.TestCommon.set;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+
+import us.kbase.common.service.JsonClientException;
+import us.kbase.common.service.ServerException;
+import us.kbase.common.service.UnauthorizedException;
+import us.kbase.common.test.TestCommon;
+import us.kbase.handlemngr.HandleMngrClient;
+import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
+import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandlerException;
+import us.kbase.typedobj.idref.IdReferenceType;
+import us.kbase.workspace.kbase.HandleIdHandlerFactory;
+
+public class HandleIdHandlerFactoryTest {
+
+	/* Currently this only tests the permissions chunk of the factory, since
+	 * the ID handling part is not unit testable as it creates a handle client that talks
+	 * directly to the handle service.
+	 * 
+	 * TODO CODE pass in a getHandleClient(url, token) function to the constructor to make unit testable
+	 * or getHandleClient(client, token)
+	 */
+	
+	@Test
+	public void getIDType() throws Exception {
+		assertThat("incorrect type", new HandleIdHandlerFactory(null, null).getIDType(),
+				is(new IdReferenceType("handle")));
+	}
+	
+	@Test
+	public void addReadPermissionsNoop() throws Exception {
+		setPermissionsReadNoop(null);
+		setPermissionsReadNoop(set());
+	}
+
+	private void setPermissionsReadNoop(final Collection<String> ids) throws Exception {
+		final HandleMngrClient c = mock(HandleMngrClient.class);
+		final HandleIdHandlerFactory f = new HandleIdHandlerFactory(null, c);
+		
+		final IdReferencePermissionHandler h = f.createPermissionHandler();
+		
+		h.addReadPermission(ids);
+		
+		verifyZeroInteractions(c);
+	}
+	
+	@Test
+	public void addReadPermissions() throws Exception {
+		final HandleMngrClient c = mock(HandleMngrClient.class);
+		final HandleIdHandlerFactory f = new HandleIdHandlerFactory(null, c);
+		
+		final IdReferencePermissionHandler h = f.createPermissionHandler();
+		
+		h.addReadPermission(Arrays.asList("foo", "bar"));
+		
+		verify(c).setPublicRead(Arrays.asList("foo", "bar"));
+	}
+	
+	@Test
+	public void addReadPermissionsWithUser() throws Exception {
+		final HandleMngrClient c = mock(HandleMngrClient.class);
+		final HandleIdHandlerFactory f = new HandleIdHandlerFactory(null, c);
+		
+		final IdReferencePermissionHandler h = f.createPermissionHandler("user");
+		
+		h.addReadPermission(Arrays.asList("foo", "bar"));
+		
+		verify(c).addReadAcl(Arrays.asList("foo", "bar"), "user");
+	}
+	
+	@Test
+	public void addReadPermissionsFailNullClient() throws Exception {
+		final HandleIdHandlerFactory f = new HandleIdHandlerFactory(null, null);
+		final IdReferencePermissionHandler h = f.createPermissionHandler("user");
+		addReadPermissionsFail(h, new IdReferencePermissionHandlerException(
+				"The workspace is not currently connected to the Handle Service and cannot " +
+				"process Handle ids."));
+	}
+	
+	@Test
+	public void addReadPermissionsFailNoUserIOException() throws Exception {
+		addReadPermissionsFailNoUser(new IOException("oopsie"),
+				"There was an IO problem while attempting to set Handle ACLs: oopsie");
+	}
+
+	@Test
+	public void addReadPermissionsFailNoUserUnauthorizedException() throws Exception {
+		addReadPermissionsFailNoUser(new UnauthorizedException("oh you naughty person"),
+				"Unable to contact the Handle Manager - the Workspace credentials were " +
+				"rejected: oh you naughty person");
+	}
+	
+	@Test
+	public void addReadPermissionsFailNoUserServerException() throws Exception {
+		addReadPermissionsFailNoUser(new ServerException("well poop", 1, "foo"),
+				"The Handle Manager reported a problem while attempting to set Handle ACLs: " +
+				"well poop");
+	}
+	
+	@Test
+	public void addReadPermissionsFailNoUserJsonClientException() throws Exception {
+		addReadPermissionsFailNoUser(new JsonClientException("dang it to heck"),
+				"There was an unexpected problem while contacting the Handle Manager to set " +
+				"Handle ACLs: dang it to heck");
+	}
+	
+	private void addReadPermissionsFailNoUser(final Exception ex, final String err)
+			throws IOException, JsonClientException {
+		final HandleMngrClient c = mock(HandleMngrClient.class);
+		final HandleIdHandlerFactory f = new HandleIdHandlerFactory(null, c);
+		final IdReferencePermissionHandler h = f.createPermissionHandler();
+		
+		doThrow(ex).when(c).setPublicRead(Arrays.asList("foo"));
+		
+		addReadPermissionsFail(h, new IdReferencePermissionHandlerException(err));
+	}
+	
+	@Test
+	public void addReadPermissionsFailWithUserIOException() throws Exception {
+		addReadPermissionsFailWithUser(new IOException("oopsie"),
+				"There was an IO problem while attempting to set Handle ACLs: oopsie");
+	}
+
+	@Test
+	public void addReadPermissionsFailWithUserUnauthorizedException() throws Exception {
+		addReadPermissionsFailWithUser(new UnauthorizedException("oh you naughty person"),
+				"Unable to contact the Handle Manager - the Workspace credentials were " +
+				"rejected: oh you naughty person");
+	}
+	
+	@Test
+	public void addReadPermissionsFailWithUserServerException() throws Exception {
+		addReadPermissionsFailWithUser(new ServerException("well poop", 1, "foo"),
+				"The Handle Manager reported a problem while attempting to set Handle ACLs: " +
+				"well poop");
+	}
+	
+	@Test
+	public void addReadPermissionsFailWithUserJsonClientException() throws Exception {
+		addReadPermissionsFailWithUser(new JsonClientException("dang it to heck"),
+				"There was an unexpected problem while contacting the Handle Manager to set " +
+				"Handle ACLs: dang it to heck");
+	}
+	
+	private void addReadPermissionsFailWithUser(final Exception ex, final String err)
+			throws IOException, JsonClientException {
+		final HandleMngrClient c = mock(HandleMngrClient.class);
+		final HandleIdHandlerFactory f = new HandleIdHandlerFactory(null, c);
+		final IdReferencePermissionHandler h = f.createPermissionHandler("user");
+		
+		doThrow(ex).when(c).addReadAcl(Arrays.asList("foo"), "user");
+		
+		addReadPermissionsFail(h, new IdReferencePermissionHandlerException(err));
+	}
+	
+	private void addReadPermissionsFail(
+			final IdReferencePermissionHandler h,
+			final Exception expected) {
+		
+		try {
+			h.addReadPermission(Arrays.asList("foo"));
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+}

--- a/src/us/kbase/workspace/test/workspace/TestIDReferenceHandlerFactory.java
+++ b/src/us/kbase/workspace/test/workspace/TestIDReferenceHandlerFactory.java
@@ -16,6 +16,7 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSet.NoSuchIdException;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandler;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFactory;
+import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
 import us.kbase.typedobj.idref.RemappedId;
 import us.kbase.typedobj.idref.SimpleRemappedId;
 
@@ -136,6 +137,16 @@ public class TestIDReferenceHandlerFactory implements IdReferenceHandlerFactory 
 			return type;
 		}
 		
+	}
+
+	@Override
+	public IdReferencePermissionHandler createPermissionHandler() {
+		return null;
+	}
+
+	@Override
+	public IdReferencePermissionHandler createPermissionHandler(String userName) {
+		return null;
 	}
 
 }


### PR DESCRIPTION
Currently only affect handles. The code that set permissions on handles
was buried fairly deep in the code and was not extensible to other ID
types. Add a permissions abstraction so that 1) it is extensible and 2)
the handle code is isolated to a single class, not spread all over.