### PR TITLE
Add ErrorOr class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
   - MONGODB_VER=mongodb-linux-x86_64-3.6.10 MINIO=2019-05-23T00-29-34Z ANT_TEST=test_quick_coverage WIRED_TIGER=true
 
 before_install:
+  # apt update fails without this key
+  - wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
   - sudo add-apt-repository -y ppa:deadsnakes/ppa
   - sudo apt update -q
   - sudo apt install -y ant-optional

--- a/build.xml
+++ b/build.xml
@@ -62,7 +62,6 @@
     <include name="apache_commons/commons-io-2.4.jar"/>
     <include name="apache_commons/commons-lang3-3.1.jar"/>
     <include name="mongo/mongo-java-driver-3.8.2.jar"/>
-    <include name="bson4jackson/bson4jackson-2.2.0-2.2.0.jar"/>
     <include name="slf4j/slf4j-api-1.7.7.jar"/>
     <include name="logback/logback-core-1.1.2.jar"/>
     <include name="logback/logback-classic-1.1.2.jar"/>

--- a/src/us/kbase/workspace/database/exceptions/ErrorOr.java
+++ b/src/us/kbase/workspace/database/exceptions/ErrorOr.java
@@ -1,0 +1,96 @@
+package us.kbase.workspace.database.exceptions;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+/** 
+ * A class that represents an object or an error that occurred attempting to create or retrieve
+ * the object.
+ */
+public class ErrorOr<T> {
+
+	// TODO ERROR may want to support including custom error fields? Different errors = different fields
+	// TODO LOMBOK
+	// TODO CODE return this from bulk methods rather than object / null 
+	
+	private final ErrorType error;
+	private final T object;
+	
+	
+	/** Create an object containing an error.
+	 * @param error the error.
+	 */
+	public ErrorOr(final ErrorType error) {
+		this.object = null;
+		this.error = requireNonNull(error, "error");
+	}
+	
+	/** Create an object containing a result object. Null is acceptable, but consider using
+	 * {@link Optional} instead.
+	 * @param object the object.
+	 */
+	public ErrorOr(final T object) {
+		this.object = object;
+		this.error = null;
+	}
+	
+	/** Returns true if this instance contains an error, false if an object.
+	 * @return true if this instance contains an error.
+	 */
+	public boolean isError() {
+		return error != null;
+	}
+	
+	/** Get the error, if any.
+	 * @return the error.
+	 * @throws NoSuchElementException if this instance does not contain an error.
+	 */
+	public ErrorType getError() {
+		if (error == null) {
+			throw new NoSuchElementException("error");
+		}
+		return error;
+	}
+	
+	/** Get the object, if any. The object may be null.
+	 * @return the object.
+	 * @throws NoSuchElementException if this instance does not contain an error.
+	 */
+	public T getObject() {
+		if (error != null) {
+			throw new NoSuchElementException("object");
+		}
+		return object;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((error == null) ? 0 : error.hashCode());
+		result = prime * result + ((object == null) ? 0 : object.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ErrorOr<?> other = (ErrorOr<?>) obj;
+		if (error != other.error)
+			return false;
+		if (object == null) {
+			if (other.object != null)
+				return false;
+		} else if (!object.equals(other.object))
+			return false;
+		return true;
+	}
+}
+

--- a/src/us/kbase/workspace/database/exceptions/ErrorType.java
+++ b/src/us/kbase/workspace/database/exceptions/ErrorType.java
@@ -1,0 +1,58 @@
+package us.kbase.workspace.database.exceptions;
+
+/** An enum representing the type of a particular error.
+ * @author gaprice@lbl.gov
+ *
+ */
+
+// TODO ERROR change the current exception types to *LegacyException and use error code in new exceptions
+public enum ErrorType {
+	
+	// many of these are unused currently but will be used in the future
+	
+	/** The authentication service returned an error. */
+	AUTHENTICATION_FAILED	(10000, "Authentication failed"),
+	/** No token was provided when required */
+	NO_TOKEN				(10010, "No authentication token"),
+	/** The token provided is not valid. */
+	INVALID_TOKEN			(10020, "Invalid token"),
+	/** The user is not authorized to perform the requested action. */
+	UNAUTHORIZED			(20000, "Unauthorized"),
+	/** A required input parameter was not provided. */
+	MISSING_PARAMETER		(30000, "Missing input parameter"),
+	/** An input parameter had an illegal value. */
+	ILLEGAL_PARAMETER		(30001, "Illegal input parameter"),
+	/** The provided user name was not legal. */
+	ILLEGAL_USER_NAME		(30010, "Illegal user name"),
+	/** The provided user does not exist. */
+	NO_SUCH_USER			(50000, "No such user"),
+	/** The provided workspace does not exist. */
+	NO_SUCH_WORKSPACE		(50010, "No such group"),
+	/** The provided workspace is deleted. */
+	DELETED_WORKSPACE		(50020, "Workspace is deleted"),
+	/** The requested operation is not supported. */
+	UNSUPPORTED_OP			(100000, "Unsupported operation");
+	
+	private final int errcode;
+	private final String error;
+	
+	private ErrorType(final int errcode, final String error) {
+		this.errcode = errcode;
+		this.error = error;
+	}
+
+	/** Get the error code for the error type.
+	 * @return the error code.
+	 */
+	public int getErrorCode() {
+		return errcode;
+	}
+
+	/** Get a text description of the error type.
+	 * @return the error.
+	 */
+	public String getError() {
+		return error;
+	}
+
+}

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -1014,6 +1014,7 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 			final Set<WorkspaceIdentifier> wsis,
 			final boolean allowDeleted,
 			final boolean allowMissing)
