### PR TITLE
Update Shock client to 0.1.0 for blobstore compatibility

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -22,9 +22,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="/jars/lib/jars/bson4jackson/bson4jackson-2.2.0-2.2.0.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/apache_commons/http/httpclient-4.3.1.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/apache_commons/http/httpcore-4.3.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/apache_commons/http/httpmime-4.3.1.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/texttable/text-table-formatter-1.1.1.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/apache_commons/commons-codec-1.8.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/apache_commons/commons-io-2.4.jar"/>
@@ -60,7 +57,7 @@
 	<classpathentry kind="lib" path="/jars/lib/jars/kbase/auth2/kbase-auth2test-0.2.4.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/kafka/kafka-clients-2.1.0.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/mongo/mongo-java-driver-3.8.2.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/kbase/shock/shock-client-0.0.16.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/kbase/shock/shock-client-0.1.0.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/eventstream-1.0.1.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/annotation/javax.annotation-api-1.3.2.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/bytebuddy/byte-buddy-1.9.10.jar"/>
@@ -96,5 +93,8 @@
 	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/sdk-core-2.14.25.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/url-connection-client-2.14.25.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/amazon/V2/utils-2.14.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/apache_commons/http/httpclient-4.5.9.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/apache_commons/http/httpcore-4.4.5.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/apache_commons/http/httpmime-4.5.8.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/build.xml
+++ b/build.xml
@@ -49,11 +49,11 @@
   </fileset>
 
   <fileset dir="${jardir}" id="shocklib">
-    <include name="kbase/shock/shock-client-0.0.16.jar"/>
+    <include name="kbase/shock/shock-client-0.1.0.jar"/>
     <include name="apache_commons/commons-logging-1.1.1.jar"/>
-    <include name="apache_commons/http/httpclient-4.3.1.jar"/>
-    <include name="apache_commons/http/httpcore-4.3.jar"/>
-    <include name="apache_commons/http/httpmime-4.3.1.jar"/>
+    <include name="apache_commons/http/httpclient-4.5.9.jar"/>
+    <include name="apache_commons/http/httpcore-4.4.5.jar"/>
+    <include name="apache_commons/http/httpmime-4.5.8.jar"/>
   </fileset>
 
   <fileset dir="${jardir}" id="applicationlib">

--- a/docsource/releasenotes.rst
+++ b/docsource/releasenotes.rst
@@ -1,7 +1,7 @@
 Workspace service release notes
 ===============================
 
-VERSION: 0.11.3 (Released 10/13/20)
+VERSION: 0.11.3 (Released 10/15/20)
 ----------------------------------
 
 UPDATES:

