### PR TITLE
Add arango and sample service to test configuration

### DIFF
--- a/src/us/kbase/common/test/TestCommon.java
+++ b/src/us/kbase/common/test/TestCommon.java
@@ -49,6 +49,9 @@ public class TestCommon {
 	public static final String MONGOEXE = "test.mongo.exe";
 	public static final String MONGO_USE_WIRED_TIGER = "test.mongo.useWiredTiger";
 	public static final String HANDLE_SERVICE_DIR = "test.handleservice.dir";
+	public static final String SAMPLE_SERVICE_DIR = "test.sampleservice.dir";
+	public static final String ARANGOEXE = "test.arango.exe";
+	public static final String ARANGOJS = "test.arango.js";
 	
 	public static final String JARS_PATH = "test.jars.dir";
 	
@@ -143,6 +146,14 @@ public class TestCommon {
 	public static String getMongoExe() {
 		return getTestProperty(MONGOEXE);
 	}
+	
+	public static Path getArangoExe() {
+		return Paths.get(getTestProperty(ARANGOEXE));
+	}
+	
+	public static Path getArangoJS() {
+		return Paths.get(getTestProperty(ARANGOJS));
+	}
 
 	public static String getMinioExe() {
 		return getTestProperty(MINIOEXE);
@@ -157,7 +168,11 @@ public class TestCommon {
 	}
 	
 	public static String getHandleServiceDir() {
-		return getTestProperty(HANDLE_SERVICE_DIR, true);
+		return getTestProperty(HANDLE_SERVICE_DIR);
+	}
+	
+	public static Path getSampleServiceDir() {
+		return Paths.get(getTestProperty(SAMPLE_SERVICE_DIR));
 	}
 	
 	public static Path getJarsDir() {

--- a/test.cfg.example
+++ b/test.cfg.example
@@ -19,6 +19,16 @@ test.mongo.exe = /kb/runtime/bin/mongod
 # 'true' to use the MongoDB WiredTiger file storage engine (3.0+)
 test.mongo.useWiredTiger=false
 
+# path to the ArangoDB executable (arangod, *not* arangodb) to use for the tests.
+# In the downloaded tarball it is at /usr/sbin/arangod.
+test.arango.exe=/path/to/arangoddbexecutable
+
+# path to the ArangoDB javascript startup directory to use for the tests.
+# This is the same path as provided to --javascript.startup-directory for the arangod executable.
+# In the downloaded tarball it is at /usr/share/arangodb3/js/.
+test.arango.js=/path/to/arangodjs
+
+
 # Temp directory for various database and server files. This path cannot have
 # any system specific information (e.g. ~, $HOME, etc)
 test.temp.dir = workspace_test_temp
@@ -41,8 +51,15 @@ test.temp.dir.keep=false
 # pwd
 
 # A python environment for the handle service can be created with https://github.com/pypa/pipenv
-# via the Pipfile in python dependencies.
+# via the Pipfile in python_dependencies.
 
 test.handleservice.dir=
 
+# Sample Service lib directory location
+# To set up, clone sample_service repo (https://github.com/kbase/sample_service)
+
+# A python environment for the sample service can be created with https://github.com/pypa/pipenv
+# via the Pipfile in python_dependencies.
+
+test.sampleservice.dir=
 


### PR DESCRIPTION
Updates the test config example file for sample service configuration items and the test configuration helper code to pull said items.