### PR TITLE
Add dependency checking code to the ID handlers

### DIFF
--- a/src/us/kbase/typedobj/idref/IdReferenceHandlerSetFactory.java
+++ b/src/us/kbase/typedobj/idref/IdReferenceHandlerSetFactory.java
@@ -1,12 +1,14 @@
 package us.kbase.typedobj.idref;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import us.kbase.auth.AuthToken;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandler;
 import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
+import us.kbase.workspace.database.DependencyStatus;
 
 /** Builds a set of ID handlers for handling IDs found while validating a
  * typed object. The handler could, for example, check the ID format, check
@@ -63,6 +65,12 @@ public class IdReferenceHandlerSetFactory {
 		 * @return the ID type.
 		 */
 		public IdReferenceType getIDType();
+		
+		/** Get the status of any dependencies on which this factory relies.
+		 * @return the dependency statuses or an empty list if the factory has no dependencies or
+		 *  is inactive.
+		 */
+		public List<DependencyStatus> getDependencyStatus();
 	}
 	
 	/** Create a handler set factory.

--- a/src/us/kbase/typedobj/test/DummyIdHandlerFactory.java
+++ b/src/us/kbase/typedobj/test/DummyIdHandlerFactory.java
@@ -17,6 +17,7 @@ import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermis
 import us.kbase.typedobj.idref.DefaultRemappedId;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
+import us.kbase.workspace.database.DependencyStatus;
 
 public class DummyIdHandlerFactory implements IdReferenceHandlerFactory {
 
@@ -127,6 +128,11 @@ public class DummyIdHandlerFactory implements IdReferenceHandlerFactory {
 	@Override
 	public IdReferencePermissionHandler createPermissionHandler(String userName) {
 		return null;
+	}
+
+	@Override
+	public List<DependencyStatus> getDependencyStatus() {
+		throw new UnimplementedException();
 	}
 
 }

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -704,7 +704,7 @@ public class Workspace {
 		int objcount = 1;
 		for (WorkspaceSaveObject wo: objects) {
 			//maintain ordering
-			wo.getProvenance().setWorkspaceID(new Long(rwsi.getID()));
+			wo.getProvenance().setWorkspaceID(Long.valueOf(rwsi.getID()));
 			final List<Reference> provrefs = new LinkedList<Reference>();
 			for (final Provenance.ProvenanceAction action: wo.getProvenance().getActions()) {
 				for (final String ref: action.getWorkspaceObjects()) {
@@ -1720,6 +1720,12 @@ public class Workspace {
 		@Override
 		public IdReferenceType getIDType() {
 			return WS_ID_TYPE;
+		}
+		
+		@Override
+		public List<DependencyStatus> getDependencyStatus() {
+			// unused
+			return null;
 		}
 
 		@Override

--- a/src/us/kbase/workspace/kbase/HandleIdHandlerFactory.java
+++ b/src/us/kbase/workspace/kbase/HandleIdHandlerFactory.java
@@ -3,7 +3,9 @@ package us.kbase.workspace.kbase;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -27,6 +29,7 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandler;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFactory;
 import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
 import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandlerException;
+import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.typedobj.idref.RemappedId;
 
 /**
@@ -69,6 +72,21 @@ public class HandleIdHandlerFactory implements IdReferenceHandlerFactory {
 	@Override
 	public IdReferenceType getIDType() {
 		return TYPE;
+	}
+	
+	@Override
+	public List<DependencyStatus> getDependencyStatus() {
+		if (client == null) {
+			return Collections.emptyList();
+		}
+		try {
+			final String ver = (String) client.status().get("version");
+			// no need to check return value, always returns OK or fails
+			return Arrays.asList(new DependencyStatus(true, "OK", "Handle service", ver));
+		} catch (IOException | JsonClientException e) {
+			return Arrays.asList(
+					new DependencyStatus(false, e.getMessage(), "Handle service", "Unknown"));
+		}
 	}
 	
 	private class HandlePermissionsHandler implements IdReferencePermissionHandler {

--- a/src/us/kbase/workspace/kbase/SampleIdHandlerFactory.java
+++ b/src/us/kbase/workspace/kbase/SampleIdHandlerFactory.java
@@ -29,6 +29,7 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandler;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFactory;
 import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
 import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandlerException;
+import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.typedobj.idref.RemappedId;
 
 /**
@@ -69,6 +70,21 @@ public class SampleIdHandlerFactory implements IdReferenceHandlerFactory {
 	@Override
 	public IdReferenceType getIDType() {
 		return TYPE;
+	}
+	
+	@Override
+	public List<DependencyStatus> getDependencyStatus() {
+		if (client == null) {
+			return Collections.emptyList();
+		}
+		try {
+			final String ver = (String) client.status().get("version");
+			// no need to check return value, always returns OK or fails
+			return Arrays.asList(new DependencyStatus(true, "OK", "Sample service", ver));
+		} catch (IOException | JsonClientException e) {
+			return Arrays.asList(
+					new DependencyStatus(false, e.getMessage(), "Sample service", "Unknown"));
+		}
 	}
 	
 	private class SamplePermissionsHandler implements IdReferencePermissionHandler {

--- a/src/us/kbase/workspace/kbase/ShockIdHandlerFactory.java
+++ b/src/us/kbase/workspace/kbase/ShockIdHandlerFactory.java
@@ -29,6 +29,7 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandlerException
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.NoSuchIdException;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.SimpleRemappedId;
+import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandler;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFactory;
 import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
@@ -102,6 +103,20 @@ public class ShockIdHandlerFactory implements IdReferenceHandlerFactory {
 	@Override
 	public IdReferenceType getIDType() {
 		return TYPE;
+	}
+	
+	@Override
+	public List<DependencyStatus> getDependencyStatus() {
+		if (adminClient == null) {
+			return Collections.emptyList();
+		}
+		try {
+			return Arrays.asList(new DependencyStatus(true, "OK", "Linked Shock for IDs",
+					adminClient.getRemoteVersion()));
+		} catch (InvalidShockUrlException | IOException e) {
+			return Arrays.asList(new DependencyStatus(
+					false, e.getMessage(), "Linked Shock for IDs", "Unknown"));
+		}
 	}
 	
 	private class ShockPermissionsHandler implements IdReferencePermissionHandler {

--- a/src/us/kbase/workspace/test/kbase/SampleServiceIntegrationTest.java
+++ b/src/us/kbase/workspace/test/kbase/SampleServiceIntegrationTest.java
@@ -309,8 +309,8 @@ public class SampleServiceIntegrationTest {
 		
 		assertThat("incorrect sample dep", sample, is(ImmutableMap.of(
 				"name", "Sample service", "state", "OK", "message", "OK")));
-		
-		
 	}
+	
+	// TODO NOW finish sample integration tests
 	
 }

--- a/src/us/kbase/workspace/test/workspace/TestIDReferenceHandlerFactory.java
+++ b/src/us/kbase/workspace/test/workspace/TestIDReferenceHandlerFactory.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 
 import us.kbase.auth.AuthToken;
+import us.kbase.common.exceptions.UnimplementedException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.HandlerLockedException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdParseException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceException;
@@ -19,6 +20,7 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFa
 import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
 import us.kbase.typedobj.idref.RemappedId;
 import us.kbase.typedobj.idref.SimpleRemappedId;
+import us.kbase.workspace.database.DependencyStatus;
 
 public class TestIDReferenceHandlerFactory implements IdReferenceHandlerFactory {
 
@@ -147,6 +149,11 @@ public class TestIDReferenceHandlerFactory implements IdReferenceHandlerFactory 
 	@Override
 	public IdReferencePermissionHandler createPermissionHandler(String userName) {
 		return null;
+	}
+
+	@Override
+	public List<DependencyStatus> getDependencyStatus() {
+		throw new UnimplementedException();
 	}
 
 }


### PR DESCRIPTION
Makes much more sense and will allow simplifying the WorkspaceServer and
the InitWorkspace classes. Will also make it easier to add more ID types
in future as changes to those classes will no longer be necessary.

Next: integrate into the rest of the server and remove dependency checking code from the WorkspaceServer class.