### PR TITLE
Fix bug in sample ID handler

### DIFF
--- a/src/us/kbase/workspace/kbase/SampleIdHandlerFactory.java
+++ b/src/us/kbase/workspace/kbase/SampleIdHandlerFactory.java
@@ -239,7 +239,7 @@ public class SampleIdHandlerFactory implements IdReferenceHandlerFactory {
 							"There was an unexpected error while trying to contact the " +
 							"Sample Service: " + e.getLocalizedMessage(), TYPE, e);
 				}
-				if (user != acls.getOwner() && !acls.getAdmin().contains(user)) {
+				if (!user.equals(acls.getOwner()) && !acls.getAdmin().contains(user)) {
 					throw new IdReferenceException(
 							String.format("User %s does not have administrative permissions " +
 									"for sample %s", user, id),

--- a/src/us/kbase/workspace/test/WorkspaceTestCommon.java
+++ b/src/us/kbase/workspace/test/WorkspaceTestCommon.java
@@ -4,6 +4,8 @@ import static us.kbase.common.test.TestCommon.destroyDB;
 
 import com.mongodb.DB;
 
+// TODO CODE this class can probably go away.
+
 public class WorkspaceTestCommon {
 	
 	public static void destroyWSandTypeDBs(DB mdb, String typedb) {

--- a/src/us/kbase/workspace/test/kbase/SampleIDHandlerFactoryTest.java
+++ b/src/us/kbase/workspace/test/kbase/SampleIDHandlerFactoryTest.java
@@ -331,7 +331,9 @@ public class SampleIDHandlerFactoryTest {
 		final SampleServiceClientWrapper cli = mock(SampleServiceClientWrapper.class);
 		
 		final IdReferenceHandler<Integer> h = new SampleIdHandlerFactory(cli)
-				.createHandler(Integer.class, new AuthToken("t", "user1"));
+				// keep the new String(). String interning caused this test to pass when
+				// it should've failed
+				.createHandler(Integer.class, new AuthToken("t", new String("user1")));
 		
 		assertThat("incorrect uniqueness", h.addId(9, "id1", null), is(true));
 		assertThat("incorrect uniqueness", h.addId(9, "id1", null), is(false));


### PR DESCRIPTION
String interning caused `==` to work when the correct equality method is
using `equals()`