### PR TITLE
Add sample service client

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -94,5 +94,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="/jars/lib/jars/kbase/common/kbase-common-0.1.0.jar" sourcepath="/jars/lib/jars/kbase/common/kbase-common-0.1.0-sources.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/kbase/sample/SampleServiceClient-0.1.0-alpha21.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -94,6 +94,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="/jars/lib/jars/kbase/common/kbase-common-0.1.0.jar" sourcepath="/jars/lib/jars/kbase/common/kbase-common-0.1.0-sources.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/kbase/sample/SampleServiceClient-0.1.0-alpha21.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/kbase/sample/SampleServiceClient-0.1.0-alpha22.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/build.xml
+++ b/build.xml
@@ -68,6 +68,7 @@
     <include name="google/guava-14.0.1.jar"/>
     <include name="kafka/kafka-clients-2.1.0.jar"/>
     <include name="kbase/handle/AbstractHandleClient-1.0.0.jar"/>
+    <include name="kbase/sample/SampleServiceClient-0.1.0-alpha21.jar"/>
   </fileset>
 
   <fileset dir="${jardir}" id="s3lib">

--- a/build.xml
+++ b/build.xml
@@ -68,7 +68,7 @@
     <include name="google/guava-14.0.1.jar"/>
     <include name="kafka/kafka-clients-2.1.0.jar"/>
     <include name="kbase/handle/AbstractHandleClient-1.0.0.jar"/>
-    <include name="kbase/sample/SampleServiceClient-0.1.0-alpha21.jar"/>
+    <include name="kbase/sample/SampleServiceClient-0.1.0-alpha22.jar"/>
   </fileset>
 
   <fileset dir="${jardir}" id="s3lib">

