### PR TITLE
Add sample service test rig and one simple test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 language: java
 jdk:
@@ -14,26 +14,35 @@ env:
 before_install:
   # apt update fails without this key
   - wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-  - sudo add-apt-repository -y ppa:deadsnakes/ppa
-  - sudo apt update -q
+
+  # install ant deps
   - sudo apt install -y ant-optional
-  - sudo apt install -y python3.6 python3-pip
-  - pyenv local 3.6
+
+  # install python deps
+  - pyenv versions
+  - export PYVER=$(pyenv versions | grep "3.7")
+  - echo $PYVER
+  - pyenv local $PYVER
   - python --version
-  - pip3 --version
-  - pip3 install sphinx
-  - pip3 install jsonrpcbase==0.2.0
-  - pip3 install configparser==4.0.2
-  - pip3 install pymongo==3.9.0
-  - pip3 install cachetools==3.1.1
-  - pip3 install uwsgi==2.0.18
+  - pip3 install pipenv
 
 install:
   - export HOMEDIR=`pwd`
+  
+  # set up jars
   - cd ..
   - git clone https://github.com/kbase/jars
   - export JARSDIR=`pwd`/jars/lib/jars/
 
+  # set up arango
+  - export ARANGODB_VER=3.5.1
+  - export ARANGODB_V=35
+  - curl -O https://download.arangodb.com/arangodb$ARANGODB_V/Community/Linux/arangodb3-linux-$ARANGODB_VER.tar.gz
+  - tar -xf arangodb3-linux-$ARANGODB_VER.tar.gz 
+  - export ARANGO_EXE=$(pwd)/arangodb3-$ARANGODB_VER/usr/sbin/arangod
+  - export ARANGO_JS=$(pwd)/arangodb3-$ARANGODB_VER/usr/share/arangodb3/js/
+
+  # set up handle service
   - export HS_COMMIT=aae2f70120e75d2ccccab1b1c01dbb9e8327eee8
   - export LOG_COMMIT=b549c557e3c519e0a55eadf7863a93db25cd6806
   - git clone https://github.com/kbase/handle_service2.git
@@ -46,7 +55,23 @@ install:
   - wget https://raw.githubusercontent.com/kbase/sdkbase2/$LOG_COMMIT/log.py
   - cd ..
   - export HSDIR=`pwd`
+  - cd ../..
+  
+  # set up sample service
+  - export SAMPLE_COMMIT=695bb800cb3babe2084e93c260affcd10018d3e7
+  - git clone https://github.com/kbase/sample_service.git
+  - cd sample_service
+  - git checkout $SAMPLE_COMMIT
+  - cd lib
+  - export SAMPLE_DIR=`pwd`
+  - cd ../..
+  
   - cd $HOMEDIR
+  
+  # install python dependencies
+  - cd python_dependencies
+  - pipenv install --dev
+  - cd ..
 
 script:
   # set up minio
@@ -74,11 +99,15 @@ script:
   - sed -i "s#^test.shock.version.*#test.shock.version=0.9.6#" test.cfg
   - sed -i "s#^test.shock.exe.*#test.shock.exe=$SHOCKEXE#" test.cfg
   - sed -i "s#^test.handleservice.dir.*#test.handleservice.dir=$HSDIR#" test.cfg
+  - sed -i "s#^test.sampleservice.dir.*#test.sampleservice.dir=$SAMPLE_DIR#" test.cfg
+  - sed -i "s#^test.arango.exe.*#test.arango.exe=$ARANGO_EXE#" test.cfg
+  - sed -i "s#^test.arango.js.*#test.arango.js=$ARANGO_JS#" test.cfg
   - cat test.cfg
  
   # run tests
   - ant javadoc
-  - ant $ANT_TEST
+  - export PIPENV_PIPFILE=$(pwd)/python_dependencies/Pipfile
+  - pipenv run ant $ANT_TEST
 
 after_success:
   - ls test-reports

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,10 @@ env:
   - MONGODB_VER=mongodb-linux-x86_64-3.6.10 MINIO=2019-05-23T00-29-34Z ANT_TEST=test_quick_coverage WIRED_TIGER=true
 
 before_install:
-  # apt update fails without this key
-  - wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-
   # install ant deps
   - sudo apt install -y ant-optional
 
-  # install python deps
+  # setup python environment
   - pyenv versions
   - export PYVER=$(pyenv versions | grep "3.7")
   - echo $PYVER

--- a/python_dependencies/Pipfile
+++ b/python_dependencies/Pipfile
@@ -14,7 +14,7 @@ requests = "==2.22.0"
 cachetools = "*"
 configparser = "*"
 pymongo = "*"
-uwsgi = "*"
+uwsgi = "==2.0.18"
 
 # sample service dependencies
 python-arango = "==5.0.0"

