### PR TITLE
S3 SDK V2 presigned url workaround example

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -68,5 +68,20 @@
 	<classpathentry kind="lib" path="/jars/lib/jars/kafka/kafka-clients-2.1.0.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/mongo/mongo-java-driver-3.8.2.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/kbase/shock/shock-client-0.0.16.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/annotations-2.5.62.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/auth-2.5.62.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/aws-core-2.5.62.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/aws-query-protocol-2.5.62.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/aws-xml-protocol-2.5.62.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/eventstream-1.0.1.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/http-client-spi-2.5.62.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/profiles-2.5.62.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/protocol-core-2.5.62.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/regions-2.5.62.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/s3-2.5.62.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/sdk-core-2.5.62.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/utils-2.5.62.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/reactivestreams/reactive-streams-1.0.2.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/url-connection-client-2.5.63.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/build.xml
+++ b/build.xml
@@ -357,6 +357,7 @@
       <exclude name="performance/**"/>
       <exclude name="debugging/**"/>
       <exclude name="sorting/**"/>
+      <exclude name="s3presignedurl/**"/>
     </javac>
     <junit fork="yes" failureproperty="test.failed">
       <classpath refid="test.client.import.classpath"/>

--- a/src/us/kbase/workspace/database/mongo/BlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/BlobStore.java
@@ -62,10 +62,6 @@ public interface BlobStore {
 	public void removeBlob(MD5 md5) throws BlobStoreAuthorizationException,
 		BlobStoreCommunicationException;
 	
-	// TODO NOW remove. Why the hell is this here?
-	public String getExternalIdentifier(MD5 md5) throws
-		BlobStoreCommunicationException, NoSuchBlobException;
-	
 	/** Returns the status of the blob store's dependencies.
 	 * @return the dependency status.
 	 */

--- a/src/us/kbase/workspace/database/mongo/BlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/BlobStore.java
@@ -62,6 +62,7 @@ public interface BlobStore {
 	public void removeBlob(MD5 md5) throws BlobStoreAuthorizationException,
 		BlobStoreCommunicationException;
 	
+	// TODO NOW remove. Why the hell is this here?
 	public String getExternalIdentifier(MD5 md5) throws
 		BlobStoreCommunicationException, NoSuchBlobException;
 	

--- a/src/us/kbase/workspace/database/mongo/GridFSBlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/GridFSBlobStore.java
@@ -117,11 +117,6 @@ public class GridFSBlobStore implements BlobStore {
 	}
 
 	@Override
-	public String getExternalIdentifier(MD5 md5) {
-		return null;
-	}
-
-	@Override
 	public List<DependencyStatus> status() {
 		//note failures are tested manually for now, if you make changes test
 		//things still work

--- a/src/us/kbase/workspace/database/mongo/S3BlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/S3BlobStore.java
@@ -1,0 +1,57 @@
+package us.kbase.workspace.database.mongo;
+
+import java.util.List;
+
+import us.kbase.typedobj.core.MD5;
+import us.kbase.typedobj.core.Restreamable;
+import us.kbase.workspace.database.ByteArrayFileCacheManager;
+import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
+import us.kbase.workspace.database.DependencyStatus;
+import us.kbase.workspace.database.exceptions.FileCacheIOException;
+import us.kbase.workspace.database.exceptions.FileCacheLimitExceededException;
+import us.kbase.workspace.database.mongo.exceptions.BlobStoreAuthorizationException;
+import us.kbase.workspace.database.mongo.exceptions.BlobStoreCommunicationException;
+import us.kbase.workspace.database.mongo.exceptions.NoSuchBlobException;
+
+public class S3BlobStore implements BlobStore {
+	
+	public S3BlobStore() {
+		// TODO Auto-generated constructor stub
+	}
+
+	@Override
+	public void saveBlob(final MD5 md5, final Restreamable data, final boolean sorted)
+			throws BlobStoreAuthorizationException, BlobStoreCommunicationException {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public ByteArrayFileCache getBlob(final MD5 md5, final ByteArrayFileCacheManager bafcMan)
+			throws BlobStoreAuthorizationException, BlobStoreCommunicationException,
+				NoSuchBlobException, FileCacheLimitExceededException, FileCacheIOException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void removeBlob(final MD5 md5)
+			throws BlobStoreAuthorizationException, BlobStoreCommunicationException {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public String getExternalIdentifier(final MD5 md5)
+			throws BlobStoreCommunicationException, NoSuchBlobException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public List<DependencyStatus> status() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/src/us/kbase/workspace/database/mongo/S3BlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/S3BlobStore.java
@@ -42,13 +42,6 @@ public class S3BlobStore implements BlobStore {
 	}
 
 	@Override
-	public String getExternalIdentifier(final MD5 md5)
-			throws BlobStoreCommunicationException, NoSuchBlobException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
 	public List<DependencyStatus> status() {
 		// TODO Auto-generated method stub
 		return null;

--- a/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
@@ -246,10 +246,4 @@ public class ShockBlobStore implements BlobStore {
 					"Could not read from the mongo database", me);
 		}
 	}
-
-	@Override
-	public String getExternalIdentifier(final MD5 md5) throws
-			BlobStoreCommunicationException, NoSuchBlobException {
-		return getNode(md5);
-	}
 }

--- a/src/us/kbase/workspace/test/database/mongo/GridFSBlobStoreTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/GridFSBlobStoreTest.java
@@ -2,7 +2,6 @@ package us.kbase.workspace.test.database.mongo;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -132,7 +131,6 @@ public class GridFSBlobStoreTest {
 		assertThat("data returned marked as sorted", d.isSorted(), is(true));
 		String returned = IOUtils.toString(d.getJSON());
 		assertThat("Didn't get same data back from store", returned, is(data));
-		assertTrue("GridFS has no external ID", gfsb.getExternalIdentifier(md1copy) == null);
 		gfsb.saveBlob(md1, new StringRestreamable(data), true); //should be able to save the same thing twice with no error
 		
 		gfsb.saveBlob(md1, new StringRestreamable(data), false); //this should do nothing

--- a/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreIntegrationTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreIntegrationTest.java
@@ -1,7 +1,6 @@
 package us.kbase.workspace.test.database.mongo;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -11,7 +10,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.AfterClass;
@@ -29,7 +27,6 @@ import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.shock.client.BasicShockClient;
 import us.kbase.shock.client.ShockNode;
-import us.kbase.shock.client.ShockNodeId;
 import us.kbase.test.auth2.authcontroller.AuthController;
 import us.kbase.typedobj.core.MD5;
 import us.kbase.typedobj.core.Restreamable;
@@ -53,8 +50,6 @@ public class ShockBlobStoreIntegrationTest {
 	private static AuthController authc;
 	private static AuthToken token;
 	
-	private static final Pattern UUID =
-			Pattern.compile("[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}");
 	private static final String A32 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 	private static final String COLLECTION = "shock_nodeMap";
 
@@ -160,11 +155,6 @@ public class ShockBlobStoreIntegrationTest {
 		MD5 md1 = new MD5("5e498cecc4017dad15313bb009b0ef49");
 		String data = "this is a blob yo";
 		sb.saveBlob(md1, new StringRestreamable(data), true);
-		ShockNodeId id = new ShockNodeId(sb.getExternalIdentifier(md1));
-		assertTrue("Got a valid shock id",
-				UUID.matcher(id.getId()).matches());
-		assertThat("Ext id is the shock node", id.getId(),
-				is(sb.getExternalIdentifier(md1)));
 		MD5 md1copy = new MD5("5e498cecc4017dad15313bb009b0ef49");
 		ByteArrayFileCache d = sb.getBlob(md1copy, 
 				new ByteArrayFileCacheManager(16000000, 2000000000L, tfm));

--- a/test/s3presignedurl/S3PresignedURLExample.java
+++ b/test/s3presignedurl/S3PresignedURLExample.java
@@ -1,0 +1,45 @@
+package s3presignedurl;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.BucketAlreadyOwnedByYouException;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+public class S3PresignedURLExample {
+	
+	// https://github.com/aws/aws-sdk-java-v2/issues/849
+	
+	public static void main(String[] args) throws URISyntaxException {
+		final String s3key = args[0];
+		final String s3secret = args[1];
+		final String region = "us-west-1";
+		final String host = "http://localhost:9000"; // minio
+		
+		final S3Client cli = S3Client.builder()
+				.region(Region.of(region))
+				.endpointOverride(new URI(host))
+				.credentialsProvider(StaticCredentialsProvider.create(
+						AwsBasicCredentials.create(s3key, s3secret)))
+				.serviceConfiguration(
+						S3Configuration.builder().pathStyleAccessEnabled(true).build())
+				.httpClient(UrlConnectionHttpClient.create())
+				// disable ssl
+				.build();
+		try {
+			cli.createBucket(CreateBucketRequest.builder()
+					.bucket("foo")
+					.build());
+		} catch (BucketAlreadyOwnedByYouException e) {
+			// do nothing, we're fat dumb and happy
+		}
+	}
+	
+
+}

--- a/test/s3presignedurl/S3PresignedURLExample.java
+++ b/test/s3presignedurl/S3PresignedURLExample.java
@@ -1,45 +1,179 @@
 package s3presignedurl;
 
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.Instant;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.signer.AwsS3V4Signer;
+import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.BucketAlreadyOwnedByYouException;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import us.kbase.common.test.TestCommon;
 
 public class S3PresignedURLExample {
 	
 	// https://github.com/aws/aws-sdk-java-v2/issues/849
 	
-	public static void main(String[] args) throws URISyntaxException {
+	public static void main(String[] args)
+			throws URISyntaxException, MalformedURLException, IOException {
 		final String s3key = args[0];
 		final String s3secret = args[1];
+		final String filePath = args[2];
 		final String region = "us-west-1";
-		final String host = "http://localhost:9000"; // minio
+		// has to be prefixed by http or things go squirrelly with a opaque exception.
+		final URI host = new URI("http://localhost:9000"); // minio
+		final String bucket = "foo";
+		final String objectName = "obj1";
 		
+		TestCommon.stfuLoggers();
+		final AwsBasicCredentials creds = AwsBasicCredentials.create(s3key, s3secret);
 		final S3Client cli = S3Client.builder()
 				.region(Region.of(region))
-				.endpointOverride(new URI(host))
-				.credentialsProvider(StaticCredentialsProvider.create(
-						AwsBasicCredentials.create(s3key, s3secret)))
+				.endpointOverride(host)
+				.credentialsProvider(StaticCredentialsProvider.create(creds))
 				.serviceConfiguration(
 						S3Configuration.builder().pathStyleAccessEnabled(true).build())
 				.httpClient(UrlConnectionHttpClient.create())
-				// disable ssl
+				// Don't need to disable ssl
 				.build();
 		try {
 			cli.createBucket(CreateBucketRequest.builder()
-					.bucket("foo")
+					.bucket(bucket)
 					.build());
 		} catch (BucketAlreadyOwnedByYouException e) {
 			// do nothing, we're fat dumb and happy
 		}
-	}
-	
 
+		// no way to get config from client so this will need to be encapsulated for mocking
+		// purposes
+		final Aws4PresignerParams params = Aws4PresignerParams.builder()
+				.expirationTime(Instant.ofEpochSecond(15 * 60))
+				.awsCredentials(creds)
+				.signingName("s3")
+				.signingRegion(Region.of(region))
+				.build();
+		final SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+				.encodedPath("/" + bucket + "/" + objectName)
+//				.encodedPath("/" + bucket + "a" + "/" + objectName)
+				.host(host.getHost())
+				.port(host.getPort())
+				.method(SdkHttpMethod.PUT)
+				.protocol(host.getScheme())
+				.build();
+		final SdkHttpFullRequest result = AwsS3V4Signer.create().presign(request, params);
+		final URI target = result.getUri();
+		System.out.println(target);
+		
+		final PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
+		cm.setMaxTotal(1000); //perhaps these should be configurable
+		cm.setDefaultMaxPerRoute(1000);
+		//set timeouts for the client for 1/2m for conn req timeout and std timeout
+		final CloseableHttpClient client = HttpClients.custom().setConnectionManager(cm)
+				.build();
+		
+		try (final InputStream is = Files.newInputStream(Paths.get(filePath))) {
+			final HttpPut htp = new HttpPut(target);
+			final BasicHttpEntity ent = new BasicHttpEntity();
+			ent.setContent(new BufferedInputStream(is));
+			ent.setContentLength(Files.size(Paths.get(filePath)));
+			htp.setEntity(ent);
+			final CloseableHttpResponse res = client.execute(htp);
+			if (res.getStatusLine().getStatusCode() > 399) {
+				final byte[] buffer = new byte[1000];
+				try (final InputStream in = res.getEntity().getContent()) {
+					new DataInputStream(in).readFully(buffer);
+				} catch (EOFException e) {
+					// do nothing
+				}
+				throw new IllegalArgumentException(String.format(
+						"Error saving file to S3 (%s), truncated response follows:\n%s",
+						res.getStatusLine().getStatusCode(),
+						new String(buffer, StandardCharsets.UTF_8).trim()));
+			}
+		}
+		
+		/*
+		final HttpURLConnection conn = (HttpURLConnection) target.toURL().openConnection();
+		try {
+			conn.setRequestMethod("PUT");
+			conn.setFixedLengthStreamingMode(Files.size(Paths.get(filePath)));
+			conn.setDoOutput(true);
+			conn.setDoInput(true);
+			
+			try (final OutputStream os = conn.getOutputStream()) {
+				// dealing with io errors here is a real pain
+				try (final InputStream is = Files.newInputStream(Paths.get(filePath))) {
+					try {
+						IOUtils.copy(new BufferedInputStream(is), os);
+					} catch (IOException e) {
+						int code = conn.getResponseCode();
+						final String err = getError(conn);
+						if (!err.isEmpty()) {
+							throw new IllegalArgumentException(String.format(
+									"Error saving file to S3 (%s), truncated response follows:\n%s",
+									code, err));
+						} else {
+							throw e;
+						}
+					}
+				}
+				
+				final int code = conn.getResponseCode();
+				if (code > 399) {
+					throw new IllegalArgumentException(
+							"Error saving file to S3, truncated response follows:\n " +
+									getError(conn));
+				}
+			}
+		} finally {
+			if (conn.getErrorStream() != null) {
+				conn.getErrorStream().close();
+			}
+		}
+		*/
+		final HeadObjectResponse objhead = cli.headObject(HeadObjectRequest.builder()
+				.bucket(bucket)
+				.key(objectName)
+				.build());
+		
+		System.out.println(objhead);
+	}
+	/*
+	private static String getError(final HttpURLConnection conn) throws IOException {
+		if (conn.getErrorStream() == null) {
+			return "";
+		}
+		final byte[] buffer = new byte[1000];
+		try (final InputStream is = conn.getErrorStream()) {
+			new DataInputStream(is).readFully(buffer);
+		}
+		return new String(buffer, StandardCharsets.UTF_8).trim();
+	}
+	*/
 }


### PR DESCRIPTION
Also removed BlobStore.getExternalIdentifier(). Unused and leaks implementation details.

test/s3presignedurl/S3PresignedURLExample.java isn't actually used anywhere, but it's useful code to test error handling so I'm checking it in.

