### PR TITLE
Revamp indexing strategy for types

### DIFF
--- a/src/us/kbase/workspace/database/mongo/Fields.java
+++ b/src/us/kbase/workspace/database/mongo/Fields.java
@@ -55,11 +55,14 @@ public class Fields {
 	public static final String VER_REF = "refs";
 	public static final String VER_PROVREF = "provrefs";
 	// the full type string, e.g. Module.Type-3.4
+	// TODO CODE kept to allow for rollbacks, but unused at this point. remove in future
 	public static final String VER_TYPE_FULL = "type";
-	// the type string with the major version, e.g. Module.Type-3
-	public static final String VER_TYPE_WITH_MAJOR_VERSION = "tymaj";
 	// the type name only as a type string, e.g. Module.Type
 	public static final String VER_TYPE_NAME = "tyname";
+	// the major version of the type, e.g. 3
+	public static final String VER_TYPE_MAJOR_VERSION = "tymaj";
+	// the minor version of the type, e.g. 4
+	public static final String VER_TYPE_MINOR_VERSION = "tymin";
 	public static final String VER_SIZE = "size";
 	public static final String VER_RVRT = "revert";
 	public static final String VER_META = "meta";

--- a/src/us/kbase/workspace/database/mongo/ObjectInfoUtils.java
+++ b/src/us/kbase/workspace/database/mongo/ObjectInfoUtils.java
@@ -13,6 +13,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import us.kbase.typedobj.core.TypeDefId;
+import us.kbase.typedobj.core.TypeDefName;
 import us.kbase.workspace.database.ObjectInformation;
 import us.kbase.workspace.database.Permission;
 import us.kbase.workspace.database.PermissionSet;
@@ -132,10 +134,14 @@ public class ObjectInfoUtils {
 		@SuppressWarnings("unchecked")
 		final List<Map<String, String>> meta =
 				(List<Map<String, String>>) ver.get(Fields.VER_META);
+		final TypeDefId type = new TypeDefId(
+				new TypeDefName((String) ver.get(Fields.VER_TYPE_NAME)),
+				(int) ver.get(Fields.VER_TYPE_MAJOR_VERSION),
+				(int) ver.get(Fields.VER_TYPE_MINOR_VERSION));
 		return new ObjectInformation(
 				objid,
 				name,
-				(String) ver.get(Fields.VER_TYPE_FULL),
+				type.getTypeString(),
 				(Date) ver.get(Fields.VER_SAVEDATE),
 				(Integer) ver.get(Fields.VER_VER),
 				new WorkspaceUser((String) ver.get(Fields.VER_SAVEDBY)),

--- a/src/us/kbase/workspace/test/database/mongo/MongoStartUpTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoStartUpTest.java
@@ -307,19 +307,20 @@ public class MongoStartUpTest {
 						.append("name", "ws_1_id_1_ver_-1")
 						.append("ns", "MongoStartUpTest.workspaceObjVersions"),
 				new Document("v", INDEX_VER)
-						.append("key", new Document("type", 1).append("ws", 1).append("id", 1)
-								.append("ver", -1))
-						.append("name", "type_1_ws_1_id_1_ver_-1")
+						.append("key", new Document("tyname", 1)
+								.append("tymaj", 1).append("tymin", 1)
+								.append("ws", 1).append("id", 1).append("ver", -1))
+						.append("name", "tyname_1_tymaj_1_tymin_1_ws_1_id_1_ver_-1")
 						.append("ns", "MongoStartUpTest.workspaceObjVersions"),
 				new Document("v", INDEX_VER)
-						.append("key", new Document("tyname", 1).append("ws", 1).append("id", 1)
-								.append("ver", -1))
+						.append("key", new Document("tyname", 1).append("tymaj", 1)
+								.append("ws", 1).append("id", 1).append("ver", -1))
+						.append("name", "tyname_1_tymaj_1_ws_1_id_1_ver_-1")
+						.append("ns", "MongoStartUpTest.workspaceObjVersions"),
+				new Document("v", INDEX_VER)
+						.append("key", new Document("tyname", 1)
+								.append("ws", 1).append("id", 1).append("ver", -1))
 						.append("name", "tyname_1_ws_1_id_1_ver_-1")
-						.append("ns", "MongoStartUpTest.workspaceObjVersions"),
-				new Document("v", INDEX_VER)
-						.append("key", new Document("tymaj", 1).append("ws", 1).append("id", 1)
-								.append("ver", -1))
-						.append("name", "tymaj_1_ws_1_id_1_ver_-1")
 						.append("ns", "MongoStartUpTest.workspaceObjVersions"),
 				new Document("v", INDEX_VER)
 						.append("key", new Document("provenance", 1))


### PR DESCRIPTION
The old strategy required duplicating the type name 3 times in the
object version document. The new strategy has 2 duplications and longer
term one of them can be removed.