### PR TITLE
Add a RefLimit class for specifying limits based on refs

### DIFF
--- a/src/us/kbase/workspace/database/RefLimit.java
+++ b/src/us/kbase/workspace/database/RefLimit.java
@@ -1,0 +1,127 @@
+package us.kbase.workspace.database;
+
+import java.util.Optional;
+
+/** Specifies a workspace ref in the form X/Y/Z where X, Y, and Z are the workspace integer ID,
+ * object integer ID, and version, that limits the scope of an operation - for example, paging
+ * through objects.
+ *
+ */
+public class RefLimit {
+	
+	private static final RefLimit EMPTY = new RefLimit(null, null, null);
+	
+	private final Optional<Long> wsid;
+	private final Optional<Long> objid;
+	private final Optional<Integer> ver;
+	
+	private RefLimit(final Long wsid, final Long objid, final Integer ver) {
+		this.wsid = wsid == null || wsid < 1 ? Optional.empty() : Optional.of(wsid);
+		this.objid = objid == null || objid < 1 ? Optional.empty() : Optional.of(objid);
+		this.ver = ver== null || ver < 1 ? Optional.empty() : Optional.of(ver);
+		if (this.ver.isPresent() && (!this.objid.isPresent() || !this.wsid.isPresent())) {
+			throw new IllegalArgumentException("If a version is specified in a reference " +
+					"limit the object ID and workspace ID must also be specified");
+		}
+		if (this.objid.isPresent() && !this.wsid.isPresent()) {
+			throw new IllegalArgumentException("If an object ID is specified in a reference " +
+					"limit the workspace ID must also be specified");
+		}
+	}
+	
+	/** Get a reference limit containing no limiting information.
+	 * @return the limit.
+	 */
+	public static RefLimit buildEmpty() {
+		return EMPTY;
+	}
+	
+	/** Create the limit. Specify null or  numbers < 1 to denote that the limit should start at
+	 * the beginning of the containing item (e.g. a version < 1 means the limit should start
+	 * at the first or last version, depending on context, and an object ID < 1 means the limit
+	 * should start at the first or last object, etc). A workspace or object ID may not be
+	 * omitted if the version is included, and an object ID may not be omitted if a workspace is
+	 * included.
+	 * @param wsid - the workspace ID
+	 * @param objid - the object ID
+	 * @param ver - the version
+	 */
+	public static RefLimit build(final Long wsid, final Long objid, final Integer ver) {
+		final RefLimit rl = new RefLimit(wsid, objid, ver);
+		return rl.isEmpty() ? EMPTY: rl;
+	}
+
+	/** Get the limit for the workspace ID, if any.
+	 * @return the workspace ID
+	 */
+	public Optional<Long> getWorkspaceID() {
+		return wsid;
+	}
+
+	/** Get the limit for the object ID, if any.
+	 * @return the object ID
+	 */
+	public Optional<Long> getObjectID() {
+		return objid;
+	}
+
+	/** Get the limit for the version, if any.
+	 * @return the version
+	 */
+	public Optional<Integer> getVersion() {
+		return ver;
+	}
+
+	/** Determine whether this limit contains limiting information.
+	 * E.g, at least a workspace ID is specified. 
+	 * @return True if there is limiting information.
+	 */
+	public boolean isPresent() {
+		return wsid.isPresent();
+	}
+	
+	/** Determine whether this limit contains limiting information.
+	 * E.g, at least a workspace ID is specified. 
+	 * @return True if there is no limiting information.
+	 */
+	public boolean isEmpty() {
+		return !wsid.isPresent();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((objid == null) ? 0 : objid.hashCode());
+		result = prime * result + ((ver == null) ? 0 : ver.hashCode());
+		result = prime * result + ((wsid == null) ? 0 : wsid.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		RefLimit other = (RefLimit) obj;
+		if (objid == null) {
+			if (other.objid != null)
+				return false;
+		} else if (!objid.equals(other.objid))
+			return false;
+		if (ver == null) {
+			if (other.ver != null)
+				return false;
+		} else if (!ver.equals(other.ver))
+			return false;
+		if (wsid == null) {
+			if (other.wsid != null)
+				return false;
+		} else if (!wsid.equals(other.wsid))
+			return false;
+		return true;
+	}
+}

--- a/src/us/kbase/workspace/database/Reference.java
+++ b/src/us/kbase/workspace/database/Reference.java
@@ -47,7 +47,7 @@ public class Reference implements RemappedId {
 		version = oi.getVersion();
 	}
 
-	/** Returns the ID of the workspac for this object.
+	/** Returns the ID of the workspace for this object.
 	 * @return the workspace ID.
 	 */
 	public long getWorkspaceID() {

--- a/src/us/kbase/workspace/test/workspace/RefLimitTest.java
+++ b/src/us/kbase/workspace/test/workspace/RefLimitTest.java
@@ -1,0 +1,128 @@
+package us.kbase.workspace.test.workspace;
+
+import static us.kbase.common.test.TestCommon.assertExceptionCorrect;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import us.kbase.workspace.database.RefLimit;
+
+public class RefLimitTest {
+	
+	@Test
+	public void equals() throws Exception {
+		EqualsVerifier.forClass(RefLimit.class).usingGetClass().verify();
+	}
+	
+	@Test
+	public void buildEmpty() throws Exception {
+		final RefLimit rl1 = RefLimit.buildEmpty();
+		final RefLimit rl2 = RefLimit.build(null, null, null);
+		final RefLimit rl3 = RefLimit.build(0L, 0L, 0);
+		final RefLimit rl4 = RefLimit.build(-100L, -100L, -100);
+		
+		for (final RefLimit rl: Arrays.asList(rl1, rl2, rl3, rl4)) {
+			
+			assertThat("incorrect wsid", rl.getWorkspaceID(), is(Optional.empty()));
+			assertThat("incorrect objid", rl.getObjectID(), is(Optional.empty()));
+			assertThat("incorrect ver", rl.getVersion(), is(Optional.empty()));
+			assertThat("incorrect present", rl.isPresent(), is(false));
+			assertThat("incorrect present", rl.isEmpty(), is(true));
+		}	
+	}
+	
+	public void buildWithWsid() throws Exception {
+		RefLimit rl = RefLimit.build(1L, null, null);
+		
+		assertThat("incorrect wsid", rl.getWorkspaceID(), is(Optional.of(1L)));
+		assertThat("incorrect objid", rl.getObjectID(), is(Optional.empty()));
+		assertThat("incorrect ver", rl.getVersion(), is(Optional.empty()));
+		assertThat("incorrect present", rl.isPresent(), is(true));
+		assertThat("incorrect present", rl.isEmpty(), is(false));
+
+		rl = RefLimit.build(10L, null, null);
+		
+		assertThat("incorrect wsid", rl.getWorkspaceID(), is(Optional.of(10L)));
+		assertThat("incorrect objid", rl.getObjectID(), is(Optional.empty()));
+		assertThat("incorrect ver", rl.getVersion(), is(Optional.empty()));
+		assertThat("incorrect present", rl.isPresent(), is(true));
+		assertThat("incorrect present", rl.isEmpty(), is(false));
+	}
+	
+	@Test
+	public void buildWithObjId() throws Exception {
+		RefLimit rl = RefLimit.build(1L, 1L, null);
+		
+		assertThat("incorrect wsid", rl.getWorkspaceID(), is(Optional.of(1L)));
+		assertThat("incorrect objid", rl.getObjectID(), is(Optional.of(1L)));
+		assertThat("incorrect ver", rl.getVersion(), is(Optional.empty()));
+		assertThat("incorrect present", rl.isPresent(), is(true));
+		assertThat("incorrect present", rl.isEmpty(), is(false));
+
+		rl = RefLimit.build(1L, 7L, null);
+		
+		assertThat("incorrect wsid", rl.getWorkspaceID(), is(Optional.of(1L)));
+		assertThat("incorrect objid", rl.getObjectID(), is(Optional.of(7L)));
+		assertThat("incorrect ver", rl.getVersion(), is(Optional.empty()));
+		assertThat("incorrect present", rl.isPresent(), is(true));
+		assertThat("incorrect present", rl.isEmpty(), is(false));
+	}
+	
+	@Test
+	public void buildWithVer() throws Exception {
+		RefLimit rl = RefLimit.build(1L, 1L, 1);
+		
+		assertThat("incorrect wsid", rl.getWorkspaceID(), is(Optional.of(1L)));
+		assertThat("incorrect objid", rl.getObjectID(), is(Optional.of(1L)));
+		assertThat("incorrect ver", rl.getVersion(), is(Optional.of(1)));
+		assertThat("incorrect present", rl.isPresent(), is(true));
+		assertThat("incorrect present", rl.isEmpty(), is(false));
+
+		rl = RefLimit.build(1L, 1L, 42);
+		
+		assertThat("incorrect wsid", rl.getWorkspaceID(), is(Optional.of(1L)));
+		assertThat("incorrect objid", rl.getObjectID(), is(Optional.of(1L)));
+		assertThat("incorrect ver", rl.getVersion(), is(Optional.of(42)));
+		assertThat("incorrect present", rl.isPresent(), is(true));
+		assertThat("incorrect present", rl.isEmpty(), is(false));
+	}
+
+	@Test
+	public void buildFail() throws Exception {
+		final String err1 = "If a version is specified in a reference limit the object ID " +
+				"and workspace ID must also be specified";
+		failBuild(null, null, 1, new IllegalArgumentException(err1));
+		failBuild(0L, 0L, 1, new IllegalArgumentException(err1));
+		failBuild(1L, null, 1, new IllegalArgumentException(err1));
+		failBuild(1L, 0L, 1, new IllegalArgumentException(err1));
+		failBuild(null, 1L, 1, new IllegalArgumentException(err1));
+		failBuild(0L, 1L, 1, new IllegalArgumentException(err1));
+		
+		final String err2 = "If an object ID is specified in a reference limit the " +
+				"workspace ID must also be specified";
+		failBuild(null, 1L, null, new IllegalArgumentException(err2));
+		failBuild(0L, 1L, null, new IllegalArgumentException(err2));
+	}
+	
+	private void failBuild(
+			final Long wsid,
+			final Long objid,
+			final Integer ver,
+			final Exception expected) {
+		try {
+			RefLimit.build(wsid, objid, ver);
+			fail("expected exception");
+		} catch (Exception got) {
+			assertExceptionCorrect(got, expected);
+		}
+		
+	}
+
+
+}


### PR DESCRIPTION
surprisingly.

Will be used for paging through the list objects results. Better than
the current min and max object IDs because
1. multiple workspaces are supported, and
2. versions are supported