### PR TITLE
Update the S3 jars.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -61,21 +61,7 @@
 	<classpathentry kind="lib" path="/jars/lib/jars/kafka/kafka-clients-2.1.0.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/mongo/mongo-java-driver-3.8.2.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/kbase/shock/shock-client-0.0.16.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/annotations-2.5.62.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/auth-2.5.62.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/aws-core-2.5.62.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/aws-query-protocol-2.5.62.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/aws-xml-protocol-2.5.62.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/eventstream-1.0.1.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/http-client-spi-2.5.62.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/profiles-2.5.62.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/protocol-core-2.5.62.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/regions-2.5.62.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/s3-2.5.62.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/sdk-core-2.5.62.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/utils-2.5.62.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/reactivestreams/reactive-streams-1.0.2.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/url-connection-client-2.5.63.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/annotation/javax.annotation-api-1.3.2.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/bytebuddy/byte-buddy-1.9.10.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/bytebuddy/byte-buddy-agent-1.9.10.jar"/>
@@ -94,5 +80,21 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="/jars/lib/jars/kbase/common/kbase-common-0.1.0.jar" sourcepath="/jars/lib/jars/kbase/common/kbase-common-0.1.0-sources.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/reactivestreams/reactive-streams-1.0.3.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/annotations-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/arns-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/auth-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/aws-core-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/aws-query-protocol-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/aws-xml-protocol-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/http-client-spi-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/metrics-spi-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/profiles-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/protocol-core-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/regions-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/s3-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/sdk-core-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/url-connection-client-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/utils-2.14.25.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/build.xml
+++ b/build.xml
@@ -71,21 +71,23 @@
   </fileset>
 
   <fileset dir="${jardir}" id="s3lib">
-    <include name="amazon/V2/annotations-2.5.62.jar"/>
-    <include name="amazon/V2/auth-2.5.62.jar"/>
-    <include name="amazon/V2/aws-core-2.5.62.jar"/>
-    <include name="amazon/V2/aws-query-protocol-2.5.62.jar"/>
-    <include name="amazon/V2/aws-xml-protocol-2.5.62.jar"/>
+    <include name="amazon/V2/annotations-2.14.25.jar"/>
+    <include name="amazon/V2/arns-2.14.25.jar.jar"/>
+    <include name="amazon/V2/auth-2.14.25.jar"/>
+    <include name="amazon/V2/aws-core-2.14.25.jar"/>
+    <include name="amazon/V2/aws-query-protocol-2.14.25.jar"/>
+    <include name="amazon/V2/aws-xml-protocol-2.14.25.jar"/>
     <include name="amazon/V2/eventstream-1.0.1.jar"/>
-    <include name="amazon/V2/http-client-spi-2.5.62.jar"/>
-    <include name="amazon/V2/profiles-2.5.62.jar"/>
-    <include name="amazon/V2/protocol-core-2.5.62.jar"/>
-    <include name="amazon/V2/regions-2.5.62.jar"/>
-    <include name="amazon/V2/s3-2.5.62.jar"/>
-    <include name="amazon/V2/sdk-core-2.5.62.jar"/>
-    <include name="amazon/V2/utils-2.5.62.jar"/>
-    <include name="amazon/V2/url-connection-client-2.5.63.jar"/>
-    <include name="reactivestreams/reactive-streams-1.0.2.jar"/>
+    <include name="amazon/V2/http-client-spi-2.14.25.jar"/>
+    <include name="amazon/V2/metrics-spi-2.14.25.jar"/>
+    <include name="amazon/V2/profiles-2.14.25.jar"/>
+    <include name="amazon/V2/protocol-core-2.14.25.jar"/>
+    <include name="amazon/V2/regions-2.14.25.jar"/>
+    <include name="amazon/V2/s3-2.14.25.jar"/>
+    <include name="amazon/V2/sdk-core-2.14.25.jar"/>
+    <include name="amazon/V2/url-connection-client-2.14.25.jar"/>
+    <include name="amazon/V2/utils-2.14.25.jar"/>
+    <include name="reactivestreams/reactive-streams-1.0.3.jar"/>
   </fileset>
 
   <fileset dir="${jardir}" id="testlib">

--- a/src/us/kbase/workspace/database/mongo/S3ClientWithPresign.java
+++ b/src/us/kbase/workspace/database/mongo/S3ClientWithPresign.java
@@ -12,7 +12,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPut;
@@ -108,7 +107,6 @@ public class S3ClientWithPresign {
 		checkString(bucket, "bucket");
 		requireNonNull(object, "object");
 		final Aws4PresignerParams params = Aws4PresignerParams.builder()
-				.expirationTime(Instant.ofEpochSecond(15 * 60))
 				.awsCredentials(creds)
 				.signingName("s3")
 				.signingRegion(region)


### PR DESCRIPTION
Notes:
The behavior of the expiration time changed with the new clients and
caused all S3 saves to fail, so for now I removed the expiration time.
This means the expiration time will default to a week:
https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/signer/params/Aws4PresignerParams.Builder.html#expirationTime-java.time.Instant-
Since the URL with the creds only lives in the workspace memory and the
reference is released as soon as the object is saved, this doesn't seem
like a huge problem, as the intent is to replace the presign code next.

This PR is branching off of dev-candidate slightly after the last merge
to develop to pick up the Jackson jars updates. However, it's branched
*prior* to any sample service changes so this can be merged without
bringing in all that code if necessary.