### PR TITLE
Get dependency status from the ID handlers vs. custom methods

### DIFF
--- a/src/us/kbase/typedobj/idref/IdReferenceHandlerSetFactoryBuilder.java
+++ b/src/us/kbase/typedobj/idref/IdReferenceHandlerSetFactoryBuilder.java
@@ -3,12 +3,16 @@ package us.kbase.typedobj.idref;
 import static java.util.Objects.requireNonNull;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import us.kbase.auth.AuthToken;
 import us.kbase.typedobj.idref.IdReferenceHandlerSet.IdReferenceHandler;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFactory;
 import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
+import us.kbase.workspace.database.DependencyStatus;
 
 /** A builder for a factory for a set of {@link IdReferenceHandler}s.
  * 
@@ -33,11 +37,11 @@ import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermis
  */
 public class IdReferenceHandlerSetFactoryBuilder {
 	
-	private final Map<IdReferenceType, IdReferenceHandlerFactory> factories;
+	private final Map<IdReferenceType, IdReferenceHandlerFactory> factories; // tree map
 	private final int maxUniqueIdCount;
 	
 	private IdReferenceHandlerSetFactoryBuilder(
-			final Map<IdReferenceType, IdReferenceHandlerFactory> factories,
+			final Map<IdReferenceType, IdReferenceHandlerFactory> factories, // tree map
 			final int maxUniqueIdCount) {
 		this.factories = factories;
 		this.maxUniqueIdCount = maxUniqueIdCount;
@@ -81,6 +85,16 @@ public class IdReferenceHandlerSetFactoryBuilder {
 		}
 		return new IdReferencePermissionHandlerSet(handlers);
 	}
+	
+	/** Get the status of any dependencies of the contained factories in this builder.
+	 * @return the status of the factory dependencies.
+	 */
+	public List<DependencyStatus> getDependencyStatus() {
+		return factories.keySet().stream()
+				.flatMap(k -> factories.get(k).getDependencyStatus().stream())
+				.collect(Collectors.toList());
+		
+	}
 
 	/** Get a builder for a {@link IdReferenceHandlerSetFactoryBuilder}.
 	 * @param maxUniqueIdCount - the maximum number of unique IDs allowed in
@@ -100,7 +114,7 @@ public class IdReferenceHandlerSetFactoryBuilder {
 	public static class Builder {
 
 		private final int maxUniqueIdCount;
-		private final Map<IdReferenceType,IdReferenceHandlerFactory> factories = new HashMap<>();
+		private final Map<IdReferenceType,IdReferenceHandlerFactory> factories = new TreeMap<>();
 
 		private Builder(final int maxUniqueIdCount) {
 			if (maxUniqueIdCount < 0) {

--- a/src/us/kbase/typedobj/test/idref/IdReferenceHandlerSetFactoryBuilderTest.java
+++ b/src/us/kbase/typedobj/test/idref/IdReferenceHandlerSetFactoryBuilderTest.java
@@ -24,6 +24,7 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFa
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet;
 import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
+import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.typedobj.idref.IdReferenceType;
 
 public class IdReferenceHandlerSetFactoryBuilderTest {
@@ -227,6 +228,46 @@ public class IdReferenceHandlerSetFactoryBuilderTest {
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, new NullPointerException("userName"));
 		}
+	}
+	
+	@Test
+	public void getDependenciesEmpty() throws Exception {
+		final IdReferenceHandlerSetFactoryBuilder b = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(2).build();
+		
+		assertThat("incorrect dependencies", b.getDependencyStatus(), is(Collections.emptyList()));
+	}
+	
+	@Test
+	public void getDependencies() throws Exception {
+		final IdReferenceHandlerFactory fac1 = mock(IdReferenceHandlerFactory.class);
+		when(fac1.getIDType()).thenReturn(new IdReferenceType("t1"));
+		when(fac1.getDependencyStatus()).thenReturn(
+				Arrays.asList(new DependencyStatus(true, "s1", "n1", "v1")));
+		
+		final IdReferenceHandlerFactory fac2 = mock(IdReferenceHandlerFactory.class);
+		when(fac2.getIDType()).thenReturn(new IdReferenceType("t2"));
+		when(fac2.getDependencyStatus()).thenReturn(
+				Arrays.asList(new DependencyStatus(false, "s2", "n2", "v2")));
+		
+		final IdReferenceHandlerFactory fac3 = mock(IdReferenceHandlerFactory.class);
+		when(fac3.getIDType()).thenReturn(new IdReferenceType("t3"));
+		when(fac3.getDependencyStatus()).thenReturn(
+				Arrays.asList(new DependencyStatus(true, "s3", "n3", "v3"),
+						new DependencyStatus(false, "s4", "n4", "v4")));
+
+		final IdReferenceHandlerSetFactoryBuilder b = IdReferenceHandlerSetFactoryBuilder
+				.getBuilder(2)
+				.withFactory(fac3)
+				.withFactory(fac1)
+				.withFactory(fac2)
+				.build();
+		
+		assertThat("incorrect dependencies", b.getDependencyStatus(), is(Arrays.asList(
+				new DependencyStatus(true, "s1", "n1", "v1"),
+				new DependencyStatus(false, "s2", "n2", "v2"),
+				new DependencyStatus(true, "s3", "n3", "v3"),
+				new DependencyStatus(false, "s4", "n4", "v4"))));
 	}
 
 }

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -1750,16 +1750,7 @@ public class WorkspaceServer extends JsonServerServlet {
 		//things still work
 		//TODO TEST add tests exercising failures - this is a huge pain
 		returnVal = new LinkedHashMap<String, Object>();
-		final List<DependencyStatus> deps = ws.status();
-		if (linkedHandleServiceClient != null) {
-			deps.add(checkHandleService());
-		}
-		if (linkedShockClient != null) {
-			deps.add(checkShockLink());
-		}
-		if (linkedSampleServiceClient != null) {
-			deps.add(checkSampleLink());
-		}
+		final List<DependencyStatus> deps = wsmeth.getDependencyStatus();
 		boolean ok = true;
 		final List<Map<String, String>> dstate = new LinkedList<>();
 		for (final DependencyStatus ds: deps) {

--- a/src/us/kbase/workspace/kbase/WorkspaceServerMethods.java
+++ b/src/us/kbase/workspace/kbase/WorkspaceServerMethods.java
@@ -61,6 +61,7 @@ import us.kbase.workspace.SetGlobalPermissionsParams;
 import us.kbase.workspace.SetPermissionsParams;
 import us.kbase.workspace.WorkspaceIdentity;
 import us.kbase.workspace.WorkspacePermissions;
+import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.workspace.database.ListObjectsParameters;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIdentifier;
@@ -90,6 +91,9 @@ import us.kbase.workspace.exceptions.WorkspaceAuthorizationException;
 
 public class WorkspaceServerMethods {
 	
+	// TODO TEST unit
+	// TODO JAVADOC
+	
 	final private Workspace ws;
 	final private Types types;
 	final private ConfigurableAuthService auth;
@@ -104,6 +108,15 @@ public class WorkspaceServerMethods {
 		this.types = types;
 		this.idFacBuilder = idFacBuilder;
 		this.auth = auth;
+	}
+	
+	/** Get the status of any dependencies of the workspace service.
+	 * @return the dependency status.
+	 */
+	public List<DependencyStatus> getDependencyStatus() {
+		final List<DependencyStatus> ret = ws.status();
+		ret.addAll(idFacBuilder.getDependencyStatus());
+		return ret;
 	}
 	
 	public ConfigurableAuthService getAuth() {

--- a/src/us/kbase/workspace/test/kbase/HandleAndShockTest.java
+++ b/src/us/kbase/workspace/test/kbase/HandleAndShockTest.java
@@ -361,7 +361,7 @@ public class HandleAndShockTest {
 
 		final Iterator<Map<String, String>> gotiter = deps.iterator();
 		for (final String name: Arrays.asList(
-				"MongoDB", "Shock", "Handle service", "Linked Shock for IDs")) {
+				"MongoDB", "Shock", "Linked Shock for IDs", "Handle service")) {
 			final Map<String, String> g = gotiter.next();
 			assertThat("incorrect name", (String) g.get("name"), is(name));
 			assertThat("incorrect state", g.get("state"), is((Object) "OK"));


### PR DESCRIPTION
Builds on the work from the past few commits.

Tests for `WorkspaceServerMethods` at this point are all integration tests that start at the JSON RPC API. Fixing that is waaaay out of scope for this PR. Nonetheless, the changes are tested.

Next step: Delete all the old dependency status code which is now cruft.