### PR TITLE
Add a trivial spec to make ad hoc testing easier

### DIFF
--- a/src/us/kbase/workspace/test/kbase/HandleAndShockTest.java
+++ b/src/us/kbase/workspace/test/kbase/HandleAndShockTest.java
@@ -235,10 +235,13 @@ public class HandleAndShockTest {
 
 	private static void setUpSpecs() throws Exception {
 		final String handlespec =
+				// An SDK struct type must always have at least one field, but that field can be
+				// optional. The Empty type allows for arbitrary contents *other than* if its
+				// singular field is included. So just don't use that field
 				"module HandleByteStreamList {" +
-					"/* @optional dontusethis */" +
+					"/* @optional ifyouputanythinginthisfielditmustbeanint */" +
 					"typedef structure {" +
-						"int dontusethis;" +
+						"int ifyouputanythinginthisfielditmustbeanint;" +
 					"} Empty;" + // for ad hoc testing
 					"/* @id handle */" +
 					"typedef string handle;" +

--- a/src/us/kbase/workspace/test/kbase/HandleAndShockTest.java
+++ b/src/us/kbase/workspace/test/kbase/HandleAndShockTest.java
@@ -236,6 +236,10 @@ public class HandleAndShockTest {
 	private static void setUpSpecs() throws Exception {
 		final String handlespec =
 				"module HandleByteStreamList {" +
+					"/* @optional dontusethis */" +
+					"typedef structure {" +
+						"int dontusethis;" +
+					"} Empty;" + // for ad hoc testing
 					"/* @id handle */" +
 					"typedef string handle;" +
 					"typedef structure {" +
@@ -257,7 +261,8 @@ public class HandleAndShockTest {
 		CLIENT1.registerTypespec(new RegisterTypespecParams()
 			.withDryrun(0L)
 			.withSpec(handlespec)
-			.withNewTypes(Arrays.asList("HList", "SList", "HRef")));
+			.withNewTypes(Arrays.asList("HList", "SList", "HRef", "Empty")));
+		CLIENT1.releaseModule("HandleByteStreamList");
 	}
 
 	private static WorkspaceServer startupWorkspaceServer(


### PR DESCRIPTION
Frequently start up the services via the test with a debug pause and
then do manual testing. Having a simple spec makes this easier.