+			// TODO CODE don't think comm exception needs to be checked. Usually will just fail.
 			throws WorkspaceCommunicationException, NoSuchWorkspaceException {
 		final Map<WorkspaceIdentifier, ResolvedWorkspaceID> ret =
 				new HashMap<WorkspaceIdentifier, ResolvedWorkspaceID>();

--- a/src/us/kbase/workspace/test/workspace/ErrorOrTest.java
+++ b/src/us/kbase/workspace/test/workspace/ErrorOrTest.java
@@ -24,7 +24,7 @@ public class ErrorOrTest {
 	
 	@Test
 	public void constructWithError() {
-		final ErrorOr<Integer> eeyore= new ErrorOr<>(ErrorType.DELETED_WORKSPACE);
+		final ErrorOr<Integer> eeyore = new ErrorOr<>(ErrorType.DELETED_WORKSPACE);
 		
 		assertThat("incorrect is error", eeyore.isError(), is(true));
 		assertThat("incorrect error", eeyore.getError(), is(ErrorType.DELETED_WORKSPACE));

--- a/src/us/kbase/workspace/test/workspace/ErrorOrTest.java
+++ b/src/us/kbase/workspace/test/workspace/ErrorOrTest.java
@@ -1,0 +1,84 @@
+package us.kbase.workspace.test.workspace;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.NoSuchElementException;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import us.kbase.common.test.TestCommon;
+import us.kbase.workspace.database.exceptions.ErrorOr;
+import us.kbase.workspace.database.exceptions.ErrorType;
+
+// also tests the minimal code in ErrorType
+public class ErrorOrTest {
+	
+	@Test
+	public void equals() throws Exception {
+		EqualsVerifier.forClass(ErrorOr.class).usingGetClass().verify();
+	}
+	
+	@Test
+	public void constructWithError() {
+		final ErrorOr<Integer> eeyore= new ErrorOr<>(ErrorType.DELETED_WORKSPACE);
+		
+		assertThat("incorrect is error", eeyore.isError(), is(true));
+		assertThat("incorrect error", eeyore.getError(), is(ErrorType.DELETED_WORKSPACE));
+		
+		assertThat("incorrect error code", eeyore.getError().getErrorCode(), is(50020));
+		assertThat("incorrect error text", eeyore.getError().getError(),
+				is("Workspace is deleted"));
+	}
+		
+	@Test
+	public void constructWithErrorFail() throws Exception {
+		try {
+			new ErrorOr<>(null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("error"));
+		}
+	}
+	
+	@Test
+	public void getErrorFail() throws Exception {
+		try {
+			new ErrorOr<>("foo").getError();
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NoSuchElementException("error"));
+		}
+	}
+	
+	@Test
+	public void constructWithObject() throws Exception {
+		final ErrorOr<String> eeyore = new ErrorOr<>("foo");
+		
+		assertThat("incorrect is error", eeyore.isError(), is(false));
+		assertThat("incorrect object", eeyore.getObject(), is("foo"));
+	}
+	
+	@Test
+	public void constructWithNullObject() throws Exception {
+		final ErrorOr<String> eeyore = new ErrorOr<>((String) null);
+		
+		assertThat("incorrect is error", eeyore.isError(), is(false));
+		assertThat("incorrect object", eeyore.getObject(), nullValue());
+	}
+	
+	@Test
+	public void getObjectFail() throws Exception {
+		try {
+			new ErrorOr<>(ErrorType.ILLEGAL_PARAMETER).getObject();
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NoSuchElementException("object"));
+		}
+		
+	}
+
+}


### PR DESCRIPTION
This class will be used to return either an object, such as a Workspace
object, or an error code that explains why the object could not be
retrieved. The error code will be exposed in API methods that use the
ignoreError parameter rather than just a null value.