### PR TITLE
Remove unused cruft, force cursor close

### DIFF
--- a/src/us/kbase/typedobj/db/MongoTypeStorage.java
+++ b/src/us/kbase/typedobj/db/MongoTypeStorage.java
@@ -375,10 +375,11 @@ public class MongoTypeStorage implements TypeStorage {
 			final DBObject whereCondition,
 			final BasicDBObject projection,
 			final Class<T> clazz) {
-		final DBCursor find = col.find(whereCondition, projection);
 		final List<T> data = new LinkedList<>();
-		for (final DBObject dbo: find) {
-			data.add(toObj(dbo, clazz));
+		try (final DBCursor find = col.find(whereCondition, projection)) {
+			for (final DBObject dbo: find) {
+				data.add(toObj(dbo, clazz));
+			}
 		}
 		return data;
 	}
@@ -403,10 +404,11 @@ public class MongoTypeStorage implements TypeStorage {
 			final DBObject whereCondition,
 			final BasicDBObject projection,
 			final TypeReference<T> tr) {
-		final DBCursor find = col.find(whereCondition, projection);
 		final List<T> data = new LinkedList<>();
-		for (final DBObject dbo: find) {
-			data.add(toObj(dbo, tr));
+		try (final DBCursor find = col.find(whereCondition, projection)) {
+			for (final DBObject dbo: find) {
+				data.add(toObj(dbo, tr));
+			}
 		}
 		return data;
 	}

--- a/src/us/kbase/workspace/database/GetObjectInformationParameters.java
+++ b/src/us/kbase/workspace/database/GetObjectInformationParameters.java
@@ -13,6 +13,8 @@ import us.kbase.typedobj.core.TypeDefId;
  */
 public class GetObjectInformationParameters {
 	
+	// TODO TEST unit tests although this is pretty trivial stuff
+	
 	final private PermissionSet pset;
 	final private TypeDefId type;
 	final private List<WorkspaceUser> savers;

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -563,8 +563,7 @@ public class Workspace {
 		final Map<WorkspaceIdentifier, ResolvedWorkspaceID> rwslist =
 				db.resolveWorkspaces(new HashSet<WorkspaceIdentifier>(wslist));
 		final Map<ResolvedWorkspaceID, Map<User, Permission>> perms =
-				db.getAllPermissions(new HashSet<ResolvedWorkspaceID>(
-						rwslist.values()));
+				db.getAllPermissions(new HashSet<ResolvedWorkspaceID>(rwslist.values()));
 		final List<Map<User, Permission>> ret = new LinkedList<Map<User,Permission>>();
 		for (final WorkspaceIdentifier wsi: wslist) {
 			final ResolvedWorkspaceID rwsi = rwslist.get(wsi);
@@ -1010,8 +1009,7 @@ public class Workspace {
 		return new UserWorkspaceIDs(user, minPerm, workspaceIDs, publicIDs);
 	}
 	
-	public List<ObjectInformation> listObjects(
-			final ListObjectsParameters params)
+	public List<ObjectInformation> listObjects(final ListObjectsParameters params)
 			throws CorruptWorkspaceDBException, NoSuchWorkspaceException,
 				WorkspaceCommunicationException, WorkspaceAuthorizationException {
 
@@ -1022,6 +1020,9 @@ public class Workspace {
 				params.getMinimumPermission(), params.isExcludeGlobal(), true, params.asAdmin());
 		rw.clear();
 		if (!params.asAdmin()) {
+			// I don't understand why this is here. Seems like the db call above will only
+			// return readable workspaces unless the user is an admin
+			// At some point, but not now, should investigate further and maybe remove
 			for (final WorkspaceIdentifier wsi: params.getWorkspaces()) {
 				PermissionsCheckerFactory.comparePermission(params.getUser(), Permission.READ,
 						pset.getPermission(rwsis.get(wsi)), wsi, "read");

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -1070,17 +1070,9 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 	@Override
 	public Map<ResolvedWorkspaceID, Map<User, Permission>> getAllPermissions(
 			final Set<ResolvedWorkspaceID> rwsis)
-			throws WorkspaceCommunicationException,
-			CorruptWorkspaceDBException {
-		final Map<ResolvedWorkspaceID, Map<User, Permission>> res =
-				query.queryPermissions(rwsis, null);
-		final Map<ResolvedWorkspaceID, Map<User, Permission>> ret = 
-				new HashMap<ResolvedWorkspaceID, Map<User, Permission>>();
-		//probably a better way to do this
-		for (final ResolvedWorkspaceID r: res.keySet()) {
-			ret.put((ResolvedWorkspaceID)r, res.get(r)); 
-		}
-		return ret;
+			throws WorkspaceCommunicationException, CorruptWorkspaceDBException {
+		// TODO CODE error on null or empty input
+		return query.queryPermissions(rwsis, null);
 	}
 	
 	@Override
@@ -1128,21 +1120,19 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 		}
 		final Map<ResolvedWorkspaceID, Map<User, Permission>> userperms;
 		if (user != null) {
-			userperms = query.queryPermissions(rwsis, new HashSet<User>(Arrays.asList(user)),
-					perm, excludeDeletedWorkspaces);
+			userperms = query.queryPermissions(rwsis, user, perm, excludeDeletedWorkspaces);
 		} else {
-			userperms = new HashMap<ResolvedWorkspaceID, Map<User,Permission>>();
+			userperms = new HashMap<>();
 		}
-		final Set<User> allusers = new HashSet<User>(Arrays.asList(ALL_USERS));
 		final Map<ResolvedWorkspaceID, Map<User, Permission>> globalperms;
 		if (excludeGlobalRead || perm.compareTo(Permission.WRITE) >= 0) {
 			if (userperms.isEmpty()) {
-				globalperms = new HashMap<ResolvedWorkspaceID, Map<User,Permission>>();
+				globalperms = new HashMap<>();
 			} else {
-				globalperms = query.queryPermissions(userperms.keySet(), allusers);
+				globalperms = query.queryPermissions(userperms.keySet(), ALL_USERS);
 			}
 		} else {
-			globalperms = query.queryPermissions(rwsis, allusers,
+			globalperms = query.queryPermissions(rwsis, ALL_USERS,
 					Permission.READ, excludeDeletedWorkspaces);
 		}
 		return buildPermissionSet(user, rwsis, userperms, globalperms, includeProvidedWorkspaces);

--- a/src/us/kbase/workspace/database/mongo/ObjectLister.java
+++ b/src/us/kbase/workspace/database/mongo/ObjectLister.java
@@ -74,7 +74,7 @@ public class ObjectLister {
 				while (cur.hasNext() && verobjs.size() < querysize) {
 					verobjs.add(QueryMethods.dbObjectToMap(cur.next()));
 				}
-				// this method accesses the DB, so we group calls to it to reduce transport time
+				// this method accesses the DB, so we batch calls to it to reduce transport time
 				final Map<Map<String, Object>, ObjectInformation> objs =
 						infoUtils.generateObjectInfo(pset, verobjs, params.isShowHidden(),
 								params.isShowDeleted(), params.isShowOnlyDeleted(),

--- a/src/us/kbase/workspace/database/mongo/QueryMethods.java
+++ b/src/us/kbase/workspace/database/mongo/QueryMethods.java
@@ -443,9 +443,8 @@ public class QueryMethods {
 			throws WorkspaceCommunicationException {
 		final List<Map<String, Object>> result =
 				new ArrayList<Map<String,Object>>();
-		try {
-			final DBCursor im = queryCollectionCursor(
-					collection, query, fields, queryHint, limit);
+		try (final DBCursor im = queryCollectionCursor(
+				collection, query, fields, queryHint, limit)) {
 			for (final DBObject o: im) {
 				result.add(dbObjectToMap(o));
 			}


### PR DESCRIPTION
For some reason getting the list of workspaces to which a user had
access allows specifying multiple users, which confused the hell out of
me. Turns out this feature and a couple of helper methods are unused, so
in the garbage they go.

Also some other minor cruft cleanup and force cursors to close.