### PR TITLE
Replace S3 presign implementation

### DIFF
--- a/src/us/kbase/workspace/database/mongo/S3ClientWithPresign.java
+++ b/src/us/kbase/workspace/database/mongo/S3ClientWithPresign.java
@@ -132,7 +132,7 @@ public class S3ClientWithPresign {
 			try {
 				htp = new HttpPut(target.toURI());
 			} catch (URISyntaxException e) {
-				// this means the S3 SDK it generating urls that are invalid URIs, which is
+				// this means the S3 SDK is generating urls that are invalid URIs, which is
 				// pretty bizarre.
 				// not sure how to test this.
 				// since the URI contains credentials, we deliberately do not include the 


### PR DESCRIPTION
The updated S3 client now has built in presign functionality, use that
instead of the prior workaround
Also restore the 15m expiration time for signed URLs