### PR TITLE
Move the getTypeStringMajorVersion method from abs type def to regular

### DIFF
--- a/src/us/kbase/typedobj/core/AbsoluteTypeDefId.java
+++ b/src/us/kbase/typedobj/core/AbsoluteTypeDefId.java
@@ -51,13 +51,6 @@ public class AbsoluteTypeDefId extends TypeDefId {
 		return fromTypeId(TypeDefId.fromTypeString(type));
 	}
 	
-	/** Get the type string including the major version, e.g. Module.Type-1.
-	 * @return the type string
-	 */
-	public String getTypeStringMajorVersion() {
-		return type.getTypeString() + TYPE_VER_SEP + majorVersion;
-	}
-	
 	@Override
 	public String toString() {
 		return "AbsoluteTypeDefId [type=" + type + ", majorVersion=" +

--- a/src/us/kbase/typedobj/core/TypeDefId.java
+++ b/src/us/kbase/typedobj/core/TypeDefId.java
@@ -191,6 +191,17 @@ public class TypeDefId {
 		return t;
 	}
 	
+	/** Get the type string including the major version, e.g. Module.Type-1.
+	 * @return the type string
+	 * @throws IllegalStateException if the major version is not present.
+	 */
+	public String getTypeStringMajorVersion() {
+		if (majorVersion == null) {
+			throw new IllegalStateException("The major type version is not present");
+		}
+		return type.getTypeString() + TYPE_VER_SEP + majorVersion;
+	}
+	
 	public String getVerString() {
 		if (majorVersion == null) {
 			if (md5 != null) {

--- a/src/us/kbase/typedobj/test/AbsoluteTypeDefIdTest.java
+++ b/src/us/kbase/typedobj/test/AbsoluteTypeDefIdTest.java
@@ -16,7 +16,7 @@ import us.kbase.typedobj.core.TypeDefName;
  * 
  */
 
-public class AbsoluteTypeDefTest {
+public class AbsoluteTypeDefIdTest {
 
 	@Test
 	public void getTypeStringMajorVersion() throws Exception {

--- a/src/us/kbase/typedobj/test/TypeDefIdTest.java
+++ b/src/us/kbase/typedobj/test/TypeDefIdTest.java
@@ -1,0 +1,44 @@
+package us.kbase.typedobj.test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static us.kbase.common.test.TestCommon.assertExceptionCorrect;
+
+import org.junit.Test;
+
+import us.kbase.typedobj.core.TypeDefId;
+import us.kbase.typedobj.core.TypeDefName;
+
+/* Note most tests are currently in TypeDefsTest.java. They should be cleaned up, completed,
+ * and moved here.
+ * Additionally, splitting both type classes into MD5 based types and standard types should
+ * be explored, but that's quite a bit of work and requires tracing a lot of code paths to
+ * see if they accept either kind of type.
+ * 
+ */
+
+public class TypeDefIdTest {
+
+	@Test
+	public void getTypeStringMajorVersion() throws Exception {
+		TypeDefId t = new TypeDefId(new TypeDefName("Mod.Type"), 3, 1);
+		assertThat("incorrect type string", t.getTypeStringMajorVersion(), is("Mod.Type-3"));
+		
+		t = new TypeDefId(new TypeDefName("Mod.Type"), 3);
+		assertThat("incorrect type string", t.getTypeStringMajorVersion(), is("Mod.Type-3"));
+	}
+	
+	@Test
+	public void getTypeStringMajorVersionFail() throws Exception {
+		final TypeDefId t = new TypeDefId(new TypeDefName("Mod.Type"));
+		try {
+			t.getTypeStringMajorVersion();
+			fail("expected exception");
+		} catch (Exception got) {
+			assertExceptionCorrect(got, new IllegalStateException(
+					"The major type version is not present"));
+		}
+		
+	}
+}


### PR DESCRIPTION
Needed for both classes and abs inherits from regular.

Also fix test name.