### PR TITLE
Add deleteObject unit tests

### DIFF
--- a/src/us/kbase/common/test/TestCommon.java
+++ b/src/us/kbase/common/test/TestCommon.java
@@ -215,6 +215,16 @@ public class TestCommon {
 		assertThat("incorrect exception type", got, instanceOf(expected.getClass()));
 	}
 	
+	public static void assertCloseToNow(final long epochMillis) {
+		final long now = Instant.now().toEpochMilli();
+		assertThat(String.format("time (%s) not within 1000ms of now: %s", epochMillis, now),
+				Math.abs(epochMillis - now) < 1000, is(true));
+	}
+	
+	public static void assertCloseToNow(final Instant creationDate) {
+		assertCloseToNow(creationDate.toEpochMilli());
+	}
+	
 	public static void assertNoTempFilesExist(TempFilesManager tfm)
 			throws Exception {
 		assertNoTempFilesExist(Arrays.asList(tfm));


### PR DESCRIPTION
While looking into what it would take to add events for hide object state changes, I discovered that the return values for deleteObject state changes were completely untested. This adds unit (ish, MongoDB is running) tests for deleteObject. It also DRYs up object creation in tests, which is fairly complex this low in the workspace stack.