### PR TITLE
Allow assigning a port to the sample service

### DIFF
--- a/src/us/kbase/workspace/test/controllers/sample/SampleServiceController.java
+++ b/src/us/kbase/workspace/test/controllers/sample/SampleServiceController.java
@@ -94,6 +94,8 @@ public class SampleServiceController {
 	}
 
 	/** Create the sample service controller.
+	 * @param port the port on which the service should listen. Pass a number less than 1 to
+	 *  generate a random port number.
 	 * @param arango the ArangoDB controller where the sample service will store files.
 	 * @param sampleServiceDir the directory containing the sample service repo.
 	 * @param rootTempDir a temporary directory in which to store sample service data and log
@@ -109,6 +111,7 @@ public class SampleServiceController {
 	 * @throws Exception if an error occurs.
 	 */
 	public SampleServiceController(
+			final int port,
 			final ArangoController arango,
 			final Path sampleServiceDir,
 			final Path rootTempDir,
@@ -122,7 +125,11 @@ public class SampleServiceController {
 
 		tempDir = makeTempDirs(rootTempDir, "SampleServiceController-", new LinkedList<String>());
 
-		port = findFreePort();
+		if (port < 1) {
+			this.port = findFreePort();
+		} else {
+			this.port = port;
+		}
 		File ssIniFile = createSampleServiceDeployCfg(
 				arango,
 				authURL,

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
@@ -91,22 +91,22 @@ import com.google.common.collect.ImmutableMap;
  * tests all backends and {@link us.kbase.workspace.database.WorkspaceDatabase} implementations.
  */
 public class JSONRPCLayerTest extends JSONRPCLayerTester {
+	
+	private static final String VER = "0.11.2";
 
 	@Test
 	public void ver() throws Exception {
-		assertThat("got correct version", CLIENT_NO_AUTH.ver(), is("0.11.2"));
+		assertThat("got correct version", CLIENT_NO_AUTH.ver(), is(VER));
 	}
 
 	@Test
 	public void status() throws Exception {
 		final Map<String, Object> st = CLIENT1.status();
-		System.out.println(st);
 
 		//top level items
 		assertThat("incorrect state", st.get("state"), is((Object) "OK"));
 		assertThat("incorrect message", st.get("message"), is((Object) "OK"));
-		// should throw an error if not a valid semver
-		Version.valueOf((String) st.get("version"));
+		assertThat("incorrect version", st.get("version"), is(VER));
 		assertThat("incorrect git url", st.get("git_url"),
 				is((Object) "https://github.com/kbase/workspace_deluxe"));
 		checkMem(st.get("freemem"), "freemem");


### PR DESCRIPTION
The workspace has to start up before the sample service, but it needs to
know the sample service URL, so the port has to be determined before the
sample service controller starts.

Also includes some minor test cleanup.