--- a/src/us/kbase/typedobj/idref/IdReferencePermissionHandlerSet.java
+++ b/src/us/kbase/typedobj/idref/IdReferencePermissionHandlerSet.java
@@ -39,8 +39,7 @@ public class IdReferencePermissionHandlerSet {
 	 */
 	protected IdReferencePermissionHandlerSet(
 			final Map<IdReferenceType, IdReferencePermissionHandler> handlers) {
-		this.handlers = new HashMap<IdReferenceType, IdReferencePermissionHandler>(
-				handlers);
+		this.handlers = new HashMap<IdReferenceType, IdReferencePermissionHandler>(handlers);
 	}
 
 	/** Returns true if this handler set contains a handler for the ID type

--- a/src/us/kbase/workspace/kbase/SampleServiceClientWrapper.java
+++ b/src/us/kbase/workspace/kbase/SampleServiceClientWrapper.java
@@ -74,7 +74,7 @@ public class SampleServiceClientWrapper {
 			final JsonClientCaller caller,
 			final Optional<String> serviceVersion) {
 		if (serviceVersion == null ||
-				serviceVersion.isEmpty() ||
+				!serviceVersion.isPresent() ||
 				serviceVersion.get().trim().isEmpty()) {
 			return new SampleServiceClientWrapper(caller);
 		} else {

--- a/src/us/kbase/workspace/kbase/SampleServiceClientWrapper.java
+++ b/src/us/kbase/workspace/kbase/SampleServiceClientWrapper.java
@@ -1,0 +1,151 @@
+package us.kbase.workspace.kbase;
+
+import static java.util.Objects.requireNonNull;
+import static us.kbase.workspace.database.Util.checkString;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import us.kbase.common.service.JsonClientCaller;
+import us.kbase.common.service.JsonClientException;
+import us.kbase.common.service.RpcContext;
+import us.kbase.sampleservice.GetSampleACLsParams;
+import us.kbase.sampleservice.SampleACLs;
+import us.kbase.sampleservice.SampleServiceClient;
+import us.kbase.sampleservice.SampleServiceClientDynamic;
+import us.kbase.sampleservice.UpdateSampleACLsParams;
+
+/**
+ * A wrapper around the generic KBase SDK client for the sample service. The standard clients
+ * are not suitable here as the client may need to operate in dynamic or standard mode depending
+ * on whether the sample service is accessed directly (for example, in tests) or via the KBase
+ * service wizard, and the standard clients are hard coded to one or the other.
+ * 
+ * Currently only methods required for workspace / sample service integration are implemented and
+ * are essentially duplicated from the SDK clients.
+ * The method documentation, if any, is duplicated from the SDK clients.
+ * 
+ * Altering the provided {@link JsonClientCaller} after passing it into the wrapper may cause
+ * undefined behavior.
+ * 
+ * @see JsonClientCaller
+ * @see SampleServiceClient
+ * @see SampleServiceClientDynamic
+ */
+public class SampleServiceClientWrapper {
+
+	private final JsonClientCaller caller;
+	private final Optional<String> serviceVersion;
+	
+	/** Create the client in standard mode. The caller should be initialized with the direct URL
+	 * to the sample service.
+	 * @param caller the generic client.
+	 */
+	public SampleServiceClientWrapper(final JsonClientCaller caller) {
+		this.caller = requireNonNull(caller, "caller");
+		this.caller.setDynamic(false);
+		this.serviceVersion = Optional.empty();
+	}
+	
+	/** Create the client in dynamic mode. The caller should be initialized with the URL of the
+	 * KBase service wizard.
+	 * @param caller the generic client.
+	 * @param serviceVersion the service tag for the Sample Service, e.g. release, beta, dev, a
+	 * version, or a git hash.
+	 */
+	public SampleServiceClientWrapper(final JsonClientCaller caller, final String serviceVersion) {
+		this.caller = requireNonNull(caller, "caller");
+		this.caller.setDynamic(true);
+		this.serviceVersion = Optional.of(checkString(serviceVersion, "serviceVersion"));
+	}
+	
+	/** Get a sample service client.
+	 * @param caller the generic client.
+	 * @param serviceVersion null or empty to get a standard client, or a service tag to get a
+	 * dynamic client.
+	 * @return the client.
+	 */
+	public static SampleServiceClientWrapper getClient(
+			final JsonClientCaller caller,
+			final Optional<String> serviceVersion) {
+		if (serviceVersion == null || serviceVersion.isEmpty() || serviceVersion.get().isBlank()) {
+			return new SampleServiceClientWrapper(caller);
+		} else {
+			return new SampleServiceClientWrapper(caller, serviceVersion.get());
+		}
+	}
+
+	/**
+	 * <p>Original spec-file function name: get_sample_acls</p>
+	 * <pre>
+	 * Get a sample's ACLs.
+	 * </pre>
+	 * @param params instance of type
+	 * {@link us.kbase.sampleservice.GetSampleACLsParams GetSampleACLsParams}
+	 * @return parameter "acls" of type {@link us.kbase.sampleservice.SampleACLs SampleACLs}
+	 * @throws IOException if an IO exception occurs
+	 * @throws JsonClientException if a JSON RPC exception occurs
+	 */
+	public SampleACLs getSampleAcls(GetSampleACLsParams params, RpcContext... jsonRpcContext)
+			throws IOException, JsonClientException {
+		List<Object> args = new ArrayList<Object>();
+		args.add(params);
+		TypeReference<List<SampleACLs>> retType = new TypeReference<List<SampleACLs>>() {};
+		List<SampleACLs> res = caller.jsonrpcCall(
+				"SampleService.get_sample_acls",
+				args,
+				retType,
+				true,
+				false,
+				jsonRpcContext,
+				this.serviceVersion.orElse(null));
+		return res.get(0);
+	}
+
+	/**
+	 * <p>Original spec-file function name: update_sample_acls</p>
+	 * <pre>
+	 * Update a sample's ACLs.
+	 * </pre>
+	 * @param params instance of type
+	 * {@link us.kbase.sampleservice.UpdateSampleACLsParams UpdateSampleACLsParams}
+	 * @throws IOException if an IO exception occurs
+	 * @throws JsonClientException if a JSON RPC exception occurs
+	 */
+	public void updateSampleAcls(UpdateSampleACLsParams params, RpcContext... jsonRpcContext)
+			throws IOException, JsonClientException {
+		List<Object> args = new ArrayList<Object>();
+		args.add(params);
+		TypeReference<Object> retType = new TypeReference<Object>() {};
+		caller.jsonrpcCall(
+				"SampleService.update_sample_acls",
+				args,
+				retType,
+				false,
+				true,
+				jsonRpcContext,
+				this.serviceVersion.orElse(null));
+	}
+
+	public Map<String, Object> status(RpcContext... jsonRpcContext)
+			throws IOException, JsonClientException {
+		List<Object> args = new ArrayList<Object>();
+		TypeReference<List<Map<String, Object>>> retType =
+				new TypeReference<List<Map<String, Object>>>() {};
+		List<Map<String, Object>> res = caller.jsonrpcCall(
+				"SampleService.status",
+				args,
+				retType,
+				true,
+				false,
+				jsonRpcContext,
+				this.serviceVersion.orElse(null));
+		return res.get(0);
+	}
+
+}

--- a/src/us/kbase/workspace/kbase/SampleServiceClientWrapper.java
+++ b/src/us/kbase/workspace/kbase/SampleServiceClientWrapper.java
@@ -73,7 +73,9 @@ public class SampleServiceClientWrapper {
 	public static SampleServiceClientWrapper getClient(
 			final JsonClientCaller caller,
 			final Optional<String> serviceVersion) {
-		if (serviceVersion == null || serviceVersion.isEmpty() || serviceVersion.get().isBlank()) {
+		if (serviceVersion == null ||
+				serviceVersion.isEmpty() ||
+				serviceVersion.get().trim().isEmpty()) {
 			return new SampleServiceClientWrapper(caller);
 		} else {
 			return new SampleServiceClientWrapper(caller, serviceVersion.get());

--- a/src/us/kbase/workspace/test/kbase/SampleServiceClientWrapperTest.java
+++ b/src/us/kbase/workspace/test/kbase/SampleServiceClientWrapperTest.java
@@ -1,0 +1,296 @@
+package us.kbase.workspace.test.kbase;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.common.service.JsonClientCaller;
+import us.kbase.common.service.RpcContext;
+import us.kbase.common.test.TestCommon;
+import us.kbase.sampleservice.GetSampleACLsParams;
+import us.kbase.sampleservice.SampleACLs;
+import us.kbase.sampleservice.UpdateSampleACLsParams;
+import us.kbase.workspace.kbase.SampleServiceClientWrapper;
+
+public class SampleServiceClientWrapperTest {
+	
+	/* These tests use identity for equality within the mocks and test results, which is a
+	 * practice of which I'm not fond. However, in this case, the objects are always passed
+	 * through as is and creating new, non-identity objects for the tests would require
+	 * writing custom matchers for the objects, so it's not worth the trouble.
+	 * 
+	 * It'd be nice if the SDK generated equals and hashCode methods...
+	 * 
+	 * Also, the JsonRPCContext input parameter is ignored because it's unused in all cases
+	 * I'm aware of and will not be used in the workspace.
+	 */
+	
+	@Test
+	public void constructStandardFail() throws Exception {
+		try {
+			new SampleServiceClientWrapper(null);
+			fail("expected exception");
+		} catch (NullPointerException e) {
+			TestCommon.assertExceptionCorrect(e, new NullPointerException("caller"));
+		}
+	}
+	
+	@Test
+	public void constructDynamicFail() throws Exception {
+		final JsonClientCaller jcc = mock(JsonClientCaller.class);
+		
+		constructDynamicFail(null, "f", new NullPointerException("caller"));
+		constructDynamicFail(jcc, null, new IllegalArgumentException(
+				"serviceVersion cannot be null or whitespace only"));
+		constructDynamicFail(jcc, "   \t    ", new IllegalArgumentException(
+				"serviceVersion cannot be null or whitespace only"));
+	}
+	
+	private void constructDynamicFail(
+			final JsonClientCaller jcc,
+			final String servVer,
+			final Exception expected) {
+		try {
+			new SampleServiceClientWrapper(jcc, servVer);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}		
+	}
+	
+	@Test
+	public void getAclsStandard() throws Exception {
+		final JsonClientCaller jcc = mock(JsonClientCaller.class);
+		
+		final GetSampleACLsParams args = new GetSampleACLsParams().withId("foo");
+		final SampleACLs res = new SampleACLs().withOwner("bar");
+		
+		when(jcc.jsonrpcCall(
+				eq("SampleService.get_sample_acls"),
+				eq(Arrays.asList(args)),
+				// the JCC creates a new typeref here and typerefs don't seem to have a
+				// usable equals method, so just accept anything.
+				any(),
+				eq(true),
+				eq(false),
+				eq(new RpcContext[0]),
+				eq(null)))
+		.thenReturn(Arrays.asList(res));
+		
+		assertThat(
+				"incorrect sample acl",
+				new SampleServiceClientWrapper(jcc).getSampleAcls(args),
+				is(res));
+		
+		verify(jcc).setDynamic(false);
+	}
+	
+	@Test
+	public void getAclsDynamic() throws Exception {
+		final JsonClientCaller jcc = mock(JsonClientCaller.class);
+		
+		final GetSampleACLsParams args = new GetSampleACLsParams().withId("foo");
+		final SampleACLs res = new SampleACLs().withOwner("bar");
+		
+		when(jcc.jsonrpcCall(
+				eq("SampleService.get_sample_acls"),
+				eq(Arrays.asList(args)),
+				// the JCC creates a new typeref here and typerefs don't seem to have a
+				// usable equals method, so just accept anything.
+				any(),
+				eq(true),
+				eq(false),
+				eq(new RpcContext[0]),
+				eq("bar")))
+		.thenReturn(Arrays.asList(res));
+		
+		assertThat(
+				"incorrect sample acl",
+				new SampleServiceClientWrapper(jcc, "bar").getSampleAcls(args),
+				is(res));
+		
+		verify(jcc).setDynamic(true);
+	}
+	
+	@Test
+	public void updateAclsStandard() throws Exception {
+		final JsonClientCaller jcc = mock(JsonClientCaller.class);
+		
+		final UpdateSampleACLsParams args = new UpdateSampleACLsParams().withId("bar");
+		
+		new SampleServiceClientWrapper(jcc).updateSampleAcls(args);
+		
+		verify(jcc).jsonrpcCall(
+				eq("SampleService.update_sample_acls"),
+				eq(Arrays.asList(args)),
+				// the JCC creates a new typeref here and typerefs don't seem to have a
+				// usable equals method, so just accept anything.
+				any(),
+				eq(false),
+				eq(true),
+				eq(new RpcContext[0]),
+				eq(null));
+		
+		verify(jcc).setDynamic(false);
+	}
+	
+	@Test
+	public void updateAclsDynamic() throws Exception {
+		final JsonClientCaller jcc = mock(JsonClientCaller.class);
+		
+		final UpdateSampleACLsParams args = new UpdateSampleACLsParams().withId("bar");
+		
+		new SampleServiceClientWrapper(jcc, "whee").updateSampleAcls(args);
+		
+		verify(jcc).jsonrpcCall(
+				eq("SampleService.update_sample_acls"),
+				eq(Arrays.asList(args)),
+				// the JCC creates a new typeref here and typerefs don't seem to have a
+				// usable equals method, so just accept anything.
+				any(),
+				eq(false),
+				eq(true),
+				eq(new RpcContext[0]),
+				eq("whee"));
+		
+		verify(jcc).setDynamic(true);
+	}
+	
+	@Test
+	public void statusStandard() throws Exception {
+		final JsonClientCaller jcc = mock(JsonClientCaller.class);
+
+		final Map<String, Object> res = ImmutableMap.of("foo", "bat");
+		
+		when(jcc.jsonrpcCall(
+				eq("SampleService.status"),
+				eq(Collections.emptyList()),
+				// the JCC creates a new typeref here and typerefs don't seem to have a
+				// usable equals method, so just accept anything.
+				any(),
+				eq(true),
+				eq(false),
+				eq(new RpcContext[0]),
+				eq(null)))
+		.thenReturn(Arrays.asList(res));
+		
+		assertThat(
+				"incorrect sample acl",
+				new SampleServiceClientWrapper(jcc).status(),
+				is(res));
+		
+		verify(jcc).setDynamic(false);
+	}
+	
+	@Test
+	public void statusDynamic() throws Exception {
+		final JsonClientCaller jcc = mock(JsonClientCaller.class);
+
+		final Map<String, Object> res = ImmutableMap.of("foo", "bat");
+		
+		when(jcc.jsonrpcCall(
+				eq("SampleService.status"),
+				eq(Collections.emptyList()),
+				// the JCC creates a new typeref here and typerefs don't seem to have a
+				// usable equals method, so just accept anything.
+				any(),
+				eq(true),
+				eq(false),
+				eq(new RpcContext[0]),
+				eq("1.0.1")))
+		.thenReturn(Arrays.asList(res));
+		
+		assertThat(
+				"incorrect sample acl",
+				new SampleServiceClientWrapper(jcc, "1.0.1").status(),
+				is(res));
+		
+		verify(jcc).setDynamic(true);
+	}
+	
+	/* the next 2 methods test building the client with the static helper method */
+	
+	@Test
+	public void getClientStandard() throws Exception {
+		statusStandardWithStaticBuilderMethod(null);
+		statusStandardWithStaticBuilderMethod(Optional.empty());
+		statusStandardWithStaticBuilderMethod(Optional.of("  \t   "));
+	}
+		
+	private void statusStandardWithStaticBuilderMethod(final Optional<String> serviceVer)
+			throws Exception {
+		final JsonClientCaller jcc = mock(JsonClientCaller.class);
+
+		final Map<String, Object> res = ImmutableMap.of("foo", "bat");
+		
+		when(jcc.jsonrpcCall(
+				eq("SampleService.status"),
+				eq(Collections.emptyList()),
+				// the JCC creates a new typeref here and typerefs don't seem to have a
+				// usable equals method, so just accept anything.
+				any(),
+				eq(true),
+				eq(false),
+				eq(new RpcContext[0]),
+				eq(null)))
+		.thenReturn(Arrays.asList(res));
+		
+		assertThat(
+				"incorrect sample acl",
+				SampleServiceClientWrapper.getClient(jcc, serviceVer).status(),
+				is(res));
+		
+		verify(jcc).setDynamic(false);
+	}
+	
+	@Test
+	public void getClientDynamic() throws Exception {
+		final JsonClientCaller jcc = mock(JsonClientCaller.class);
+
+		final Map<String, Object> res = ImmutableMap.of("foo", "bat");
+		
+		when(jcc.jsonrpcCall(
+				eq("SampleService.status"),
+				eq(Collections.emptyList()),
+				// the JCC creates a new typeref here and typerefs don't seem to have a
+				// usable equals method, so just accept anything.
+				any(),
+				eq(true),
+				eq(false),
+				eq(new RpcContext[0]),
+				eq("1.0.1")))
+		.thenReturn(Arrays.asList(res));
+		
+		assertThat(
+				"incorrect sample acl",
+				SampleServiceClientWrapper.getClient(jcc, Optional.of("1.0.1")).status(),
+				is(res));
+		
+		verify(jcc).setDynamic(true);
+	}
+	
+	@Test
+	public void getClientFail() throws Exception {
+		try {
+			SampleServiceClientWrapper.getClient(null, null);
+			fail("expected exception");
+		} catch (NullPointerException e) {
+			TestCommon.assertExceptionCorrect(e, new NullPointerException("caller"));
+		}
+	}
+	
+}


### PR DESCRIPTION
The inability to initialize a client as either dynamic or standard means I need to roll my own, unfortunately.

This is a little on the large side but it's all greenfield, completely standalone, and 75% test code and so hopefully shouldn't be too difficult to understand.