--- a/python_dependencies/Pipfile.lock
+++ b/python_dependencies/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f38520f3fa7036a11181ac86603a8bb8e1e461065cd36dd61c1dfe2bc30e6050"
+            "sha256": "e88684a252369270d5b76c14db6509cd98c1a066963446ca2758e062c1a5b8ba"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,10 +26,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:0ef97238856430dcf9228e07f316aefc17e8939fc8507e18c6501b761ef1a42a",
+                "sha256:2867b7b9f8326499ab5b0e2d12801fa5c98842d2cbd22b35112ae04bf85b4dff"
             ],
-            "version": "==19.3.0"
+            "version": "==20.1.0"
         },
         "cacheout": {
             "hashes": [
@@ -236,62 +236,62 @@
         },
         "pymongo": {
             "hashes": [
-                "sha256:01b4e10027aef5bb9ecefbc26f5df3368ce34aef81df43850f701e716e3fe16d",
-                "sha256:0fc5aa1b1acf7f61af46fe0414e6a4d0c234b339db4c03a63da48599acf1cbfc",
-                "sha256:1396eb7151e0558b1f817e4b9d7697d5599e5c40d839a9f7270bd90af994ad82",
-                "sha256:18e84a3ec5e73adcb4187b8e5541b2ad61d716026ed9863267e650300d8bea33",
-                "sha256:19adf2848b80cb349b9891cc854581bbf24c338be9a3260e73159bdeb2264464",
-                "sha256:20ee0475aa2ba437b0a14806f125d696f90a8433d820fb558fdd6f052acde103",
-                "sha256:26798795097bdeb571f13942beef7e0b60125397811c75b7aa9214d89880dd1d",
-                "sha256:26e707a4eb851ec27bb969b5f1413b9b2eac28fe34271fa72329100317ea7c73",
-                "sha256:2a3c7ad01553b27ec553688a1e6445e7f40355fb37d925c11fcb50b504e367f8",
-                "sha256:2f07b27dbf303ea53f4147a7922ce91a26b34a0011131471d8aaf73151fdee9a",
-                "sha256:316f0cf543013d0c085e15a2c8abe0db70f93c9722c0f99b6f3318ff69477d70",
-                "sha256:31d11a600eea0c60de22c8bdcb58cda63c762891facdcb74248c36713240987f",
-                "sha256:334ef3ffd0df87ea83a0054454336159f8ad9c1b389e19c0032d9cb8410660e6",
-                "sha256:358ba4693c01022d507b96a980ded855a32dbdccc3c9331d0667be5e967f30ed",
-                "sha256:3a6568bc53103df260f5c7d2da36dffc5202b9a36c85540bba1836a774943794",
-                "sha256:444bf2f44264578c4085bb04493bfed0e5c1b4fe7c2704504d769f955cc78fe4",
-                "sha256:47a00b22c52ee59dffc2aad02d0bbfb20c26ec5b8de8900492bf13ad6901cf35",
-                "sha256:4c067db43b331fc709080d441cb2e157114fec60749667d12186cc3fc8e7a951",
-                "sha256:4c092310f804a5d45a1bcaa4191d6d016c457b6ed3982a622c35f729ff1c7f6b",
-                "sha256:53b711b33134e292ef8499835a3df10909c58df53a2a0308f598c432e9a62892",
-                "sha256:568d6bee70652d8a5af1cd3eec48b4ca1696fb1773b80719ebbd2925b72cb8f6",
-                "sha256:56fa55032782b7f8e0bf6956420d11e2d4e9860598dfe9c504edec53af0fc372",
-                "sha256:5a2c492680c61b440272341294172fa3b3751797b1ab983533a770e4fb0a67ac",
-                "sha256:61235cc39b5b2f593086d1d38f3fc130b2d125bd8fc8621d35bc5b6bdeb92bd2",
-                "sha256:619ac9aaf681434b4d4718d1b31aa2f0fce64f2b3f8435688fcbdc0c818b6c54",
-                "sha256:6238ac1f483494011abde5286282afdfacd8926659e222ba9b74c67008d3a58c",
-                "sha256:63752a72ca4d4e1386278bd43d14232f51718b409e7ac86bcf8810826b531113",
-                "sha256:6fdc5ccb43864065d40dd838437952e9e3da9821b7eac605ba46ada77f846bdf",
-                "sha256:7abc3a6825a346fa4621a6f63e3b662bbb9e0f6ffc32d30a459d695f20fb1a8b",
-                "sha256:7aef381bb9ae8a3821abd7f9d4d93978dbd99072b48522e181baeffcd95b56ae",
-                "sha256:80df3caf251fe61a3f0c9614adc6e2bfcffd1cd3345280896766712fb4b4d6d7",
-                "sha256:95f970f34b59987dee6f360d2e7d30e181d58957b85dff929eee4423739bd151",
-                "sha256:993257f6ca3cde55332af1f62af3e04ca89ce63c08b56a387cdd46136c72f2fa",
-                "sha256:9c0a57390549affc2b5dda24a38de03a5c7cbc58750cd161ff5d106c3c6eec80",
-                "sha256:a0794e987d55d2f719cc95fcf980fc62d12b80e287e6a761c4be14c60bd9fecc",
-                "sha256:a3b98121e68bf370dd8ea09df67e916f93ea95b52fc010902312168c4d1aff5d",
-                "sha256:a60756d55f0887023b3899e6c2923ba5f0042fb11b1d17810b4e07395404f33e",
-                "sha256:a676bd2fbc2309092b9bbb0083d35718b5420af3a42135ebb1e4c3633f56604d",
-                "sha256:a732838c78554c1257ff2492f5c8c4c7312d0aecd7f732149e255f3749edd5ee",
-                "sha256:ae65d65fde4135ef423a2608587c9ef585a3551fc2e4e431e7c7e527047581be",
-                "sha256:b070a4f064a9edb70f921bfdc270725cff7a78c22036dd37a767c51393fb956f",
-                "sha256:b6da85949aa91e9f8c521681344bd2e163de894a5492337fba8b05c409225a4f",
-                "sha256:bbf47110765b2a999803a7de457567389253f8670f7daafb98e059c899ce9764",
-                "sha256:c06b3f998d2d7160db58db69adfb807d2ec307e883e2f17f6b87a1ef6c723f11",
-                "sha256:c318fb70542be16d3d4063cde6010b1e4d328993a793529c15a619251f517c39",
-                "sha256:c4aef42e5fa4c9d5a99f751fb79caa880dac7eaf8a65121549318b984676a1b7",
-                "sha256:c9ca545e93a9c2a3bdaa2e6e21f7a43267ff0813e8055adf2b591c13164c0c57",
-                "sha256:da2c3220eb55c4239dd8b982e213da0b79023cac59fe54ca09365f2bc7e4ad32",
-                "sha256:dd8055da300535eefd446b30995c0813cc4394873c9509323762a93e97c04c03",
-                "sha256:e2b46e092ea54b732d98c476720386ff2ccd126de1e52076b470b117bff7e409",
-                "sha256:e334c4f39a2863a239d38b5829e442a87f241a92da9941861ee6ec5d6380b7fe",
-                "sha256:e5c54f04ca42bbb5153aec5d4f2e3d9f81e316945220ac318abd4083308143f5",
-                "sha256:f96333f9d2517c752c20a35ff95de5fc2763ac8cdb1653df0f6f45d281620606"
+                "sha256:03dc64a9aa7a5d405aea5c56db95835f6a2fa31b3502c5af1760e0e99210be30",
+                "sha256:05fcc6f9c60e6efe5219fbb5a30258adb3d3e5cbd317068f3d73c09727f2abb6",
+                "sha256:076a7f2f7c251635cf6116ac8e45eefac77758ee5a77ab7bd2f63999e957613b",
+                "sha256:137e6fa718c7eff270dbd2fc4b90d94b1a69c9e9eb3f3de9e850a7fd33c822dc",
+                "sha256:1f865b1d1c191d785106f54df9abdc7d2f45a946b45fd1ea0a641b4f982a2a77",
+                "sha256:213c445fe7e654621c6309e874627c35354b46ef3ee807f5a1927dc4b30e1a67",
+                "sha256:25e617daf47d8dfd4e152c880cd0741cbdb48e51f54b8de9ddbfe74ecd87dd16",
+                "sha256:3d9bb1ba935a90ec4809a8031efd988bdb13cdba05d9e9a3e9bf151bf759ecde",
+                "sha256:40696a9a53faa7d85aaa6fd7bef1cae08f7882640bad08c350fb59dee7ad069b",
+                "sha256:421aa1b92c291c429668bd8d8d8ec2bd00f183483a756928e3afbf2b6f941f00",
+                "sha256:4437300eb3a5e9cc1a73b07d22c77302f872f339caca97e9bf8cf45eca8fa0d2",
+                "sha256:455f4deb00158d5ec8b1d3092df6abb681b225774ab8a59b3510293b4c8530e3",
+                "sha256:475a34a0745c456ceffaec4ce86b7e0983478f1b6140890dff7b161e7bcd895b",
+                "sha256:4797c0080f41eba90404335e5ded3aa66731d303293a675ff097ce4ea3025bb9",
+                "sha256:4ae23fbbe9eadf61279a26eba866bbf161a6f7e2ffad14a42cf20e9cb8e94166",
+                "sha256:4b32744901ee9990aa8cd488ec85634f443526def1e5190a407dc107148249d7",
+                "sha256:50127b13b38e8e586d5e97d342689405edbd74ad0bd891d97ee126a8c7b6e45f",
+                "sha256:50531caa7b4be1c4ed5e2d5793a4e51cc9bd62a919a6fd3299ef7c902e206eab",
+                "sha256:68220b81850de8e966d4667d5c325a96c6ac0d6adb3d18935d6e3d325d441f48",
+                "sha256:689142dc0c150e9cb7c012d84cac2c346d40beb891323afb6caf18ec4caafae0",
+                "sha256:6a15e2bee5c4188369a87ed6f02de804651152634a46cca91966a11c8abd2550",
+                "sha256:7122ffe597b531fb065d3314e704a6fe152b81820ca5f38543e70ffcc95ecfd4",
+                "sha256:7307024b18266b302f4265da84bb1effb5d18999ef35b30d17592959568d5c0a",
+                "sha256:7a4a6f5b818988a3917ec4baa91d1143242bdfece8d38305020463955961266a",
+                "sha256:83c5a3ecd96a9f3f11cfe6dfcbcec7323265340eb24cc996acaecea129865a3a",
+                "sha256:890b0f1e18dbd898aeb0ab9eae1ab159c6bcbe87f0abb065b0044581d8614062",
+                "sha256:8deda1f7b4c03242f2a8037706d9584e703f3d8c74d6d9cac5833db36fe16c42",
+                "sha256:8ea13d0348b4c96b437d944d7068d59ed4a6c98aaa6c40d8537a2981313f1c66",
+                "sha256:91e96bf85b7c07c827d339a386e8a3cf2e90ef098c42595227f729922d0851df",
+                "sha256:96782ebb3c9e91e174c333208b272ea144ed2a684413afb1038e3b3342230d72",
+                "sha256:9755c726aa6788f076114dfdc03b92b03ff8860316cca00902cce88bcdb5fedd",
+                "sha256:9dbab90c348c512e03f146e93a5e2610acec76df391043ecd46b6b775d5397e6",
+                "sha256:9ee0eef254e340cc11c379f797af3977992a7f2c176f1a658740c94bf677e13c",
+                "sha256:9fc17fdac8f1973850d42e51e8ba6149d93b1993ed6768a24f352f926dd3d587",
+                "sha256:a2787319dc69854acdfd6452e6a8ba8f929aeb20843c7f090e04159fc18e6245",
+                "sha256:b7c522292407fa04d8195032493aac937e253ad9ae524aab43b9d9d242571f03",
+                "sha256:bd312794f51e37dcf77f013d40650fe4fbb211dd55ef2863839c37480bd44369",
+                "sha256:c0d660a186e36c526366edf8a64391874fe53cf8b7039224137aee0163c046df",
+                "sha256:c4869141e20769b65d2d72686e7a7eb141ce9f3168106bed3e7dcced54eb2422",
+                "sha256:cc4057f692ac35bbe82a0a908d42ce3a281c9e913290fac37d7fa3bd01307dfb",
+                "sha256:cccf1e7806f12300e3a3b48f219e111000c2538483e85c869c35c1ae591e6ce9",
+                "sha256:ce208f80f398522e49d9db789065c8ad2cd37b21bd6b23d30053474b7416af11",
+                "sha256:d0565481dc196986c484a7fb13214fc6402201f7fb55c65fd215b3324962fe6c",
+                "sha256:d1b3366329c45a474b3bbc9b9c95d4c686e03f35da7fd12bc144626d1f2a7c04",
+                "sha256:d226e0d4b9192d95079a9a29c04dd81816b1ce8903b8c174a39224fe978547cb",
+                "sha256:d38b35f6eef4237b1d0d8e845fc1546dad85c55eba447e28c211da8c7ef9697c",
+                "sha256:d64c98277ea80e4484f1332ab107e8dfd173a7dcf1bdbf10a9cccc97aaab145f",
+                "sha256:d9de8427a5601799784eb0e7fa1b031aa64086ce04de29df775a8ca37eedac41",
+                "sha256:e6a15cf8f887d9f578dd49c6fb3a99d53e1d922fdd67a245a67488d77bf56eb2",
+                "sha256:e8c446882cbb3774cd78c738c9f58220606b702b7c1655f1423357dc51674054",
+                "sha256:e8d188ee39bd0ffe76603da887706e4e7b471f613625899ddf1e27867dc6a0d3",
+                "sha256:ef76535776c0708a85258f6dc51d36a2df12633c735f6d197ed7dfcaa7449b99",
+                "sha256:f6efca006a81e1197b925a7d7b16b8f61980697bb6746587aad8842865233218"
             ],
             "index": "pypi",
-            "version": "==3.10.1"
+            "version": "==3.11.0"
         },
         "pyrsistent": {
             "hashes": [
@@ -369,10 +369,10 @@
         },
         "uwsgi": {
             "hashes": [
-                "sha256:faa85e053c0b1be4d5585b0858d3a511d2cd10201802e8676060fd0a109e5869"
+                "sha256:4972ac538800fb2d421027f49b4a1869b66048839507ccf0aa2fda792d99f583"
             ],
             "index": "pypi",
-            "version": "==2.0.19.1"
+            "version": "==2.0.18"
         },
         "zipp": {
             "hashes": [

--- a/src/us/kbase/workspace/test/database/mongo/S3BlobStoreIntegrationTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/S3BlobStoreIntegrationTest.java
@@ -85,7 +85,7 @@ public class S3BlobStoreIntegrationTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		if (minio != null) {
-			minio.destroy(TestCommon.getDeleteTempFiles());
+			minio.destroy(TestCommon.getDeleteTempFiles(), true);
 		}
 		if (mongoCon != null) {
 			mongoCon.destroy(TestCommon.getDeleteTempFiles());

--- a/src/us/kbase/workspace/test/database/mongo/S3BlobStoreIntegrationTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/S3BlobStoreIntegrationTest.java
@@ -85,7 +85,7 @@ public class S3BlobStoreIntegrationTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		if (minio != null) {
-			minio.destroy(TestCommon.getDeleteTempFiles(), true);
+			minio.destroy(TestCommon.getDeleteTempFiles());
 		}
 		if (mongoCon != null) {
 			mongoCon.destroy(TestCommon.getDeleteTempFiles());

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
@@ -1129,7 +1129,7 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 		assertNull("Got object info when expected null", nullobj.get(6));
 	}
 
-	// TODO TEST should also test that getting objects with handles fail, but that's a pain to set up
+	// TODO TEST should test that getting objects with handles fail, but that's a pain to set up
 	@Test
 	public void saveObjectsFailNoHandleProcessor() throws Exception {
 		CLIENT1.createWorkspace(new CreateWorkspaceParams()
@@ -1143,6 +1143,7 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 						"objects containing handle IDs. at /h", 1, "n"));
 	}
 
+	// TODO TEST should test that getting objects with bs ids fail, but that's a pain to set up
 	@Test
 	public void saveObjectsFailNoShockProcessor() throws Exception {
 		CLIENT1.createWorkspace(new CreateWorkspaceParams()
@@ -1157,6 +1158,24 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 						"for bytestream IDs and so objects containing bytestream IDs cannot be " +
 						"processed. at /s", id, id), 1, "n"));
 	}
+	
+	// TODO TEST should test that getting objects with samples fail, but that's a pain to set up
+	@Test
+	public void saveObjectsFailNoSampleProcessor() throws Exception {
+		CLIENT1.createWorkspace(new CreateWorkspaceParams()
+				.withWorkspace("nosample")).getE1();
+
+		// these error messages could be cleaned up a bit. They're caused by multiple layers
+		// of code handling the lower layer's errors.
+		// However, these errors should basically never happen in practice so meh.
+		saveObject2MethodsFail(CLIENT1, "nosample", "foo", "Sample.SampleID",
+				new UObject(ImmutableMap.of("s", "UUID_goes_here")), new ServerException(
+						"Object #1, foo failed type checking:\nInvalid id UUID_goes_here of " +
+						"type sample: Found sample id UUID_goes_here. The workspace service " +
+						"currently does not have a connection to the sample service and so " +
+						"cannot process objects containing sample IDs. at /s", 1, "n"));
+	}
+
 
 	private void saveObject2MethodsFail(
 			final WorkspaceClient cli,

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
@@ -361,6 +361,22 @@ public class JSONRPCLayerTester {
 			.withSpec(handleShock)
 			.withNewTypes(Arrays.asList("ExtIDs")));
 		CLIENT1.releaseModule("HandleByteStream");
+		
+		final String sample =
+				"module Sample {" +
+					"/* @id sample */" +
+					"typedef string sample;" +
+					"typedef structure {" +
+						"sample s;" +
+					"} SampleID;" +
+				"};";
+		CLIENT1.requestModuleOwnership("Sample");
+		administerCommand(CLIENT2, "approveModRequest", "module", "Sample");
+		CLIENT1.registerTypespec(new RegisterTypespecParams()
+			.withDryrun(0L)
+			.withSpec(sample)
+			.withNewTypes(Arrays.asList("SampleID")));
+		CLIENT1.releaseModule("Sample");
 	}
 
 	public static void administerCommand(WorkspaceClient client, String command, String... params) throws IOException,

--- a/src/us/kbase/workspace/test/kbase/SampleServiceIntegrationTest.java
+++ b/src/us/kbase/workspace/test/kbase/SampleServiceIntegrationTest.java
@@ -264,7 +264,7 @@ public class SampleServiceIntegrationTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		if (SAMPLE != null) {
-			SAMPLE.destroy(TestCommon.getDeleteTempFiles());
+			SAMPLE.destroy(TestCommon.getDeleteTempFiles(), true);
 		}
 		if (SERVER != null) {
 			System.out.print("Killing workspace server... ");

--- a/src/us/kbase/workspace/test/kbase/SampleServiceIntegrationTest.java
+++ b/src/us/kbase/workspace/test/kbase/SampleServiceIntegrationTest.java
@@ -1,0 +1,316 @@
+package us.kbase.workspace.test.kbase;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static us.kbase.common.test.controllers.ControllerCommon.findFreePort;
+import static us.kbase.workspace.test.kbase.JSONRPCLayerTester.administerCommand;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.ini4j.Ini;
+import org.ini4j.Profile.Section;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.arangodb.ArangoDatabase;
+import com.arangodb.entity.CollectionType;
+import com.arangodb.model.CollectionCreateOptions;
+import com.github.zafarkhaja.semver.Version;
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.auth.AuthToken;
+import us.kbase.common.test.TestCommon;
+import us.kbase.common.test.controllers.mongo.MongoController;
+import us.kbase.sampleservice.SampleServiceClient;
+import us.kbase.test.auth2.authcontroller.AuthController;
+import us.kbase.workspace.RegisterTypespecParams;
+import us.kbase.workspace.WorkspaceClient;
+import us.kbase.workspace.WorkspaceServer;
+import us.kbase.workspace.test.controllers.arango.ArangoController;
+import us.kbase.workspace.test.controllers.sample.SampleServiceController;
+import us.kbase.workspace.test.kbase.JSONRPCLayerTester.ServerThread;
+
+public class SampleServiceIntegrationTest {
+
+	private static ArangoController ARANGO;
+	private static MongoController MONGO;
+	private static SampleServiceController SAMPLE;
+	private static AuthController AUTH;
+	private static WorkspaceServer SERVER;
+	
+	private static final String USER1 = "user1";
+	private static final String USER2 = "user2";
+	private static final String USER3 = "user3";
+	private static final String SAMPLE_SERVICE_FULL_ADMIN_ROLE = "SamServFull";
+	
+	private static AuthToken SAMPLE_SERVICE_ADMIN_TOKEN = null;
+
+	private static WorkspaceClient CLIENT1;
+	private static WorkspaceClient CLIENT2;
+	private static WorkspaceClient CLIENT3;
+	private static WorkspaceClient CLIENT_NOAUTH;
+	
+	private static SampleServiceClient SAMPLE_CLIENT;
+	
+	private static final String ARANGO_DB = "ws_sample_service_integration_test";
+	private static final String ARANGO_USER = "arangouser";
+	private static final String ARANGO_PWD = "arangopwd";
+	private static final String ARANGO_COL_SAMPLE = "sampleCol";
+	private static final String ARANGO_COL_VER = "verCol";
+	private static final String ARANGO_COL_VER_EDGE = "verEdgeCol";
+	private static final String ARANGO_COL_NODE = "nodeCol";
+	private static final String ARANGO_COL_NODE_EDGE = "nodeEdgeCol";
+	private static final String ARANGO_COL_DATA_LINK = "dataLinkCol";
+	private static final String ARANGO_COL_WS_OBJ = "wsObjCol";
+	private static final String ARANGO_COL_SCHEMA = "schemaCol";
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		TestCommon.stfuLoggers();
+
+		MONGO = new MongoController(
+				TestCommon.getMongoExe(),
+				Paths.get(TestCommon.getTempDir()),
+				TestCommon.useWiredTigerEngine());
+		System.out.println("Using Mongo temp dir " + MONGO.getTempDir());
+		final String mongohost = "localhost:" + MONGO.getServerPort();
+
+		ARANGO = new ArangoController(
+				TestCommon.getArangoExe(),
+				TestCommon.getArangoJS(),
+				Paths.get(TestCommon.getTempDir()));
+		
+		// set up auth
+		final String dbname = SampleServiceIntegrationTest.class.getSimpleName() + "Auth";
+		AUTH = new AuthController(
+				TestCommon.getJarsDir(),
+				"localhost:" + MONGO.getServerPort(),
+				dbname,
+				Paths.get(TestCommon.getTempDir()));
+		final URL authURL = new URL("http://localhost:" + AUTH.getServerPort() + "/testmode");
+		System.out.println("started auth server at " + authURL);
+
+		TestCommon.createAuthUser(authURL, USER1, "display1");
+		final String token1 = TestCommon.createLoginToken(authURL, USER1);
+		TestCommon.createAuthUser(authURL, USER2, "display2");
+		final String token2 = TestCommon.createLoginToken(authURL, USER2);
+		TestCommon.createAuthUser(authURL, USER3, "display3");
+		final String token3 = TestCommon.createLoginToken(authURL, USER3);
+		TestCommon.createCustomRole(authURL, SAMPLE_SERVICE_FULL_ADMIN_ROLE, "sample admin role");
+		TestCommon.setUserRoles(authURL, USER3, Arrays.asList(SAMPLE_SERVICE_FULL_ADMIN_ROLE));
+		final AuthToken t1 = new AuthToken(token1, USER1);
+		final AuthToken t2 = new AuthToken(token2, USER2);
+		SAMPLE_SERVICE_ADMIN_TOKEN = new AuthToken(token3, USER3);
+		
+		// this is pretty wacky and demonstrates the tight binding between the sample
+		// service and the workspace.
+		final int sampleServicePort = findFreePort();
+
+		SERVER = startupWorkspaceServer(mongohost,
+				SampleServiceIntegrationTest.class.getSimpleName(),
+				SampleServiceIntegrationTest.class.getSimpleName() + "_types",
+				new URL("http://localhost:" + sampleServicePort),
+				SAMPLE_SERVICE_ADMIN_TOKEN
+				);
+
+		int port = SERVER.getServerPort();
+		System.out.println("Started test workspace server on port " + port);
+
+		final URL url = new URL("http://localhost:" + port);
+		CLIENT1 = new WorkspaceClient(url, t1);
+		CLIENT2 = new WorkspaceClient(url, t2);
+		CLIENT3 = new WorkspaceClient(url, SAMPLE_SERVICE_ADMIN_TOKEN);
+		CLIENT_NOAUTH = new WorkspaceClient(url);
+		CLIENT1.setIsInsecureHttpConnectionAllowed(true);
+		CLIENT2.setIsInsecureHttpConnectionAllowed(true);
+		CLIENT3.setIsInsecureHttpConnectionAllowed(true);
+		CLIENT_NOAUTH.setIsInsecureHttpConnectionAllowed(true);
+
+		setUpSpecs();
+		
+		setUpSampleDB();
+		SAMPLE = new SampleServiceController(
+				sampleServicePort,
+				ARANGO,
+				TestCommon.getSampleServiceDir(),
+				Paths.get(TestCommon.getTempDir()),
+				authURL,
+				token2,
+				SAMPLE_SERVICE_FULL_ADMIN_ROLE,
+				new URL("http://localhost:" + port),
+				token2, // we won't be doing any calls that require ws auth
+				new SampleServiceController.SampleServiceArangoParameters(
+						ARANGO_USER,
+						ARANGO_PWD,
+						ARANGO_DB,
+						ARANGO_COL_SAMPLE,
+						ARANGO_COL_VER,
+						ARANGO_COL_VER_EDGE,
+						ARANGO_COL_NODE,
+						ARANGO_COL_NODE_EDGE,
+						ARANGO_COL_DATA_LINK,
+						ARANGO_COL_WS_OBJ,
+						ARANGO_COL_SCHEMA)
+				);
+		
+		SAMPLE_CLIENT = new SampleServiceClient(
+				new URL("http://localhost:" + SAMPLE.getPort()), t1);
+		SAMPLE_CLIENT.setIsInsecureHttpConnectionAllowed(true);
+		System.out.println(String.format("Running sample service v %s at http://localhost:%s",
+				SAMPLE_CLIENT.status().get("version"), SAMPLE.getPort()));
+	}
+	
+	private static void setUpSampleDB() throws Exception {
+		ARANGO.getClient().createUser(ARANGO_USER, ARANGO_PWD);
+		ARANGO.getClient().createDatabase(ARANGO_DB);
+		final ArangoDatabase db = ARANGO.getClient().db(ARANGO_DB);
+
+		db.grantAccess(ARANGO_USER);
+		
+		final CollectionCreateOptions edge = new CollectionCreateOptions()
+				.type(CollectionType.EDGES);
+		db.createCollection(ARANGO_COL_SAMPLE);
+		db.createCollection(ARANGO_COL_VER);
+		db.createCollection(ARANGO_COL_VER_EDGE, edge);
+		db.createCollection(ARANGO_COL_NODE);
+		db.createCollection(ARANGO_COL_NODE_EDGE, edge);
+		db.createCollection(ARANGO_COL_DATA_LINK, edge);
+		db.createCollection(ARANGO_COL_WS_OBJ);
+		db.createCollection(ARANGO_COL_SCHEMA);
+	}
+
+	private static void setUpSpecs() throws Exception {
+		final String handlespec =
+				"module Samples {" +
+					"/* @id sample */" +
+					"typedef string sample;" +
+					"typedef structure {" +
+						"list<sample> samples;" +
+					"} SList;" +
+					"/* @id ws */" +
+					"typedef string wsid;" +
+					"typedef structure {" +
+						"wsid id;" +
+					"} SRef;" +
+				"};";
+		CLIENT1.requestModuleOwnership("Samples");
+		administerCommand(CLIENT2, "approveModRequest", "module", "Samples");
+		CLIENT1.registerTypespec(new RegisterTypespecParams()
+			.withDryrun(0L)
+			.withSpec(handlespec)
+			.withNewTypes(Arrays.asList("SList", "SRef")));
+	}
+
+	private static WorkspaceServer startupWorkspaceServer(
+			final String mongohost,
+			final String db,
+			final String typedb,
+			final URL sampleServiceURL,
+			final AuthToken sampleServiceToken)
+			throws Exception {
+
+		//write the server config file:
+		File iniFile = File.createTempFile("test", ".cfg",
+				new File(TestCommon.getTempDir()));
+		if (iniFile.exists()) {
+			iniFile.delete();
+		}
+		System.out.println("Created temporary config file: " + iniFile.getAbsolutePath());
+		Ini ini = new Ini();
+		Section ws = ini.add("Workspace");
+		ws.add("mongodb-host", mongohost);
+		ws.add("mongodb-database", db);
+		ws.add("mongodb-type-database", typedb);
+		ws.add("backend-secret", "foo");
+		ws.add("auth-service-url-allow-insecure", "true");
+		ws.add("auth-service-url", "http://localhost:" + AUTH.getServerPort() +
+				"/testmode/api/legacy/KBase");
+		ws.add("auth2-service-url", "http://localhost:" + AUTH.getServerPort() + "/testmode/");
+		ws.add("backend-type", "GridFS");
+		ws.add("ws-admin", USER2);
+		ws.add("ignore-handle-service", "true");
+		ws.add("sample-service-url", sampleServiceURL.toString());
+		ws.add("sample-service-administrator-token", sampleServiceToken.getToken());
+		ws.add("temp-dir", Paths.get(TestCommon.getTempDir())
+				.resolve("tempFor" + SampleServiceIntegrationTest.class.getSimpleName()));
+		ini.store(iniFile);
+		iniFile.deleteOnExit();
+
+		//set up env
+		Map<String, String> env = TestCommon.getenv();
+		env.put("KB_DEPLOYMENT_CONFIG", iniFile.getAbsolutePath());
+		env.put("KB_SERVICE_NAME", "Workspace");
+
+		WorkspaceServer.clearConfigForTests();
+		WorkspaceServer server = new WorkspaceServer();
+		new ServerThread(server).start();
+		System.out.println("Main thread waiting for server to start up");
+		while (server.getServerPort() == null) {
+			Thread.sleep(1000);
+		}
+		return server;
+	}
+
+	//TODO TEST should clear DBs between tests
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		if (SAMPLE != null) {
+			SAMPLE.destroy(TestCommon.getDeleteTempFiles());
+		}
+		if (SERVER != null) {
+			System.out.print("Killing workspace server... ");
+			SERVER.stopServer();
+			System.out.println("Done");
+		}
+		if (AUTH != null) {
+			AUTH.destroy(TestCommon.getDeleteTempFiles());
+		}
+		if (ARANGO != null) {
+			ARANGO.destroy(TestCommon.getDeleteTempFiles());
+		}
+		if (MONGO != null) {
+			MONGO.destroy(TestCommon.getDeleteTempFiles());
+		}
+	}
+	
+	@Test
+	public void status() throws Exception {
+		// only test the parts of the status that are relevant for the sample service
+		final Map<String, Object> status = CLIENT1.status();
+		
+//		System.out.println(status);
+		
+		assertThat("incorrect status keys", status.keySet(), is(new HashSet<>(Arrays.asList(
+				"state", "message", "dependencies", "version", "git_url", "freemem", "totalmem",
+				"maxmem"))));
+		
+		assertThat("incorrect state", status.get("state"), is("OK"));
+
+		@SuppressWarnings("unchecked")
+		final List<Map<String, String>> deps =
+				(List<Map<String, String>>) status.get("dependencies");
+		assertThat("incorrect dependency count", deps.size(), is(3));
+		
+		assertThat("incorrect dep 1", deps.get(0).get("name"), is("MongoDB"));
+		assertThat("incorrect dep 2", deps.get(1).get("name"), is("GridFS"));
+		
+		final Map<String, String> sample = deps.get(2);
+		Version.valueOf((String) sample.get("version")); // tests it's a valid semver
+		sample.remove("version");
+		
+		assertThat("incorrect sample dep", sample, is(ImmutableMap.of(
+				"name", "Sample service", "state", "OK", "message", "OK")));
+		
+		
+	}
+	
+}

--- a/src/us/kbase/workspace/test/kbase/SampleServiceIntegrationTest.java
+++ b/src/us/kbase/workspace/test/kbase/SampleServiceIntegrationTest.java
@@ -264,7 +264,7 @@ public class SampleServiceIntegrationTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		if (SAMPLE != null) {
-			SAMPLE.destroy(TestCommon.getDeleteTempFiles(), true);
+			SAMPLE.destroy(TestCommon.getDeleteTempFiles());
 		}
 		if (SERVER != null) {
 			System.out.print("Killing workspace server... ");


### PR DESCRIPTION
Next PRs will fill out the tests. However, all the code changes that can be covered without bringing up dependent servers in  various states of usability are currently covered. Uncovered code is tested manually as it is not expected to change often.

Notes:

* focal caused the minio-related tests to fail. Not clear why this is.
* trying to install and use a python version that doesn't pre-exist in travis is a nightmare.
* trusty doesn't include python3.7 but xenial does. Bionic may work as well. Focal does not for the reason above.
* uwsgi 2.0.19 seemed to have build problems, so pinned to 2.0.18.
* Python's SSL module is broken on Trusty: deadsnakes/issues#63 . This prevented get-pip.py from working.

Everything that was tried to get Travis to finally work is preserved here: https://github.com/MrCreosote/workspace_deluxe/tree/python-travis-hell
This PR contains the final state of that branch.