--- a/performance/us/kbase/workspace/performance/shockclient/SaveAndGetFromShock.java
+++ b/performance/us/kbase/workspace/performance/shockclient/SaveAndGetFromShock.java
@@ -34,7 +34,7 @@ public class SaveAndGetFromShock {
 		final long presave = System.nanoTime();
 		for (int i = 0; i < COUNT; i++) {
 			final ByteArrayInputStream bais = new ByteArrayInputStream(conbytes);
-			final ShockNode node = bsc.addNode(bais, "foo", "text");
+			final ShockNode node = bsc.addNode(bais, FILE_SIZE, "foo", "text");
 			ids.add(node.getId().getId());
 		}
 		double elapsed = printElapse("shock load", presave);

--- a/src/us/kbase/common/test/service/ServiceCheckerTest.java
+++ b/src/us/kbase/common/test/service/ServiceCheckerTest.java
@@ -17,7 +17,7 @@ import us.kbase.common.service.ServiceChecker.ServiceException;
 
 public class ServiceCheckerTest {
 	
-	private final static String KBASE_ENV = "https://ci.kbase.us"; // "https://kbase.us/"
+	private final static String KBASE_ENV = "https://next.kbase.us"; // "https://kbase.us/"
 
 	public static class TestSpec {
 		public final String err;

--- a/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
+++ b/src/us/kbase/workspace/database/mongo/ShockBlobStore.java
@@ -127,7 +127,7 @@ public class ShockBlobStore implements BlobStore {
 	private ShockNode saveNode(final MD5 md5, final Restreamable data)
 			throws BlobStoreCommunicationException {
 		try (final InputStream is = data.getInputStream()) {
-			return client.addNode(is, "workspace_" + md5.getMD5(), "JSON");
+			return client.addNode(is, data.getSize(), "workspace_" + md5.getMD5(), "JSON");
 		} catch (JsonProcessingException jpe) {
 			//this should be impossible
 			throw new RuntimeException("Attribute serialization failed: "

--- a/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreIntegrationTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreIntegrationTest.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -119,7 +120,8 @@ public class ShockBlobStoreIntegrationTest {
 	@Test
 	public void dataWithoutSortMarker() throws Exception {
 		String s = "pootypoot";
-		ShockNode sn = client.addNode(new ByteArrayInputStream(s.getBytes("UTF-8")), A32, "JSON");
+		ShockNode sn = client.addNode(
+				new ByteArrayInputStream(s.getBytes("UTF-8")), 9, A32, "JSON");
 		DBObject rec = new BasicDBObject(Fields.SHOCK_CHKSUM, A32);
 		rec.put(Fields.SHOCK_NODE, sn.getId().getId());
 		rec.put(Fields.SHOCK_VER, sn.getVersion().getVersion());
@@ -146,7 +148,7 @@ public class ShockBlobStoreIntegrationTest {
 		}
 		@Override
 		public long getSize() {
-			return -1; // unused for Shock (might be used for blobstore in future)
+			return data.getBytes(StandardCharsets.UTF_8).length;
 		}
 	}
 	

--- a/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/ShockBlobStoreTest.java
@@ -168,11 +168,12 @@ public class ShockBlobStoreTest {
 		
 		when(col.findOne(new BasicDBObject("chksum", md5))).thenReturn(null);
 		
-		final InputStream stream = new ByteArrayInputStream("foo".getBytes());
+		final InputStream stream = new ByteArrayInputStream("foobar".getBytes());
 		
 		when(res.getInputStream()).thenReturn(stream);
+		when(res.getSize()).thenReturn(6L);
 		
-		when(client.addNode(stream, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
+		when(client.addNode(stream, 6, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
 				.thenReturn(sn);
 		
 		when(sn.getId()).thenReturn(new ShockNodeId("ca4a4b5a-b676-4090-9a7d-9690189e29be"));
@@ -214,8 +215,9 @@ public class ShockBlobStoreTest {
 		final InputStream stream = new ByteArrayInputStream("foo".getBytes());
 		
 		when(res.getInputStream()).thenReturn(stream);
+		when(res.getSize()).thenReturn(3L);
 		
-		when(client.addNode(stream, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
+		when(client.addNode(stream, 3, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
 				.thenReturn(sn1, sn2, sn3, sn4, sn5);
 		
 		when(sfi1.getChecksum("md5")).thenReturn("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3");
@@ -272,8 +274,9 @@ public class ShockBlobStoreTest {
 		final InputStream stream = new ByteArrayInputStream("foo".getBytes());
 		
 		when(res.getInputStream()).thenReturn(stream);
+		when(res.getSize()).thenReturn(3L);
 		
-		when(client.addNode(stream, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
+		when(client.addNode(stream, 3, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
 				.thenReturn(sn1, sn2, sn3, sn4, sn5);
 		
 		when(sfi1.getChecksum("md5")).thenReturn("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3");
@@ -355,8 +358,9 @@ public class ShockBlobStoreTest {
 		final InputStream stream = new ByteArrayInputStream("foo".getBytes());
 		
 		when(res.getInputStream()).thenReturn(stream);
+		when(res.getSize()).thenReturn(3L);
 		
-		when(client.addNode(stream, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
+		when(client.addNode(stream, 3, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
 				.thenThrow(thrown);
 		
 		failSaveBlob(sbs, new MD5(md5), res, true, expected);
@@ -380,8 +384,9 @@ public class ShockBlobStoreTest {
 		final InputStream stream = new ByteArrayInputStream("foo".getBytes());
 		
 		when(res.getInputStream()).thenReturn(stream);
+		when(res.getSize()).thenReturn(3L);
 		
-		when(client.addNode(stream, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
+		when(client.addNode(stream, 3, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
 				.thenReturn(sn);
 		
 		when(sn.getId()).thenReturn(new ShockNodeId("ca4a4b5a-b676-4090-9a7d-9690189e29be"));
@@ -428,8 +433,9 @@ public class ShockBlobStoreTest {
 		final InputStream stream = new ByteArrayInputStream("foo".getBytes());
 		
 		when(res.getInputStream()).thenReturn(stream);
+		when(res.getSize()).thenReturn(3L);
 		
-		when(client.addNode(stream, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
+		when(client.addNode(stream, 3, "workspace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "JSON"))
 				.thenReturn(sn1);
 		
 		when(sfi1.getChecksum("md5")).thenReturn("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3");

--- a/src/us/kbase/workspace/test/docserver/DocServerTest.java
+++ b/src/us/kbase/workspace/test/docserver/DocServerTest.java
@@ -1,6 +1,7 @@
 package us.kbase.workspace.test.docserver;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
@@ -61,6 +62,7 @@ public class DocServerTest {
 	
 	private static String CT_HTML = "text/html";
 	private static String CT_HTML_ERR = "text/html;charset=ISO-8859-1";
+	private static String USER_AGENT_PREFIX = "Apache-HttpClient/4.5.9 ("; // java version next
 	
 	private static int INFO = JsonServerSyslog.LOG_LEVEL_INFO;
 	private static int ERR = JsonServerSyslog.LOG_LEVEL_ERR;
@@ -567,7 +569,7 @@ public class DocServerTest {
 			assertThat("status code correct", msgparts[1],
 					is(exp.level == INFO ? "200" : "404"));
 			assertThat("User agent correct", msgparts[2],
-					is("Apache-HttpClient/4.3.1 (java 1.5)"));
+					startsWith(USER_AGENT_PREFIX));
 		}
 		return callID;
 	}

--- a/src/us/kbase/workspace/test/kbase/HandleAndShockTest.java
+++ b/src/us/kbase/workspace/test/kbase/HandleAndShockTest.java
@@ -220,13 +220,18 @@ public class HandleAndShockTest {
 
 		BasicShockClient bsc = new BasicShockClient(new URL("http://localhost:"
 				+ SHOCK.getServerPort()), CLIENT1.getToken());
-		SHOCK_USER1 = bsc.addNode().getACLs().getOwner();
+		SHOCK_USER1 = addBasicNode(bsc).getACLs().getOwner();
 		bsc.updateToken(CLIENT2.getToken());
-		SHOCK_USER2 = bsc.addNode().getACLs().getOwner();
+		SHOCK_USER2 = addBasicNode(bsc).getACLs().getOwner();
 		bsc.updateToken(HANDLE_SRVC_TOKEN);
-		SHOCK_USER3 = bsc.addNode().getACLs().getOwner();
+		SHOCK_USER3 = addBasicNode(bsc).getACLs().getOwner();
 
 		System.out.println("finished HandleService setup");
+	}
+	
+	private static ShockNode addBasicNode(final BasicShockClient bsc) throws Exception {
+		return bsc.addNode(
+				new ByteArrayInputStream("a".getBytes("UTF-8")), 1, "n", "JSON");
 	}
 
 	private static void setUpSpecs() throws Exception {
@@ -400,7 +405,7 @@ public class HandleAndShockTest {
 		BasicShockClient bsc = new BasicShockClient(
 				new URL("http://localhost:" + SHOCK.getServerPort()), CLIENT1.getToken());
 
-		final ShockNode node = bsc.addNode();
+		final ShockNode node = addBasicNode(bsc);
 		String shock_id = node.getId().getId();
 		final Handle handle = new Handle();
 		handle.setId(shock_id);
@@ -538,15 +543,15 @@ public class HandleAndShockTest {
 		// as well as nodes merely owned by the user.
 		final String workspace = "basicshock";
 		CLIENT1.createWorkspace(new CreateWorkspaceParams().withWorkspace(workspace));
-		final ShockNode n1 = WS_OWNED_SHOCK.addNode(ImmutableMap.of("foo", "bar"),
-				new ByteArrayInputStream("contents".getBytes()), "fname", "text");
+		final ShockNode n1 = WS_OWNED_SHOCK.addNode(
+				new ByteArrayInputStream("contents".getBytes()), 8, "fname", "text");
 		n1.addToNodeAcl(Arrays.asList(USER1), ShockACLType.ALL);
 		// test that user1's write & delete creds are removed from the ws-owned node
 		checkReadAcl(n1, Arrays.asList(SHOCK_USER3, SHOCK_USER1));
 		checkWriteAcl(n1, Arrays.asList(SHOCK_USER3, SHOCK_USER1));
 		checkDeleteAcl(n1, Arrays.asList(SHOCK_USER3, SHOCK_USER1));
-		final ShockNode n2 = SHOCK_CLIENT_1.addNode(ImmutableMap.of("foo", "bar2"),
-				new ByteArrayInputStream("contents2".getBytes()), "fname2", "text2");
+		final ShockNode n2 = SHOCK_CLIENT_1.addNode(
+				new ByteArrayInputStream("contents2".getBytes()), 9, "fname2", "text2");
 		try {
 			// expect n1 to stay the same, n2 to be changed to a new shock ID
 			CLIENT1.saveObjects(new SaveObjectsParams()
@@ -643,7 +648,6 @@ public class HandleAndShockTest {
 			throws Exception {
 		final ShockNode sn = cli.getNode(id);
 		final ShockFileInformation fi = sn.getFileInformation();
-		assertThat("incorrect attribs", sn.getAttributes(), is(attrib));
 		assertThat("incorrect filename", fi.getName(), is(filename));
 		assertThat("incorrect format", fi.getFormat(), is(format));
 		assertThat("incorrect file", IOUtils.toString(sn.getFile()), is(file));
@@ -667,12 +671,12 @@ public class HandleAndShockTest {
 				"Object #1, foo has invalid reference: Bytestream node %s does not exist at " +
 				"/ids/0", id), 1, "n"));
 
-		final ShockNode sn = WS_OWNED_SHOCK.addNode();
+		final ShockNode sn = addBasicNode(WS_OWNED_SHOCK);
 		saveWithShockIDFail(CLIENT1, workspace, sn.getId().getId(), new ServerException(
 				String.format("Object #1, foo has invalid reference: User user1 cannot " +
 				"read bytestream node %s at /ids/0", sn.getId().getId()), 1, "n"));
 		
-		final ShockNode sn2 = SHOCK_CLIENT_2.addNode();
+		final ShockNode sn2 = addBasicNode(SHOCK_CLIENT_2);
 		sn2.addToNodeAcl(Arrays.asList(USER1), ShockACLType.READ);
 		saveWithShockIDFail(CLIENT1, workspace, sn2.getId().getId(), new ServerException(
 				String.format("Object #1, foo has invalid reference: User user1 does not " +
@@ -702,7 +706,7 @@ public class HandleAndShockTest {
 	public void getWithShockIDsFail() throws Exception {
 		final String workspace = "shockgetfail";
 		CLIENT1.createWorkspace(new CreateWorkspaceParams().withWorkspace(workspace));
-		final ShockNode n1 = WS_OWNED_SHOCK.addNode();
+		final ShockNode n1 = addBasicNode(WS_OWNED_SHOCK);
 		n1.addToNodeAcl(Arrays.asList(USER1), ShockACLType.READ);
 		final ShockNodeId id = n1.getId();
 		try {
@@ -762,7 +766,7 @@ public class HandleAndShockTest {
 		BasicShockClient bsc = new BasicShockClient(
 				new URL("http://localhost:" + SHOCK.getServerPort()), CLIENT1.getToken());
 
-		final ShockNode node = bsc.addNode();
+		final ShockNode node = addBasicNode(bsc);
 		String shock_id = node.getId().getId();
 
 		final Handle handle = new Handle();

--- a/test/performance/ConfigurationsAndThreads.java
+++ b/test/performance/ConfigurationsAndThreads.java
@@ -566,7 +566,8 @@ public class ConfigurationsAndThreads {
 		@Override
 		public int performWrites() throws Exception {
 			for (int i = 0; i < this.writes; i++) {
-				nodes.add(bsc.addNode(new ByteArrayInputStream(data), "foo", "UTF-8"));
+				nodes.add(bsc.addNode(
+						new ByteArrayInputStream(data), data.length, "foo", "UTF-8"));
 			}
 			return 0;
 		}


### PR DESCRIPTION
As near as I can tell, how this screwup happened is:

* while developing the blobstore, I came up with a list of repos that required a shock client update.
* I left the workspace off that list since it would no longer talk to shock, but talk to S3 directly.
* Later, I added support for the `@bytestream` annotation that causes the workspace to talk to shock, but reasoned the client didn't need an update because the `@bytestream` code doesn't use any of the changed APIs.
* I forgot that on client startup the client *does* use one of the changed APIs invisibly to check the shock connection and credentials are fine.
* Apparently I never tested the bytestream stuff against the blobstore.

Lesson learned: always test everything against everything.