### PR TITLE
Correct test instructions

### DIFF
--- a/docsource/test.rst
+++ b/docsource/test.rst
@@ -1,9 +1,6 @@
 Test
 ====
 
-Prior to running workspace tests, the workspace source files must be built.
-See :ref:`buildconfigdeploy`.
-
 In order to run tests:
 
 * MongoDB must be installed, but not necessarily running.
@@ -17,13 +14,22 @@ In order to run tests:
 
 * The Handle Service must be installed, but not necessarily running. See ``test.cfg.example``
   for setup instructions.
+  
+* The KBase Jars repo must be cloned into the parent directory of the workspace repo directory,
+  e.g::
+
+    ls 
+    jars  workspace_deluxe
 
 See :ref:`servicedeps` for more information about these test dependencies.
 
 Next, copy the ``test.cfg.example`` file to ``test.cfg`` and fill in appropriately.
 
-Finally::
+Then::
 
+    cd handle_service_test/
+    pipenv shell
+    cd ..
     make test
 
 The tests currently take 20-30 minutes to run on spinning disks, or 8-10 minutes on SSDs.


### PR DESCRIPTION
build/config/install needs a rework badly (still references the
dev_container) but that's a lot more work and probably needs some helper
scripts / better instructions rather than just a 5m rewrite. Maybe just
provide a docker-compose.