### PR TITLE
Object list fn code cleanup

### DIFF
--- a/src/us/kbase/workspace/database/GetObjectInformationParameters.java
+++ b/src/us/kbase/workspace/database/GetObjectInformationParameters.java
@@ -171,20 +171,4 @@ public class GetObjectInformationParameters {
 	public boolean asAdmin() {
 		return asAdmin;
 	}
-	
-	/** Check if there are no filters set other than the object ID filters. The object ID filters
-	 * may or may not be set.
-	 * The other filters are the two date filters, the metadata filter, the savers filter, and
-	 * the type filter.
-	 * @return true if no filters other than the object ID filters are set.
-	 */
-	public boolean isObjectIDFiltersOnly() {
-		// be really careful about modifying this function. See notes in {@link ObjectInfoUtils}.
-		boolean oidFiltersOnly = after == null;
-		oidFiltersOnly = oidFiltersOnly && before == null;
-		oidFiltersOnly = oidFiltersOnly && meta.isEmpty();
-		oidFiltersOnly = oidFiltersOnly && savers.isEmpty();
-		oidFiltersOnly = oidFiltersOnly && type == null; // must have workspaces specified
-		return oidFiltersOnly;
-	}
 }

--- a/src/us/kbase/workspace/database/ListObjectsParameters.java
+++ b/src/us/kbase/workspace/database/ListObjectsParameters.java
@@ -1,5 +1,6 @@
 package us.kbase.workspace.database;
 
+import static java.util.Objects.requireNonNull;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -53,26 +54,23 @@ public class ListObjectsParameters {
 			final Collection<WorkspaceIdentifier> wsis) {
 		this.user = user;
 		if (wsis == null || wsis.isEmpty()) {
-			throw new IllegalArgumentException(
-					"Must provide at least one workspace");
+			throw new IllegalArgumentException("Must provide at least one workspace");
 		}
-		this.wsis = Collections.unmodifiableSet(
-				new HashSet<WorkspaceIdentifier>(wsis));
+		this.wsis = Collections.unmodifiableSet(new HashSet<>(wsis));
 		type = null;
 	}
 	
 	/** Create a set of parameters for calling the list objects method as an admin.
 	 * @param wsis the workspaces for which to list objects.
 	 */
