### PR TITLE
Remove an old TODO and fix a typo

### DIFF
--- a/docsource/shockintegration.rst
+++ b/docsource/shockintegration.rst
@@ -299,7 +299,7 @@ Step 5 - retrieve the data from the Workspace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Retrieving the data from the workspace also works normally, but there’s a
-couple of important points. When calling the ``get_objects2``, method (or the deprecated
+couple of important points. When calling the ``get_objects2`` method (or the deprecated
 ``get_objects``, ``get_referenced_objects``, ``get_object_subset``, or
 ``get_object_provenance`` methods):
 

--- a/src/us/kbase/workspace/test/kbase/SampleServiceIntegrationTest.java
+++ b/src/us/kbase/workspace/test/kbase/SampleServiceIntegrationTest.java
@@ -690,6 +690,4 @@ public class SampleServiceIntegrationTest {
 					+ err + "\n" + stack);
 		}
 	}
-	// TODO NOW finish sample integration tests
-	
 }


### PR DESCRIPTION
Apparently forgot to remove the TODO when the integration tests were
finished