### PR TITLE
Remove auto download option for handle service controller

### DIFF
--- a/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
+++ b/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
@@ -502,10 +502,10 @@ public class InitWorkspaceServer {
 		try {
 			return auth.validateToken(cfg.getHandleServiceToken());
 		} catch (AuthException e) {
-			rep.reportFail("Invalid handle manager token: " + e.getMessage());
+			rep.reportFail("Invalid handle service token: " + e.getMessage());
 		} catch (IOException e) {
 			rep.reportFail("Couldn't contact the auth service to obtain a token " +
-					"for the handle manager: " + e.getLocalizedMessage());
+					"for the handle service: " + e.getLocalizedMessage());
 		}
 		return null;
 	}

--- a/src/us/kbase/workspace/test/controllers/handle/HandleServiceController.java
+++ b/src/us/kbase/workspace/test/controllers/handle/HandleServiceController.java
@@ -22,8 +22,7 @@ import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.common.test.controllers.shock.ShockController;
 
 
-/** Q&D Utility to run Handle Service/Manager servers for the purposes of
- * testing from Java.
+/** Q&D Utility to run the Handle Service for the purposes of testing from Java.
  * @author gaprice@lbl.gov
  *
  */
@@ -55,12 +54,7 @@ public class HandleServiceController {
 
 		String lib_dir = "lib";
 		Path lib_root = tempDir.resolve(lib_dir);
-		if (handleServiceDir == null) {
-			downloadSourceFiles(lib_root);
-		}
-		else {
-			FileUtils.copyDirectory(new File(handleServiceDir), lib_root.toFile());
-		}
+		FileUtils.copyDirectory(new File(handleServiceDir), lib_root.toFile());
 
 		final String lib_dir_path = lib_root.toAbsolutePath().toString();
 		logfile = tempDir.resolve("handle_service.log");
@@ -77,43 +71,6 @@ public class HandleServiceController {
 		handleService = handlepb.start();
 
 		Thread.sleep(1000); //let the service start up
-	}
-
-	private void downloadSourceFiles(Path lib_root) throws IOException {
-		// download source files from github repo
-
-		Files.createDirectories(lib_root);
-
-		Path handle_dir = lib_root.resolve("AbstractHandle");
-		Files.createDirectories(handle_dir);
-
-		String handle_repo_prefix = "https://raw.githubusercontent.com/kbase/handle_service2/develop/lib/AbstractHandle/";
-		String [] handle_impl_files = {"__init__.py", "AbstractHandleImpl.py",
-				"AbstractHandleServer.py", "authclient.py", "baseclient.py"};
-		for (String file_name : handle_impl_files) {
-			FileUtils.copyURLToFile(new URL(handle_repo_prefix + file_name),
-					handle_dir.resolve(file_name).toFile());
-		}
-
-		Path handle_utils_dir = handle_dir.resolve("Utils");
-		Files.createDirectories(handle_utils_dir);
-		String [] handle_util_files = {"__init__.py", "Handler.py", "MongoUtil.py",
-				"ShockUtil.py", "TokenCache.py"};
-		for (String file_name : handle_util_files) {
-			FileUtils.copyURLToFile(new URL(handle_repo_prefix + "Utils/" + file_name),
-					handle_utils_dir.resolve(file_name).toFile());
-		}
-
-		Path biokbase_dir = lib_root.resolve("biokbase");
-		Files.createDirectories(biokbase_dir);
-
-		String biokbase_repo_prefix = "https://raw.githubusercontent.com/kbase/sdkbase2/python/";
-		String [] biokbase_files = {"log.py"};
-		for (String file_name : biokbase_files) {
-			FileUtils.copyURLToFile(new URL(biokbase_repo_prefix + file_name),
-					biokbase_dir.resolve(file_name).toFile());
-		}
-
 	}
 
 	private File createHandleServiceDeployCfg(

--- a/test.cfg.example
+++ b/test.cfg.example
@@ -28,8 +28,7 @@ test.temp.dir = workspace_test_temp
 test.temp.dir.keep=false
 
 # Handle Service lib directory location
-# Leave empty if you want to test the latest HandleService
-# Otherwise clone handle_service2 repo (https://github.com/kbase/handle_service2)
+# To set up, clone handle_service2 repo (https://github.com/kbase/handle_service2)
 # Then create biokbase dir in lib dir and copy log.py file into biokbase
 #   (https://github.com/kbase/sdkbase2/blob/python/log.py)
 # e.g.
@@ -41,8 +40,8 @@ test.temp.dir.keep=false
 # cd ..
 # pwd
 
-# A HS2 environment can be created with https://github.com/pypa/pipenv via the Pipfile in
-# handle_service_test.
+# A python environment for the handle service can be created with https://github.com/pypa/pipenv
+# via the Pipfile in python dependencies.
 
 test.handleservice.dir=
 


### PR DESCRIPTION
Code being removed provides the ability to automatically download the
handle service code from github and use it in the tests. But:

1) It's not used anywhere
2) It pull the latest version of the handle service files rather than a
pinned version
3) More code to maintain

Hence the removal

Also some minor text cleanup