-	public ListObjectsParameters(
-			final Collection<WorkspaceIdentifier> wsis) {
+	public ListObjectsParameters(final Collection<WorkspaceIdentifier> wsis) {
 		this.user = null;
 		this.asAdmin = true;
 		if (wsis == null || wsis.isEmpty() || wsis.size() > MAX_WS_AS_ADMIN) {
 			throw new IllegalArgumentException(String.format(
 					"Must provide between 1 and %s workspaces", MAX_WS_AS_ADMIN));
 		}
-		this.wsis = Collections.unmodifiableSet(new HashSet<WorkspaceIdentifier>(wsis));
+		this.wsis = Collections.unmodifiableSet(new HashSet<>(wsis));
 		type = null;
 	}
 	
@@ -81,16 +79,10 @@ public class ListObjectsParameters {
 	 * readable objects will be returned.
 	 * @param type the type of objects to list.
 	 */
-	public ListObjectsParameters(
-			final WorkspaceUser user,
-			final TypeDefId type) {
+	public ListObjectsParameters(final WorkspaceUser user, final TypeDefId type) {
 		this.user = user;
-		if (type == null) {
-			throw new NullPointerException("Type cannot be null");
-		}
-		this.type = type;
-		this.wsis = Collections.unmodifiableSet(
-				new HashSet<WorkspaceIdentifier>());
+		this.type = requireNonNull(type, "Type cannot be null");
+		this.wsis = Collections.unmodifiableSet(new HashSet<>());
 	}
 	
 	/** Create a set of parameters for calling the list objects method.
@@ -105,15 +97,10 @@ public class ListObjectsParameters {
 			final TypeDefId type) {
 		this.user = user;
 		if (wsis == null || wsis.isEmpty()) {
-			throw new IllegalArgumentException(
-					"Must provide at least one workspace");
+			throw new IllegalArgumentException("Must provide at least one workspace");
 		}
-		this.wsis = Collections.unmodifiableSet(
-				new HashSet<WorkspaceIdentifier>(wsis));
-		if (type == null) {
-			throw new NullPointerException("Type cannot be null");
-		}
-		this.type = type;
+		this.wsis = Collections.unmodifiableSet(new HashSet<>(wsis));
+		this.type = requireNonNull(type, "Type cannot be null");
 	}
 	
 	/** Create a set of parameters for calling the list objects method as an admin.
@@ -130,10 +117,7 @@ public class ListObjectsParameters {
 					"Must provide between 1 and %s workspaces", MAX_WS_AS_ADMIN));
 		}
 		this.wsis = Collections.unmodifiableSet(new HashSet<WorkspaceIdentifier>(wsis));
-		if (type == null) {
-			throw new NullPointerException("Type cannot be null");
-		}
-		this.type = type;
+		this.type = requireNonNull(type, "Type cannot be null");
 	}
 
 	/** Get the workspaces to list.
@@ -171,8 +155,7 @@ public class ListObjectsParameters {
 	 * read is passed in, the permission is set to read.
 	 * @return this ListObjectsParameters instance.
 	 */
-	public ListObjectsParameters withMinimumPermission(
-			final Permission minPerm) {
+	public ListObjectsParameters withMinimumPermission(final Permission minPerm) {
 		if (minPerm == null || Permission.READ.compareTo(minPerm) > 0) {
 			this.minPerm = Permission.READ;
 		} else {
@@ -196,8 +179,7 @@ public class ListObjectsParameters {
 	 */
 	public ListObjectsParameters withSavers(final List<WorkspaceUser> savers) {
 		if (savers == null) {
-			this.savers = Collections.unmodifiableList(
-					new LinkedList<WorkspaceUser>());
+			this.savers = Collections.unmodifiableList(new LinkedList<>());
 		} else {
 			this.savers = Collections.unmodifiableList(savers);
 		}
@@ -216,12 +198,10 @@ public class ListObjectsParameters {
 	 * @param meta the metadata. If null, set to an empty map.
 	 * @return this ListObjectsParameters instance.
 	 */
-	public ListObjectsParameters withMetadata(
-			final WorkspaceUserMetadata meta) {
+	public ListObjectsParameters withMetadata(final WorkspaceUserMetadata meta) {
 		if (meta != null) {
 			if (meta.size() > 1) {
-				throw new IllegalArgumentException(
-						"Only one metadata spec allowed");
+				throw new IllegalArgumentException("Only one metadata spec allowed");
 			}
 			this.meta = meta;
 		} else {
@@ -343,8 +323,7 @@ public class ListObjectsParameters {
 	 * @param showOnlyDeleted true if only deleted objects should be listed
 	 * @return this ListObjectsParameters instance.
 	 */
-	public ListObjectsParameters withShowOnlyDeleted(
-			final boolean showOnlyDeleted) {
+	public ListObjectsParameters withShowOnlyDeleted(final boolean showOnlyDeleted) {
 		this.showOnlyDeleted = showOnlyDeleted;
 		return this;
 	}
@@ -360,8 +339,7 @@ public class ListObjectsParameters {
 	 * @param showAllVers true if all versions of objects should be listed
 	 * @return this ListObjectsParameters instance.
 	 */
-	public ListObjectsParameters withShowAllVersions(
-			final boolean showAllVers) {
+	public ListObjectsParameters withShowAllVersions(final boolean showAllVers) {
 		this.showAllVers = showAllVers;
 		return this;
 	}
@@ -398,8 +376,7 @@ public class ListObjectsParameters {
 	 * should be excluded.
 	 * @return this ListObjectsParameters instance.
 	 */
-	public ListObjectsParameters withExcludeGlobal(
-			final boolean excludeGlobal) {
+	public ListObjectsParameters withExcludeGlobal(final boolean excludeGlobal) {
 		this.excludeGlobal = excludeGlobal;
 		return this;
 	}
@@ -433,15 +410,11 @@ public class ListObjectsParameters {
 		return asAdmin;
 	}
 	
-	GetObjectInformationParameters generateParameters(
-			final PermissionSet perms) {
-		if (perms == null) {
-			throw new NullPointerException("perms cannot be null");
-		}
+	GetObjectInformationParameters generateParameters(final PermissionSet perms) {
 		return new GetObjectInformationParameters(
-				perms, type, savers, meta, after, before, minObjectID,
-				maxObjectID, showHidden, showDeleted, showOnlyDeleted,
-				showAllVers, includeMetaData, limit, asAdmin);
+				requireNonNull(perms, "perms cannot be null"), type, savers, meta, after, before,
+				minObjectID, maxObjectID, showHidden, showDeleted, showOnlyDeleted, showAllVers,
+				includeMetaData, limit, asAdmin);
 		
 	}
 }

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.Set;
 
 import org.bson.types.ObjectId;
@@ -414,8 +415,7 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		}
 	}
 
-	private static final Set<String> FLDS_CREATE_WS =
-			newHashSet(Fields.WS_DEL, Fields.WS_OWNER);
+	private static final Set<String> FLDS_CREATE_WS = newHashSet(Fields.WS_DEL, Fields.WS_OWNER);
 	
 	@Override
 	public WorkspaceInformation createWorkspace(
@@ -970,11 +970,7 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 	//http://stackoverflow.com/questions/2041778/initialize-java-hashset-values-by-construction
 	@SafeVarargs
 	private static <T> Set<T> newHashSet(T... objs) {
-		Set<T> set = new HashSet<T>();
-		for (T o : objs) {
-			set.add(o);
-		}
-		return set;
+		return Stream.of(objs).collect(Collectors.toSet());
 	}
 	
 	@Override
@@ -1325,7 +1321,8 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		final DBObject q = new BasicDBObject(Fields.WS_ID,
 				new BasicDBObject("$in", rwsis.keySet()));
 		if (owners != null && !owners.isEmpty()) {
-			q.put(Fields.WS_OWNER, new BasicDBObject("$in", convertWorkspaceUsers(owners)));
+			q.put(Fields.WS_OWNER, new BasicDBObject(
+					"$in", owners.stream().map(o -> o.getUser()).collect(Collectors.toList())));
 		}
 		if (meta != null && !meta.isEmpty()) {
 			final List<DBObject> andmetaq = new LinkedList<DBObject>();
@@ -1367,14 +1364,6 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		return ret;
 	}
 
-	private List<String> convertWorkspaceUsers(final List<WorkspaceUser> owners) {
-		final List<String> own = new ArrayList<String>();
-		for (final WorkspaceUser wu: owners) {
-			own.add(wu.getUser());
-		}
-		return own;
-	}
-	
 	@Override
 	public WorkspaceUser getWorkspaceOwner(final ResolvedWorkspaceID rwsi)
 			throws WorkspaceCommunicationException,

--- a/src/us/kbase/workspace/database/mongo/ObjectInfoUtils.java
+++ b/src/us/kbase/workspace/database/mongo/ObjectInfoUtils.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import us.kbase.workspace.database.GetObjectInformationParameters;
 import us.kbase.workspace.database.ObjectInformation;
@@ -47,14 +48,14 @@ public class ObjectInfoUtils {
 		this.query = requireNonNull(query, "query argument may not be null");
 	}
 	
-	private static final Set<String> FLDS_LIST_OBJ_VER = newHashSet(
+	private static final Set<String> FLDS_LIST_OBJ_VER = Stream.of(
 			Fields.VER_VER, Fields.VER_TYPE, Fields.VER_SAVEDATE,
 			Fields.VER_SAVEDBY, Fields.VER_VER, Fields.VER_CHKSUM,
-			Fields.VER_SIZE, Fields.VER_ID, Fields.VER_WS_ID);
+			Fields.VER_SIZE, Fields.VER_ID, Fields.VER_WS_ID).collect(Collectors.toSet());
 	
-	private static final Set<String> FLDS_LIST_OBJ = newHashSet(
+	private static final Set<String> FLDS_LIST_OBJ = Stream.of(
 			Fields.OBJ_ID, Fields.OBJ_NAME, Fields.OBJ_DEL, Fields.OBJ_HIDE,
-			Fields.OBJ_VCNT, Fields.OBJ_WS_ID);
+			Fields.OBJ_VCNT, Fields.OBJ_WS_ID).collect(Collectors.toSet());
 	
 	List<ObjectInformation> filter(final GetObjectInformationParameters params)
 			throws WorkspaceCommunicationException {
@@ -174,7 +175,8 @@ public class ObjectInfoUtils {
 		}
 		if (!params.getSavers().isEmpty()) {
 			verq.put(Fields.VER_SAVEDBY, new BasicDBObject(
-					"$in", convertWorkspaceUsers(params.getSavers())));
+					"$in", params.getSavers().stream().map(o -> o.getUser())
+							.collect(Collectors.toList())));
 		}
 		if (!params.getMetadata().isEmpty()) {
 			final List<DBObject> andmetaq = new LinkedList<DBObject>();
@@ -369,27 +371,5 @@ public class ObjectInfoUtils {
 			ret.get(wsid).put(objid, o);
 		}
 		return ret;
-	}
-	
-	/* the following methods are duplicated in MongoWorkspaceDB class, but so
-	 * simple not worth worrying about it
-	 */
-	private List<String> convertWorkspaceUsers(
-			final List<WorkspaceUser> owners) {
-		final List<String> own = new ArrayList<>();
-		for (final WorkspaceUser wu: owners) {
-			own.add(wu.getUser());
-		}
-		return own;
-	}
-	
-	//http://stackoverflow.com/questions/2041778/initialize-java-hashset-values-by-construction
-	@SafeVarargs
-	private static <T> Set<T> newHashSet(T... objs) {
-		Set<T> set = new HashSet<T>();
-		for (T o : objs) {
-			set.add(o);
-		}
-		return set;
 	}
 }

--- a/src/us/kbase/workspace/database/mongo/ObjectInfoUtils.java
+++ b/src/us/kbase/workspace/database/mongo/ObjectInfoUtils.java
@@ -1,5 +1,6 @@
 package us.kbase.workspace.database.mongo;
 
+import static java.util.Objects.requireNonNull;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import us.kbase.workspace.database.GetObjectInformationParameters;
 import us.kbase.workspace.database.ObjectInformation;
@@ -23,6 +25,7 @@ import us.kbase.workspace.database.WorkspaceUser;
 import us.kbase.workspace.database.exceptions.WorkspaceCommunicationException;
 
 import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import com.mongodb.MongoException;
@@ -41,10 +44,7 @@ public class ObjectInfoUtils {
 	private final QueryMethods query;
 	
 	ObjectInfoUtils(final QueryMethods query) {
-		if (query == null) {
-			throw new NullPointerException("query argument may not be null");
-		}
-		this.query = query;
+		this.query = requireNonNull(query, "query argument may not be null");
 	}
 	
 	private static final Set<String> FLDS_LIST_OBJ_VER = newHashSet(
@@ -56,8 +56,7 @@ public class ObjectInfoUtils {
 			Fields.OBJ_ID, Fields.OBJ_NAME, Fields.OBJ_DEL, Fields.OBJ_HIDE,
 			Fields.OBJ_VCNT, Fields.OBJ_WS_ID);
 	
-	List<ObjectInformation> filter(
-			final GetObjectInformationParameters params)
+	List<ObjectInformation> filter(final GetObjectInformationParameters params)
 			throws WorkspaceCommunicationException {
 		/* Could make this method more efficient by doing different queries
 		 * based on the filters. If there's no filters except the workspace,
@@ -69,8 +68,7 @@ public class ObjectInfoUtils {
 		
 		// if the limit = 1 don't want to keep querying for 1 object
 		// until one is found that's not deleted/hidden/early version
-		final int querysize = params.getLimit() < 100 ? 100 :
-				params.getLimit();
+		final int querysize = params.getLimit() < 100 ? 100 : params.getLimit();
 		final PermissionSet pset = params.getPermissionSet();
 		if (pset.isEmpty()) {
 			return new LinkedList<ObjectInformation>();
@@ -78,61 +76,48 @@ public class ObjectInfoUtils {
 		final DBObject verq = buildQuery(params);
 		final DBObject projection = buildProjection(params);
 		final DBObject sort = buildSortSpec(params);
-		final DBCursor cur = buildCursor(verq, projection, sort);
 		
 		//querying on versions directly so no need to worry about race 
 		//condition where the workspace object was saved but no versions
 		//were saved yet
 		
 		final List<ObjectInformation> ret = new LinkedList<>();
-		while (cur.hasNext() && ret.size() < params.getLimit()) {
-			final List<Map<String, Object>> verobjs = new ArrayList<>();
-			while (cur.hasNext() && verobjs.size() < querysize) {
-				try {
+		try (final DBCursor cur = getVersionCollection().find(verq, projection)) {
+			cur.sort(sort);
+			while (cur.hasNext() && ret.size() < params.getLimit()) {
+				final List<Map<String, Object>> verobjs = new ArrayList<>();
+				while (cur.hasNext() && verobjs.size() < querysize) {
 					verobjs.add(QueryMethods.dbObjectToMap(cur.next()));
-				} catch (MongoException me) {
-					throw new WorkspaceCommunicationException(
-							"There was a problem communicating with the database", me);
+				}
+				// this method accesses the DB, so we group calls to it to reduce transport time
+				final Map<Map<String, Object>, ObjectInformation> objs =
+						generateObjectInfo(pset, verobjs, params.isShowHidden(),
+								params.isShowDeleted(), params.isShowOnlyDeleted(),
+								params.isShowAllVersions(), params.asAdmin()
+								);
+				//maintain the ordering 
+				final Iterator<Map<String, Object>> veriter = verobjs.iterator();
+				while (veriter.hasNext() && ret.size() < params.getLimit()) {
+					final Map<String, Object> v = veriter.next();
+					if (objs.containsKey(v)) {
+						ret.add(objs.get(v));
+					}
 				}
 			}
-			final Map<Map<String, Object>, ObjectInformation> objs =
-					generateObjectInfo(pset, verobjs, params.isShowHidden(),
-							params.isShowDeleted(), params.isShowOnlyDeleted(),
-							params.isShowAllVersions(), params.asAdmin()
-							);
-			//maintain the ordering 
-			final Iterator<Map<String, Object>> veriter = verobjs.iterator();
-			while (veriter.hasNext() && ret.size() < params.getLimit()) {
-				final Map<String, Object> v = veriter.next();
-				if (objs.containsKey(v)) {
-					ret.add(objs.get(v));
-				}
-			}
-		}
-		return ret;
-	}
-
-	private DBCursor buildCursor(
-			final DBObject verq,
-			final DBObject projection,
-			final DBObject sort)
-			throws WorkspaceCommunicationException {
-		final DBCursor cur;
-		try {
-			cur = query.getDatabase().getCollection(query.getVersionCollection())
-					.find(verq, projection).sort(sort);
 		} catch (MongoException me) {
 			throw new WorkspaceCommunicationException(
 					"There was a problem communicating with the database", me);
 		}
-		return cur;
+		return ret;
+	}
+	
+	private DBCollection getVersionCollection() {
+		return query.getDatabase().getCollection(query.getVersionCollection());
 	}
 
 	private DBObject buildProjection(final GetObjectInformationParameters params) {
 		final DBObject projection = new BasicDBObject();
-		for (final String field: FLDS_LIST_OBJ_VER) {
-			projection.put(field, 1);
-		}
+		FLDS_LIST_OBJ_VER.forEach(field -> projection.put(field, 1));
 		if (params.isIncludeMetaData()) {
 			projection.put(Fields.VER_META, 1);
 		}
@@ -153,20 +138,34 @@ public class ObjectInfoUtils {
 	 */
 	private DBObject buildSortSpec(final GetObjectInformationParameters params) {
 		final DBObject sort = new BasicDBObject();
-		if (params.isObjectIDFiltersOnly()) {
+		if (isObjectIDFiltersOnly(params)) {
 			sort.put(Fields.VER_WS_ID, 1);
 			sort.put(Fields.VER_ID, 1);
 			sort.put(Fields.VER_VER, -1);
 		}
 		return sort;
 	}
+	
+	/* Check if there are no filters set other than the object ID filters. The object ID filters
+	 * may or may not be set.
+	 * The other filters are the two date filters, the metadata filter, the savers filter, and
+	 * the type filter.
+	 * @return true if no filters other than the object ID filters are set.
+	 */
+	private boolean isObjectIDFiltersOnly(final GetObjectInformationParameters params) {
+		// be really careful about modifying this function. See notes in this file.
+		boolean oidFiltersOnly = params.getAfter() == null;
+		oidFiltersOnly = oidFiltersOnly && params.getBefore() == null;
+		oidFiltersOnly = oidFiltersOnly && params.getMetadata().isEmpty();
+		oidFiltersOnly = oidFiltersOnly && params.getSavers().isEmpty();
+		// must have workspaces specified
+		oidFiltersOnly = oidFiltersOnly && params.getType() == null;
+		return oidFiltersOnly;
+	}
 
 	private DBObject buildQuery(final GetObjectInformationParameters params) {
-		final Set<Long> ids = new HashSet<Long>();
-		for (final ResolvedWorkspaceID rwsi:
-				params.getPermissionSet().getWorkspaces()) {
-			ids.add(rwsi.getID());
-		}
+		final Set<Long> ids = params.getPermissionSet().getWorkspaces().stream()
+				.map(ws -> ws.getID()).collect(Collectors.toSet());
 		final DBObject verq = new BasicDBObject();
 		verq.put(Fields.VER_WS_ID, new BasicDBObject("$in", ids));
 		if (params.getType() != null) {
@@ -179,8 +178,7 @@ public class ObjectInfoUtils {
 		}
 		if (!params.getMetadata().isEmpty()) {
 			final List<DBObject> andmetaq = new LinkedList<DBObject>();
-			for (final Entry<String, String> e:
-					params.getMetadata().getMetadata().entrySet()) {
+			for (final Entry<String, String> e: params.getMetadata().getMetadata().entrySet()) {
 				final DBObject mentry = new BasicDBObject();
 				mentry.put(Fields.META_KEY, e.getKey());
 				mentry.put(Fields.META_VALUE, e.getValue());
@@ -221,8 +219,7 @@ public class ObjectInfoUtils {
 			final boolean includeAllVers,
 			final boolean asAdmin)
 			throws WorkspaceCommunicationException {
-		final Map<Map<String, Object>, ObjectInformation> ret =
-				new HashMap<Map<String, Object>, ObjectInformation>();
+		final Map<Map<String, Object>, ObjectInformation> ret = new HashMap<>();
 		if (verobjs.isEmpty()) {
 			return ret;
 		}
@@ -232,15 +229,16 @@ public class ObjectInfoUtils {
 		}
 		final Map<Long, Set<Long>> verdata = getObjectIDsFromVersions(verobjs);
 		//TODO PERFORMANCE This $or query might be better as multiple individual queries, test
-		final List<DBObject> orquery = new LinkedList<DBObject>();
+		// e.g. one workspace per query
+		final List<DBObject> orquery = new LinkedList<>();
 		for (final Long wsid: verdata.keySet()) {
 			final DBObject query = new BasicDBObject(Fields.VER_WS_ID, wsid);
 			query.put(Fields.VER_ID, new BasicDBObject("$in", verdata.get(wsid)));
 			orquery.add(query);
 		}
 		final DBObject objq = new BasicDBObject("$or", orquery);
-		//could include / exclude hidden and deleted objects here? Prob
-		// not worth the effort
+		//could include / exclude hidden and deleted objects here? Given reports are hidden
+		// and a large chunk of the objects might make sense
 		//we're querying with known versions, so there's no need to exclude
 		//workspace objects with 0 versions
 		final Map<Long, Map<Long, Map<String, Object>>> objdata =
@@ -287,12 +285,13 @@ public class ObjectInfoUtils {
 	
 	static ObjectInformation generateObjectInfo(
 			final ResolvedObjectID roi, final Map<String, Object> ver) {
-		return generateObjectInfo(roi.getWorkspaceIdentifier(), roi.getId(),
-				roi.getName(), ver);
+		return generateObjectInfo(roi.getWorkspaceIdentifier(), roi.getId(), roi.getName(), ver);
 	}
 	
 	static ObjectInformation generateObjectInfo(
-			final ResolvedWorkspaceID rwsi, final long objid, final String name,
+			final ResolvedWorkspaceID rwsi,
+			final long objid,
+			final String name,
 			final Map<String, Object> ver) {
 		@SuppressWarnings("unchecked")
 		final List<Map<String, String>> meta =
@@ -307,13 +306,12 @@ public class ObjectInfoUtils {
 				rwsi,
 				(String) ver.get(Fields.VER_CHKSUM),
 				(Long) ver.get(Fields.VER_SIZE),
-				meta == null ? null : new UncheckedUserMetadata(
-						metaMongoArrayToHash(meta)));
+				meta == null ? null : new UncheckedUserMetadata(metaMongoArrayToHash(meta)));
 	}
 	
 	static Map<String, String> metaMongoArrayToHash(
 			final List<? extends Object> meta) {
-		final Map<String, String> ret = new HashMap<String, String>();
+		final Map<String, String> ret = new HashMap<>();
 		if (meta != null) {
 			for (final Object o: meta) {
 				//frigging mongo
@@ -324,8 +322,7 @@ public class ObjectInfoUtils {
 				} else {
 					@SuppressWarnings("unchecked")
 					final Map<String, String> m = (Map<String, String>) o;
-					ret.put(m.get(Fields.META_KEY),
-							m.get(Fields.META_VALUE));
+					ret.put(m.get(Fields.META_KEY), m.get(Fields.META_VALUE));
 				}
 			}
 		}
@@ -334,11 +331,10 @@ public class ObjectInfoUtils {
 	
 	static List<Map<String, String>> metaHashToMongoArray(
 			final Map<String, String> usermeta) {
-		final List<Map<String, String>> meta = 
-				new ArrayList<Map<String, String>>();
+		final List<Map<String, String>> meta = new ArrayList<>();
 		if (usermeta != null) {
 			for (String key: usermeta.keySet()) {
-				Map<String, String> m = new LinkedHashMap<String, String>(2);
+				Map<String, String> m = new LinkedHashMap<>(2);
 				m.put(Fields.META_KEY, key);
 				m.put(Fields.META_VALUE, usermeta.get(key));
 				meta.add(m);
@@ -349,12 +345,12 @@ public class ObjectInfoUtils {
 	
 	private Map<Long, Set<Long>> getObjectIDsFromVersions(
 			final List<Map<String, Object>> objs) {
-		final Map<Long, Set<Long>> ret = new HashMap<Long, Set<Long>>();
+		final Map<Long, Set<Long>> ret = new HashMap<>();
 		for (final Map<String, Object> o: objs) {
 			final long wsid = (Long) o.get(Fields.VER_WS_ID);
 			final long objid = (Long) o.get(Fields.VER_ID);
 			if (!ret.containsKey(wsid)) {
-				ret.put(wsid, new HashSet<Long>());
+				ret.put(wsid, new HashSet<>());
 			}
 			ret.get(wsid).add(objid);
 		}
@@ -363,13 +359,12 @@ public class ObjectInfoUtils {
 	
 	private Map<Long, Map<Long, Map<String, Object>>> organizeObjData(
 			final List<Map<String, Object>> objs) {
-		final Map<Long, Map<Long, Map<String, Object>>> ret =
-				new HashMap<Long, Map<Long,Map<String,Object>>>();
+		final Map<Long, Map<Long, Map<String, Object>>> ret = new HashMap<>();
 		for (final Map<String, Object> o: objs) {
 			final long wsid = (Long) o.get(Fields.OBJ_WS_ID);
 			final long objid = (Long) o.get(Fields.OBJ_ID);
 			if (!ret.containsKey(wsid)) {
-				ret.put(wsid, new HashMap<Long, Map<String, Object>>());
+				ret.put(wsid, new HashMap<>());
 			}
 			ret.get(wsid).put(objid, o);
 		}
@@ -381,7 +376,7 @@ public class ObjectInfoUtils {
 	 */
 	private List<String> convertWorkspaceUsers(
 			final List<WorkspaceUser> owners) {
-		final List<String> own = new ArrayList<String>();
+		final List<String> own = new ArrayList<>();
 		for (final WorkspaceUser wu: owners) {
 			own.add(wu.getUser());
 		}


### PR DESCRIPTION
A little cleanup before adding new features. No behavioral changes.
Major changes are:

* use try-with-resources to ensure `DBCursor` is always closed
* Move `isObjectIDFiltersOnly` from the parameters value class to the object lister
  class. Really doesn't make sense where it is, and makes it harder to alter later if it's generally accessible.
* Inline a few functions that can be simplified to one line with `.stream()`