### PR TITLE
Switch from the Mongo 2.X api to the 3.0 API.

### DIFF
--- a/docsource/releasenotes.rst
+++ b/docsource/releasenotes.rst
@@ -17,6 +17,12 @@ BACKWARDS INCOMPATIBILITIES:
   search prototype event handler is configured.
 * The WorkspaceEventListener interface now includes a setObjectHidden method. Code using this
   interface must be updated to implement this method.
+* The MongoDB driver API has been updated from the 2.X driver legacy interface to
+  the new interface introduced in the 3.0 driver. This change is invisible other than the
+  ``sorted`` key in ``GridFS`` file documents has been moved to the new ``metadata``
+  field from the root of the document. Since the ``GridFS`` backend is not recommended for
+  production use and no known productions installations exist, a schema updater for the GridFS
+  backend is not provided.
 
 UPDATES:
 

--- a/performance/us/kbase/workspace/performance/refsearch/v0_3_5/GetReferencedObjectWithBFS.java
+++ b/performance/us/kbase/workspace/performance/refsearch/v0_3_5/GetReferencedObjectWithBFS.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 import org.slf4j.LoggerFactory;
 
-import us.kbase.common.mongo.GetMongoDB;
+import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.typedobj.core.AbsoluteTypeDefId;
 import us.kbase.typedobj.core.TempFilesManager;
@@ -34,11 +34,11 @@ import us.kbase.workspace.database.WorkspaceSaveObject;
 import us.kbase.workspace.database.WorkspaceUser;
 //import us.kbase.workspace.database.mongo.GridFSBlobStore;
 //import us.kbase.workspace.database.mongo.MongoWorkspaceDB;
-import us.kbase.workspace.test.WorkspaceTestCommon;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 
-import com.mongodb.DB;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 /** 
  * NOTE: This code is provided only as a reference - it was written against a much older version of
@@ -73,7 +73,7 @@ public class GetReferencedObjectWithBFS {
 					new TypeDefName(MOD_NAME_STR, REF_TYPE_STR), 1, 0);
 	
 	private static Workspace WS;
-	private static DB WSDB;
+	private static MongoDatabase WSDB;
 
 	public static void main(String[] args) throws Exception {
 		final Logger rootLogger = ((Logger) LoggerFactory.getLogger(
@@ -86,10 +86,12 @@ public class GetReferencedObjectWithBFS {
 				USE_WIRED_TIGER);
 		System.out.println("Using Mongo temp dir " + mongo.getTempDir());
 		System.out.println("Mongo port: " + mongo.getServerPort());
-		WSDB = GetMongoDB.getDB("localhost:" + mongo.getServerPort(),
-				"GetReferencedObjectBFSTest");
-		WorkspaceTestCommon.destroyWSandTypeDBs(WSDB,
-				"GetReferencedObjectBFSTest_types");
+		@SuppressWarnings("resource")
+		final MongoClient mc = new MongoClient("localhost:" + mongo.getServerPort());
+		WSDB = mc.getDatabase("GetReferencedObjectBFSTest");
+		final MongoDatabase tdb = mc.getDatabase("GetReferencedObjectBFSTest_types");
+		TestCommon.destroyDB(WSDB);
+		TestCommon.destroyDB(tdb);
 		
 		TempFilesManager tfm = new TempFilesManager(
 				new File(TEMP_DIR));

--- a/performance/us/kbase/workspace/performance/workspace/Common.java
+++ b/performance/us/kbase/workspace/performance/workspace/Common.java
@@ -5,9 +5,9 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.DB;
-import com.mongodb.DBObject;
+import org.bson.Document;
+
+import com.mongodb.client.MongoDatabase;
 
 import us.kbase.typedobj.core.MD5;
 import us.kbase.typedobj.core.TempFilesManager;
@@ -22,18 +22,18 @@ public class Common {
 
 
 	public static List<String> getMD5s(
-			final DB db,
+			final MongoDatabase db,
 			final String workspace) {
-		final DBObject ws = db.getCollection(CollectionNames.COL_WORKSPACES).findOne(
-				new BasicDBObject(Fields.WS_NAME, workspace));
-		final long id = (long) ws.get(Fields.WS_ID);
-		final DBObject sort = new BasicDBObject(Fields.VER_WS_ID, 1);
+		final Document ws = db.getCollection(CollectionNames.COL_WORKSPACES).find(
+				new Document(Fields.WS_NAME, workspace)).first();
+		final long id = ws.getLong(Fields.WS_ID);
+		final Document sort = new Document(Fields.VER_WS_ID, 1);
 		sort.put(Fields.VER_ID, 1);
 		final List<String> md5s = new ArrayList<>();
 		final long startvers = System.nanoTime();
-		for (final DBObject dbo: db.getCollection(CollectionNames.COL_WORKSPACE_VERS)
-				.find(new BasicDBObject(Fields.VER_WS_ID, id)).sort(sort)) {
-			md5s.add((String) dbo.get(Fields.VER_CHKSUM));
+		for (final Document dbo: db.getCollection(CollectionNames.COL_WORKSPACE_VERS)
+				.find(new Document(Fields.VER_WS_ID, id)).sort(sort)) {
+			md5s.add(dbo.getString(Fields.VER_CHKSUM));
 		}
 		System.out.println("time to get md5s: " + (System.nanoTime() - startvers) / 1000000000.0);
 		return md5s;
@@ -89,13 +89,13 @@ public class Common {
 		return shocktimes;
 	}
 
-	public static List<String> getShockNodes(final DB db, final List<String> md5s) {
+	public static List<String> getShockNodes(final MongoDatabase db, final List<String> md5s) {
 		final List<String> nodes = new LinkedList<>();
 		final long startNodes = System.nanoTime();
 		for (final String md5: md5s) {
-			final DBObject node = db.getCollection(InitConstants.COL_SHOCK_NODES)
-					.findOne(new BasicDBObject(Fields.SHOCK_CHKSUM, md5));
-			nodes.add((String) node.get(Fields.SHOCK_NODE));
+			final Document node = db.getCollection(InitConstants.COL_SHOCK_NODES)
+					.find(new Document(Fields.SHOCK_CHKSUM, md5)).first();
+			nodes.add( node.getString(Fields.SHOCK_NODE));
 		}
 		System.out.println("Time to get nodes: " +
 				(System.nanoTime() - startNodes) / 1000000000.0);

--- a/performance/us/kbase/workspace/performance/workspace/GetObjectsMongoWSDB.java
+++ b/performance/us/kbase/workspace/performance/workspace/GetObjectsMongoWSDB.java
@@ -9,8 +9,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import com.mongodb.DB;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.typedobj.core.TempFilesManager;
@@ -39,8 +39,9 @@ public class GetObjectsMongoWSDB {
 			throw new IllegalArgumentException("no token in args");
 		}
 		
+		@SuppressWarnings("resource")
 		final MongoClient mc = new MongoClient();
-		final DB db = mc.getDB(WS_DB);
+		final MongoDatabase db = mc.getDatabase(WS_DB);
 		
 		final BlobStore blob = new GridFSBlobStore(db);
 		final TempFilesManager tfm = new TempFilesManager(new File("temp_getobjmongoWS"));

--- a/performance/us/kbase/workspace/performance/workspace/GridFSBackendTiming.java
+++ b/performance/us/kbase/workspace/performance/workspace/GridFSBackendTiming.java
@@ -6,8 +6,8 @@ import static us.kbase.workspace.performance.workspace.Common.printStats;
 
 import java.util.List;
 
-import com.mongodb.DB;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 import us.kbase.workspace.database.mongo.BlobStore;
 import us.kbase.workspace.database.mongo.GridFSBlobStore;
@@ -18,8 +18,9 @@ public class GridFSBackendTiming {
 	private static final String WS_DB = "ws_test_gfs";
 	
 	public static void main(final String[] args) throws Exception {
+		@SuppressWarnings("resource")
 		final MongoClient mc = new MongoClient();
-		final DB db = mc.getDB(WS_DB);
+		final MongoDatabase db = mc.getDatabase(WS_DB);
 		final List<String> md5s = getMD5s(db, WORKSPACE);
 		
 		final BlobStore blob = new GridFSBlobStore(db);

--- a/performance/us/kbase/workspace/performance/workspace/PlainJavaTiming.java
+++ b/performance/us/kbase/workspace/performance/workspace/PlainJavaTiming.java
@@ -12,8 +12,8 @@ import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 
-import com.mongodb.DB;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 public class PlainJavaTiming {
 	private static final String WORKSPACE = "TestObjs";
@@ -27,8 +27,9 @@ public class PlainJavaTiming {
 			throw new IllegalArgumentException("no token in args");
 		}
 		
+		@SuppressWarnings("resource")
 		final MongoClient mc = new MongoClient();
-		final DB db = mc.getDB(WS_DB);
+		final MongoDatabase db = mc.getDatabase(WS_DB);
 		final List<String> md5s = getMD5s(db, WORKSPACE);
 		
 		final List<String> nodes = getShockNodes(db, md5s);

--- a/performance/us/kbase/workspace/performance/workspace/ShockClientTiming.java
+++ b/performance/us/kbase/workspace/performance/workspace/ShockClientTiming.java
@@ -9,8 +9,8 @@ import java.net.URL;
 import java.util.LinkedList;
 import java.util.List;
 
-import com.mongodb.DB;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 import us.kbase.auth.AuthService;
 import us.kbase.shock.client.BasicShockClient;
@@ -29,8 +29,9 @@ public class ShockClientTiming {
 			throw new IllegalArgumentException("no token in args");
 		}
 		
+		@SuppressWarnings("resource")
 		final MongoClient mc = new MongoClient();
-		final DB db = mc.getDB(WS_DB);
+		final MongoDatabase db = mc.getDatabase(WS_DB);
 		final List<String> md5s = getMD5s(db, WORKSPACE);
 		
 		final List<String> nodes = getShockNodes(db, md5s);

--- a/readme.md
+++ b/readme.md
@@ -88,5 +88,4 @@ Notes on Travis automated tests
 The Travis tests do not run the WorkspaceLongTest or JSONRPCLongTest test classes
 because they take too long to run.
 
-Therefore, run the full test suite locally at least prior to every release, and prior to
-any PRs where there are changes to the handle management code.
+Therefore, run the full test suite locally at least prior to every release.

--- a/src/us/kbase/common/test/TestCommon.java
+++ b/src/us/kbase/common/test/TestCommon.java
@@ -29,8 +29,6 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import com.mongodb.BasicDBObject;
-import com.mongodb.DB;
 import com.mongodb.client.MongoDatabase;
 
 import ch.qos.logback.classic.Level;
@@ -185,15 +183,6 @@ public class TestCommon {
 	
 	public static boolean useWiredTigerEngine() {
 		return "true".equals(getTestProperty(MONGO_USE_WIRED_TIGER));
-	}
-	
-	public static void destroyDB(final DB db) {
-		for (String name: db.getCollectionNames()) {
-			if (!name.startsWith("system.")) {
-				// dropping collection also drops indexes
-				db.getCollection(name).remove(new BasicDBObject());
-			}
-		}
 	}
 	
 	public static void destroyDB(final MongoDatabase db) {

--- a/src/us/kbase/typedobj/db/MongoTypeStorage.java
+++ b/src/us/kbase/typedobj/db/MongoTypeStorage.java
@@ -10,23 +10,20 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
-
-import org.bson.BSONObject;
+import org.bson.Document;
 
 import us.kbase.typedobj.exceptions.TypeStorageException;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
-import com.mongodb.BasicDBObject;
-import com.mongodb.DB;
-import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
-import com.mongodb.DBObject;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
 
 public class MongoTypeStorage implements TypeStorage {
 	
-	private final DB db;
+	private final MongoDatabase db;
 	
 	public static final String TABLE_MODULE_REQUEST = "module_request";
 	public static final String TABLE_MODULE_VERSION = "module_version";
@@ -44,80 +41,83 @@ public class MongoTypeStorage implements TypeStorage {
 	
 	private static final Pattern dotSep = Pattern.compile(Pattern.quote("."));
 	
-	public MongoTypeStorage(DB db) {
-		this.db = db;
+	public MongoTypeStorage(final MongoDatabase typeDB) {
+		this.db = typeDB;
 		ensureIndeces();
 	}
 	
-	private static final DBObject UNIQ = new BasicDBObject("unique", true);
+	private static final IndexOptions UNIQ = new IndexOptions().unique(true);
 	
 	private void ensureIndeces() {
-		final DBCollection reqs = db.getCollection(TABLE_MODULE_REQUEST);
-		reqs.createIndex(new BasicDBObject("moduleName", 1).append("ownerUserId", 1), UNIQ);
-		reqs.createIndex(new BasicDBObject("ownerUserId", 1));
-		final DBCollection vers = db.getCollection(TABLE_MODULE_VERSION);
-		vers.createIndex(new BasicDBObject("moduleName", 1), UNIQ);
-		final DBCollection owns = db.getCollection(TABLE_MODULE_OWNER);
-		owns.createIndex(new BasicDBObject("moduleName", 1).append("ownerUserId", 1), UNIQ);
-		owns.createIndex(new BasicDBObject("ownerUserId", 1));
-		final DBCollection infos = db.getCollection(TABLE_MODULE_INFO_HISTORY);
-		infos.createIndex(new BasicDBObject("moduleName", 1).append("versionTime", 1), UNIQ);
-		final DBCollection specs = db.getCollection(TABLE_MODULE_SPEC_HISTORY);
-		specs.createIndex(new BasicDBObject("moduleName", 1).append("versionTime", 1), UNIQ);
-		final DBCollection tschs = db.getCollection(TABLE_MODULE_TYPE_SCHEMA);
-		tschs.createIndex(new BasicDBObject("moduleName", 1).append("typeName", 1)
+		final MongoCollection<Document> reqs = db.getCollection(TABLE_MODULE_REQUEST);
+		reqs.createIndex(new Document("moduleName", 1).append("ownerUserId", 1), UNIQ);
+		reqs.createIndex(new Document("ownerUserId", 1));
+		final MongoCollection<Document> vers = db.getCollection(TABLE_MODULE_VERSION);
+		vers.createIndex(new Document("moduleName", 1), UNIQ);
+		final MongoCollection<Document> owns = db.getCollection(TABLE_MODULE_OWNER);
+		owns.createIndex(new Document("moduleName", 1).append("ownerUserId", 1), UNIQ);
+		owns.createIndex(new Document("ownerUserId", 1));
+		final MongoCollection<Document> infos = db.getCollection(TABLE_MODULE_INFO_HISTORY);
+		infos.createIndex(new Document("moduleName", 1).append("versionTime", 1), UNIQ);
+		final MongoCollection<Document> specs = db.getCollection(TABLE_MODULE_SPEC_HISTORY);
+		specs.createIndex(new Document("moduleName", 1).append("versionTime", 1), UNIQ);
+		final MongoCollection<Document> tschs = db.getCollection(TABLE_MODULE_TYPE_SCHEMA);
+		tschs.createIndex(new Document("moduleName", 1).append("typeName", 1)
 				.append("version", 1), UNIQ);
-		tschs.createIndex(new BasicDBObject("moduleName", 1).append("moduleVersion", 1));
-		final DBCollection tprs = db.getCollection(TABLE_MODULE_TYPE_PARSE);
-		tprs.createIndex(new BasicDBObject("moduleName", 1).append("typeName", 1)
+		tschs.createIndex(new Document("moduleName", 1).append("moduleVersion", 1));
+		final MongoCollection<Document> tprs = db.getCollection(TABLE_MODULE_TYPE_PARSE);
+		tprs.createIndex(new Document("moduleName", 1).append("typeName", 1)
 				.append("version", 1), UNIQ);
-		tschs.createIndex(new BasicDBObject("moduleName", 1).append("moduleVersion", 1));
-		final DBCollection fprs = db.getCollection(TABLE_MODULE_FUNC_PARSE);
-		fprs.createIndex(new BasicDBObject("moduleName", 1).append("funcName", 1)
+		tschs.createIndex(new Document("moduleName", 1).append("moduleVersion", 1));
+		final MongoCollection<Document> fprs = db.getCollection(TABLE_MODULE_FUNC_PARSE);
+		fprs.createIndex(new Document("moduleName", 1).append("funcName", 1)
 				.append("version", 1), UNIQ);
-		fprs.createIndex(new BasicDBObject("moduleName", 1).append("moduleVersion", 1));
-		final DBCollection frefs = db.getCollection(TABLE_FUNC_REFS);
-		frefs.createIndex(new BasicDBObject("depModule", 1).append("depName", 1)
+		fprs.createIndex(new Document("moduleName", 1).append("moduleVersion", 1));
+		final MongoCollection<Document> frefs = db.getCollection(TABLE_FUNC_REFS);
+		frefs.createIndex(new Document("depModule", 1).append("depName", 1)
 				.append("depVersion", 1));
-		frefs.createIndex(new BasicDBObject("refModule", 1).append("refName", 1)
+		frefs.createIndex(new Document("refModule", 1).append("refName", 1)
 				.append("refVersion", 1));
-		frefs.createIndex(new BasicDBObject("depModule", 1).append("depModuleVersion", 1));
-		final DBCollection trefs = db.getCollection(TABLE_TYPE_REFS);
-		trefs.createIndex(new BasicDBObject("depModule", 1).append("depName", 1)
+		frefs.createIndex(new Document("depModule", 1).append("depModuleVersion", 1));
+		final MongoCollection<Document> trefs = db.getCollection(TABLE_TYPE_REFS);
+		trefs.createIndex(new Document("depModule", 1).append("depName", 1)
 				.append("depVersion", 1));
-		trefs.createIndex(new BasicDBObject("refModule", 1).append("refName", 1)
+		trefs.createIndex(new Document("refModule", 1).append("refName", 1)
 				.append("refVersion", 1));
-		trefs.createIndex(new BasicDBObject("depModule", 1).append("depModuleVersion", 1));
+		trefs.createIndex(new Document("depModule", 1).append("depModuleVersion", 1));
 	}
 	
 	private Map<String, Object> toMap(final Object obj) {
 		return MAPPER.convertValue(obj, new TypeReference<Map<String, Object>>() {});
 	}
 	
-	private DBObject toDBObj(final Object obj) {
-		return new BasicDBObject(toMap(obj));
+	private Document toDBObj(final Object obj) {
+		return new Document(toMap(obj));
 	}
 	
-	private <T> T toObj(final DBObject dbo, final Class<T> clazz) {
-		return dbo == null ? null : MAPPER.convertValue(toMapRec(dbo), clazz);
+	private <T> T toObj(final Document document, final Class<T> clazz) {
+		return document == null ? null : MAPPER.convertValue(toMapRec(document), clazz);
 	}
 	
-	private <T> T toObj(final DBObject dbo, final TypeReference<T> tr) {
-		return dbo == null ? null :  MAPPER.convertValue(toMapRec(dbo), tr);
+	private <T> T toObj(final Document document, final TypeReference<T> tr) {
+		return document == null ? null :  MAPPER.convertValue(toMapRec(document), tr);
 	}
 	
+	// These are old notes from the DBObject based legacy Mongo API.
+	// Not sure if they're still applicable here, but switching to the new API is murder
+	// and it's going to take long enough already, so minimizing changes.
 	// Unimplemented error for dbo.toMap()
 	// dbo is read only
 	// can't call convertValue() on dbo since it has a 'size' field outside of the internal map
 	// and just weird shit happens when you do anyway
-	private Map<String, Object> toMapRec(final BSONObject dbo) {
+	private Map<String, Object> toMapRec(final Document document) {
 		// can't stream because streams don't like null values at HashMap.merge()
 		final Map<String, Object> ret = new HashMap<>();
-		for (final String k: dbo.keySet()) {
+		for (final String k: document.keySet()) {
 			if (!k.equals("_id")) {
-				final Object v = dbo.get(k);
+				final Object v = document.get(k);
 				// may need lists too?
-				ret.put(k, v instanceof BSONObject ? toMapRec((BSONObject) v) : v);
+				ret.put(k, v instanceof Document ? toMapRec((Document) v) : v);
 			}
 		}
 		return ret;
@@ -128,19 +128,19 @@ public class MongoTypeStorage implements TypeStorage {
 			throws TypeStorageException {
 		try {
 			if (typeRefs.size() > 0) {
-				DBCollection refs = db.getCollection(TABLE_TYPE_REFS);
+				MongoCollection<Document> refs = db.getCollection(TABLE_TYPE_REFS);
 				for (RefInfo ref : typeRefs) {
 					if (ref.getDepModuleVersion() == 0)
 						throw new TypeStorageException("Dependent type's module version was not initialized");
-					refs.insert(toDBObj(ref));
+					refs.insertOne(toDBObj(ref));
 				}
 			}
 			if (funcRefs.size() > 0) {
-				DBCollection refs = db.getCollection(TABLE_FUNC_REFS);
+				MongoCollection<Document> refs = db.getCollection(TABLE_FUNC_REFS);
 				for (RefInfo ref : funcRefs) {
 					if (ref.getDepModuleVersion() == 0)
 						throw new TypeStorageException("Dependent function's module version was not initialized");
-					refs.insert(toDBObj(ref));
+					refs.insertOne(toDBObj(ref));
 				}
 			}
 		} catch (Exception e) {
@@ -163,9 +163,9 @@ public class MongoTypeStorage implements TypeStorage {
 	
 	private Long getLastModuleVersionOrNull(String moduleName) throws TypeStorageException {
 		try {
-			final DBCollection vers = db.getCollection(TABLE_MODULE_VERSION);
-			final ModuleVersion ret = toObj(vers.findOne(
-					new BasicDBObject("moduleName", moduleName)), ModuleVersion.class);
+			final MongoCollection<Document> vers = db.getCollection(TABLE_MODULE_VERSION);
+			final ModuleVersion ret = toObj(vers.find(
+					new Document("moduleName", moduleName)).first(), ModuleVersion.class);
 			return ret == null ? null : ret.releasedVersionTime;
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
@@ -184,9 +184,9 @@ public class MongoTypeStorage implements TypeStorage {
 
 	private ModuleInfo getModuleInfoOrNull(String moduleName, long version) throws TypeStorageException {
 		try {
-			final DBCollection infos = db.getCollection(TABLE_MODULE_INFO_HISTORY);
-			final ModuleInfo info = toObj(infos.findOne(new BasicDBObject("moduleName", moduleName)
-					.append("versionTime", version)), ModuleInfo.class);
+			final MongoCollection<Document> infos = db.getCollection(TABLE_MODULE_INFO_HISTORY);
+			final ModuleInfo info = toObj(infos.find(new Document("moduleName", moduleName)
+					.append("versionTime", version)).first(), ModuleInfo.class);
 			return info;
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
@@ -195,9 +195,9 @@ public class MongoTypeStorage implements TypeStorage {
 
 	private String getModuleSpecOrNull(String moduleName, long version) throws TypeStorageException {
 		try {
-			final DBCollection specs = db.getCollection(TABLE_MODULE_SPEC_HISTORY);
-			final ModuleSpec spec = toObj(specs.findOne(new BasicDBObject("moduleName", moduleName)
-					.append("versionTime", version)), ModuleSpec.class);
+			final MongoCollection<Document> specs = db.getCollection(TABLE_MODULE_SPEC_HISTORY);
+			final ModuleSpec spec = toObj(specs.find(new Document("moduleName", moduleName)
+					.append("versionTime", version)).first(), ModuleSpec.class);
 			return spec == null ? null : spec.document;
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
@@ -208,10 +208,10 @@ public class MongoTypeStorage implements TypeStorage {
 	public boolean checkTypeSchemaRecordExists(String moduleName,
 			String typeName, String version) throws TypeStorageException {
 		try {
-			final DBCollection docs = db.getCollection(TABLE_MODULE_TYPE_SCHEMA);
-			return null != docs.findOne(new BasicDBObject("moduleName", moduleName)
+			final MongoCollection<Document> docs = db.getCollection(TABLE_MODULE_TYPE_SCHEMA);
+			return null != docs.find(new Document("moduleName", moduleName)
 					.append("typeName", typeName)
-					.append("version", version));
+					.append("version", version)).first();
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}
@@ -220,9 +220,9 @@ public class MongoTypeStorage implements TypeStorage {
 	@Override
 	public Set<String> getAllRegisteredModules(boolean withUnsupported) throws TypeStorageException {
 		try {
-			final DBCollection infos = db.getCollection(TABLE_MODULE_VERSION);
+			final MongoCollection<Document> infos = db.getCollection(TABLE_MODULE_VERSION);
 			final Map<String, Boolean> map = getProjection(
-					infos, new BasicDBObject(), "moduleName", String.class, "supported",
+					infos, new Document(), "moduleName", String.class, "supported",
 					Boolean.class);
 			Set<String> ret = new TreeSet<String>();
 			if (withUnsupported) {
@@ -242,9 +242,9 @@ public class MongoTypeStorage implements TypeStorage {
 	public boolean getModuleSupportedState(String moduleName)
 			throws TypeStorageException {
 		try {
-			final DBCollection vers = db.getCollection(TABLE_MODULE_VERSION);
-			final ModuleVersion ret = toObj(vers.findOne(
-					new BasicDBObject("moduleName", moduleName)), ModuleVersion.class);
+			final MongoCollection<Document> vers = db.getCollection(TABLE_MODULE_VERSION);
+			final ModuleVersion ret = toObj(vers.find(
+					new Document("moduleName", moduleName)).first(), ModuleVersion.class);
 			if (ret == null)
 				throw new TypeStorageException("Support information is unavailable for module: " + moduleName);
 			return ret.isSupported();
@@ -261,10 +261,10 @@ public class MongoTypeStorage implements TypeStorage {
 			String version) throws TypeStorageException {
 		Map<String, Object> ret;
 		try {
-			final DBCollection docs = db.getCollection(TABLE_MODULE_FUNC_PARSE);
-			ret = toObj(docs.findOne(new BasicDBObject("moduleName", moduleName)
+			final MongoCollection<Document> docs = db.getCollection(TABLE_MODULE_FUNC_PARSE);
+			ret = toObj(docs.find(new Document("moduleName", moduleName)
 					.append("funcName", funcName)
-					.append("version", version)), Map.class);
+					.append("version", version)).first(), Map.class);
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}
@@ -278,7 +278,7 @@ public class MongoTypeStorage implements TypeStorage {
 	public Set<RefInfo> getFuncRefsByDep(String depModule, String depFunc,
 			String version) throws TypeStorageException {
 		try {
-			return Sets.newHashSet(find(TABLE_FUNC_REFS, new BasicDBObject("depModule", depModule)
+			return Sets.newHashSet(find(TABLE_FUNC_REFS, new Document("depModule", depModule)
 					.append("depName", depFunc).append("depVersion", version), RefInfo.class));
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
@@ -289,7 +289,7 @@ public class MongoTypeStorage implements TypeStorage {
 	public Set<RefInfo> getFuncRefsByRef(String refModule, String refType,
 			String version) throws TypeStorageException {
 		try {
-			return Sets.newHashSet(find(TABLE_FUNC_REFS, new BasicDBObject("refModule", refModule)
+			return Sets.newHashSet(find(TABLE_FUNC_REFS, new Document("refModule", refModule)
 					.append("refName", refType).append("refVersion", version), RefInfo.class));
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
@@ -317,9 +317,9 @@ public class MongoTypeStorage implements TypeStorage {
 	@Override
 	public TreeMap<Long, Boolean> getAllModuleVersions(String moduleName) throws TypeStorageException {
 		try {
-			final DBCollection infos = db.getCollection(TABLE_MODULE_INFO_HISTORY);
+			final MongoCollection<Document> infos = db.getCollection(TABLE_MODULE_INFO_HISTORY);
 			Map<Long, Boolean> map = getProjection(
-					infos, new BasicDBObject("moduleName", moduleName), "versionTime", Long.class, 
+					infos, new Document("moduleName", moduleName), "versionTime", Long.class, 
 					"released", Boolean.class);
 			long releaseVer = getLastReleasedModuleVersion(moduleName);
 			TreeMap<Long, Boolean> ret = new TreeMap<Long, Boolean>();
@@ -333,15 +333,15 @@ public class MongoTypeStorage implements TypeStorage {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	protected <KT, VT> Map<KT, VT> getProjection(
-			final DBCollection infos,
-			final DBObject whereCondition, 
+			final MongoCollection<Document> infos,
+			final Document whereCondition, 
 			final String keySelectField,
 			final Class<KT> keyType,
 			final String valueSelectField,
 			final Class<VT> valueType)
 			throws TypeStorageException {
 		final List<Map> data = find(infos, whereCondition,
-				new BasicDBObject(keySelectField, 1).append(valueSelectField, 1), Map.class);
+				new Document(keySelectField, 1).append(valueSelectField, 1), Map.class);
 		Map<KT, VT> ret = new LinkedHashMap<KT, VT>();
 		for (Map<?,?> item : data) {
 			Object key = getMongoProp(item, keySelectField);
@@ -357,58 +357,54 @@ public class MongoTypeStorage implements TypeStorage {
 
 	private <T> List<T> find(
 			final String collectionName,
-			final DBObject whereCondition,
+			final Document whereCondition,
 			final Class<T> clazz) {
-		return find(collectionName, whereCondition, new BasicDBObject(), clazz);
+		return find(collectionName, whereCondition, new Document(), clazz);
 	}
 	
 	private <T> List<T> find(
 			final String collectionName,
-			final DBObject whereCondition,
-			final BasicDBObject projection,
+			final Document whereCondition,
+			final Document projection,
 			final Class<T> clazz) {
 		return find(db.getCollection(collectionName), whereCondition, projection, clazz);
 	}
 	
 	private <T> List<T> find(
-			final DBCollection col,
-			final DBObject whereCondition,
-			final BasicDBObject projection,
+			final MongoCollection<Document> col,
+			final Document whereCondition,
+			final Document projection,
 			final Class<T> clazz) {
 		final List<T> data = new LinkedList<>();
-		try (final DBCursor find = col.find(whereCondition, projection)) {
-			for (final DBObject dbo: find) {
-				data.add(toObj(dbo, clazz));
-			}
+		for (final Document dbo: col.find(whereCondition).projection(projection)) {
+			data.add(toObj(dbo, clazz));
 		}
 		return data;
 	}
 	
 	private <T> List<T> find(
 			final String collectionName,
-			final DBObject whereCondition,
+			final Document whereCondition,
 			final TypeReference<T> tr) {
-		return find(collectionName, whereCondition, new BasicDBObject(), tr);
+		return find(collectionName, whereCondition, new Document(), tr);
 	}
 	
 	private <T> List<T> find(
 			final String collectionName,
-			final DBObject whereCondition,
-			final BasicDBObject projection,
+			final Document whereCondition,
+			final Document projection,
 			final TypeReference<T> tr) {
 		return find(db.getCollection(collectionName), whereCondition, projection, tr);
 	}
 	
 	private <T> List<T> find(
-			final DBCollection col,
-			final DBObject whereCondition,
-			final BasicDBObject projection,
+			final MongoCollection<Document> col,
+			final Document whereCondition,
+			final Document projection,
 			final TypeReference<T> tr) {
 		final List<T> data = new LinkedList<>();
-		try (final DBCursor find = col.find(whereCondition, projection)) {
-			for (final DBObject dbo: find) {
-				data.add(toObj(dbo, tr));
-			}
+		for (final Document dbo: col.find(whereCondition).projection(projection)) {
+			data.add(toObj(dbo, tr));
 		}
 		return data;
 	}
@@ -430,10 +426,10 @@ public class MongoTypeStorage implements TypeStorage {
 		if (typeName.contains("'"))
 			throw new TypeStorageException("Type names with symbol ['] are not supperted");
 		try {
-			final DBCollection schemas = db.getCollection(TABLE_MODULE_INFO_HISTORY);
+			final MongoCollection<Document> schemas = db.getCollection(TABLE_MODULE_INFO_HISTORY);
 			Map<Long, String> typeMap = getProjection(
 					schemas,
-					new BasicDBObject("moduleName", moduleName)
+					new Document("moduleName", moduleName)
 							.append("types." + typeName + ".typeName", typeName),
 					"versionTime", Long.class, "types." + typeName + ".typeVersion", String.class);
 			Map<Long, Boolean> moduleMap = getAllModuleVersions(moduleName);
@@ -456,10 +452,10 @@ public class MongoTypeStorage implements TypeStorage {
 		if (funcName.contains("'"))
 			throw new TypeStorageException("Function names with symbol ['] are not supperted");
 		try {
-			final DBCollection schemas = db.getCollection(TABLE_MODULE_INFO_HISTORY);
+			final MongoCollection<Document> schemas = db.getCollection(TABLE_MODULE_INFO_HISTORY);
 			Map<Long, String> funcMap = getProjection(
 					schemas,
-					new BasicDBObject("moduleName", moduleName)
+					new Document("moduleName", moduleName)
 							.append("funcs." + funcName + ".funcName", funcName),
 					"versionTime", Long.class, "funcs." + funcName + ".funcVersion", String.class);
 			Map<Long, Boolean> moduleMap = getAllModuleVersions(moduleName);
@@ -492,10 +488,10 @@ public class MongoTypeStorage implements TypeStorage {
 			String version) throws TypeStorageException {
 		Map<String, Object> ret;
 		try {
-			final DBCollection docs = db.getCollection(TABLE_MODULE_TYPE_PARSE);
-			ret = toObj(docs.findOne(new BasicDBObject("moduleName", moduleName)
+			final MongoCollection<Document> docs = db.getCollection(TABLE_MODULE_TYPE_PARSE);
+			ret = toObj(docs.find(new Document("moduleName", moduleName)
 					.append("typeName", typeName)
-					.append("version", version)), Map.class);
+					.append("version", version)).first(), Map.class);
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}
@@ -509,7 +505,7 @@ public class MongoTypeStorage implements TypeStorage {
 	public Set<RefInfo> getTypeRefsByDep(String depModule, String depType,
 			String version) throws TypeStorageException {
 		try {
-			return Sets.newTreeSet(find(TABLE_TYPE_REFS, new BasicDBObject("depModule", depModule)
+			return Sets.newTreeSet(find(TABLE_TYPE_REFS, new Document("depModule", depModule)
 					.append("depName", depType)
 					.append("depVersion", version), RefInfo.class));
 		} catch (Exception e) {
@@ -521,7 +517,7 @@ public class MongoTypeStorage implements TypeStorage {
 	public Set<RefInfo> getTypeRefsByRef(String refModule, String refType,
 			String version) throws TypeStorageException {
 		try {
-			return Sets.newTreeSet(find(TABLE_TYPE_REFS, new BasicDBObject("refModule", refModule)
+			return Sets.newTreeSet(find(TABLE_TYPE_REFS, new Document("refModule", refModule)
 					.append("refName", refType).append("refVersion", version), RefInfo.class));
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
@@ -530,11 +526,11 @@ public class MongoTypeStorage implements TypeStorage {
 	
 	private <T> T findOne(
 			final String collectionName,
-			final DBObject query,
+			final Document query,
 			final TypeReference<T> tr)
 			throws TypeStorageException {
 		try {
-			return toObj(db.getCollection(collectionName).findOne(query), tr);
+			return toObj(db.getCollection(collectionName).find(query).first(), tr);
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}	
@@ -552,7 +548,7 @@ public class MongoTypeStorage implements TypeStorage {
 			final String version)
 			throws TypeStorageException {
 		final Map<String, Object> rec = findOne(TABLE_MODULE_TYPE_SCHEMA,
-						new BasicDBObject("moduleName", moduleName)
+						new Document("moduleName", moduleName)
 								.append("typeName", typeName)
 								.append("version", version),
 								new TypeReference<Map<String, Object>>() {});
@@ -573,7 +569,7 @@ public class MongoTypeStorage implements TypeStorage {
 			String md5) throws TypeStorageException {
 		try {
 			final List<Map<String, Object>> list = find(TABLE_MODULE_TYPE_SCHEMA,
-					new BasicDBObject("moduleName", moduleName)
+					new Document("moduleName", moduleName)
 							.append("typeName", typeName)
 							.append("md5hash", md5),
 							new TypeReference<Map<String, Object>>() {});
@@ -586,20 +582,20 @@ public class MongoTypeStorage implements TypeStorage {
 		}
 	}
 	
-	private static final DBObject MT_DBO = new BasicDBObject();
+	private static final Document MT_DBO = new Document();
 	
 	@Override
 	public void removeAllData() throws TypeStorageException {
-		db.getCollection(TABLE_TYPE_REFS).remove(MT_DBO);
-		db.getCollection(TABLE_FUNC_REFS).remove(MT_DBO);
-		db.getCollection(TABLE_MODULE_TYPE_PARSE).remove(MT_DBO);
-		db.getCollection(TABLE_MODULE_TYPE_SCHEMA).remove(MT_DBO);
-		db.getCollection(TABLE_MODULE_FUNC_PARSE).remove(MT_DBO);
-		db.getCollection(TABLE_MODULE_REQUEST).remove(MT_DBO);
-		db.getCollection(TABLE_MODULE_OWNER).remove(MT_DBO);
-		db.getCollection(TABLE_MODULE_SPEC_HISTORY).remove(MT_DBO);
-		db.getCollection(TABLE_MODULE_INFO_HISTORY).remove(MT_DBO);
-		db.getCollection(TABLE_MODULE_VERSION).remove(MT_DBO);
+		db.getCollection(TABLE_TYPE_REFS).deleteMany(MT_DBO);
+		db.getCollection(TABLE_FUNC_REFS).deleteMany(MT_DBO);
+		db.getCollection(TABLE_MODULE_TYPE_PARSE).deleteMany(MT_DBO);
+		db.getCollection(TABLE_MODULE_TYPE_SCHEMA).deleteMany(MT_DBO);
+		db.getCollection(TABLE_MODULE_FUNC_PARSE).deleteMany(MT_DBO);
+		db.getCollection(TABLE_MODULE_REQUEST).deleteMany(MT_DBO);
+		db.getCollection(TABLE_MODULE_OWNER).deleteMany(MT_DBO);
+		db.getCollection(TABLE_MODULE_SPEC_HISTORY).deleteMany(MT_DBO);
+		db.getCollection(TABLE_MODULE_INFO_HISTORY).deleteMany(MT_DBO);
+		db.getCollection(TABLE_MODULE_VERSION).deleteMany(MT_DBO);
 	}
 	
 	// removed removeModule method after 3ad9e2d. Untested, unused.
@@ -608,17 +604,18 @@ public class MongoTypeStorage implements TypeStorage {
 	public void writeFuncParseRecord(String moduleName, String funcName,
 			String version, long moduleVersion, String parseText) throws TypeStorageException {
 		try {
-			final DBCollection recs = db.getCollection(TABLE_MODULE_FUNC_PARSE);
-			recs.remove(new BasicDBObject("moduleName", moduleName)
+			final MongoCollection<Document> recs = db.getCollection(TABLE_MODULE_FUNC_PARSE);
+			recs.deleteMany(new Document("moduleName", moduleName)
 					.append("funcName", funcName)
 					.append("version", version));
+			// this is a race condition waiting to happen
 			final FuncRecord rec = new FuncRecord();
 			rec.setModuleName(moduleName);
 			rec.setFuncName(funcName);
 			rec.setVersion(version);
 			rec.setModuleVersion(moduleVersion);
 			rec.setDocument(parseText);
-			recs.save(toDBObj(rec));
+			recs.insertOne(toDBObj(rec));
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}
@@ -626,18 +623,18 @@ public class MongoTypeStorage implements TypeStorage {
 	
 	private void writeModuleVersion(String moduleName, long version) throws TypeStorageException {
 		try {
-			final DBCollection vers = db.getCollection(TABLE_MODULE_VERSION);
+			final MongoCollection<Document> vers = db.getCollection(TABLE_MODULE_VERSION);
 			// this is a race condition waiting to happen
-			if (vers.findOne(new BasicDBObject("moduleName", moduleName)) == null) {
+			if (vers.find(new Document("moduleName", moduleName)).first() == null) {
 				ModuleVersion ver = new ModuleVersion();
 				ver.setModuleName(moduleName);
 				ver.setVersionTime(version);
 				ver.setReleasedVersionTime(version);
 				ver.setSupported(true);
-				vers.insert(toDBObj(ver));
+				vers.insertOne(toDBObj(ver));
 			} else {
-				vers.update(new BasicDBObject("moduleName", moduleName),
-						new BasicDBObject("$set", new BasicDBObject("versionTime", version)));
+				vers.updateOne(new Document("moduleName", moduleName),
+						new Document("$set", new Document("versionTime", version)));
 			}
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
@@ -650,12 +647,12 @@ public class MongoTypeStorage implements TypeStorage {
 		writeModuleVersion(info.getModuleName(), version);
 		writeModuleInfo(info, version);
 		try {
-			final DBCollection specs = db.getCollection(TABLE_MODULE_SPEC_HISTORY);
+			final MongoCollection<Document> specs = db.getCollection(TABLE_MODULE_SPEC_HISTORY);
 			ModuleSpec spec = new ModuleSpec();
 			spec.setModuleName(info.getModuleName());
 			spec.setDocument(specDocument);
 			spec.setVersionTime(version);
-			specs.insert(toDBObj(spec));
+			specs.insertOne(toDBObj(spec));
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}
@@ -670,9 +667,9 @@ public class MongoTypeStorage implements TypeStorage {
 	
 	private void writeModuleInfo(ModuleInfo info, long version) throws TypeStorageException {
 		try {
-			final DBCollection infos = db.getCollection(TABLE_MODULE_INFO_HISTORY);
+			final MongoCollection<Document> infos = db.getCollection(TABLE_MODULE_INFO_HISTORY);
 			info.setVersionTime(version);
-			infos.insert(toDBObj(info));
+			infos.insertOne(toDBObj(info));
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}
@@ -682,17 +679,18 @@ public class MongoTypeStorage implements TypeStorage {
 	public void writeTypeParseRecord(String moduleName, String typeName,
 			String version, long moduleVersion, String document) throws TypeStorageException {
 		try {
-			final DBCollection recs = db.getCollection(TABLE_MODULE_TYPE_PARSE);
-			recs.remove(new BasicDBObject("moduleName", moduleName)
+			final MongoCollection<Document> recs = db.getCollection(TABLE_MODULE_TYPE_PARSE);
+			recs.deleteMany(new Document("moduleName", moduleName)
 					.append("typeName", typeName)
 					.append("version", version));
+			// race condition
 			TypeRecord rec = new TypeRecord();
 			rec.setModuleName(moduleName);
 			rec.setTypeName(typeName);
 			rec.setVersion(version);
 			rec.setModuleVersion(moduleVersion);
 			rec.setDocument(document);
-			recs.save(toDBObj(rec));
+			recs.insertOne(toDBObj(rec));
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}
@@ -704,10 +702,10 @@ public class MongoTypeStorage implements TypeStorage {
 		if (typeName.contains("'"))
 			throw new TypeStorageException("Type names with symbol ['] are not supperted");
 		try {
-			final DBCollection infoCol = db.getCollection(TABLE_MODULE_INFO_HISTORY);
+			final MongoCollection<Document> infoCol = db.getCollection(TABLE_MODULE_INFO_HISTORY);
 			return getProjection(
 					infoCol,
-					new BasicDBObject("moduleName", moduleName)
+					new Document("moduleName", moduleName)
 							.append("types." + typeName + ".typeVersion", typeVersion)
 							.append("types." + typeName + ".supported", true),
 					"versionTime", Long.class, "released", Boolean.class);
@@ -722,10 +720,10 @@ public class MongoTypeStorage implements TypeStorage {
 		if (funcName.contains("'"))
 			throw new TypeStorageException("Function names with symbol ['] are not supperted");
 		try {
-			final DBCollection infoCol = db.getCollection(TABLE_MODULE_INFO_HISTORY);
+			final MongoCollection<Document> infoCol = db.getCollection(TABLE_MODULE_INFO_HISTORY);
 			return getProjection(
 					infoCol,
-					new BasicDBObject("moduleName", moduleName)
+					new Document("moduleName", moduleName)
 							.append("funcs." + funcName + ".funcVersion", funcVersion),
 					"versionTime", Long.class, "released", Boolean.class);
 		} catch (Exception e) {
@@ -737,10 +735,11 @@ public class MongoTypeStorage implements TypeStorage {
 	public void writeTypeSchemaRecord(String moduleName, String typeName,
 			String version, long moduleVersion, String document, String md5) throws TypeStorageException {
 		try {
-			final DBCollection recs = db.getCollection(TABLE_MODULE_TYPE_SCHEMA);
-			recs.remove(new BasicDBObject("moduleName", moduleName)
+			final MongoCollection<Document> recs = db.getCollection(TABLE_MODULE_TYPE_SCHEMA);
+			recs.deleteMany(new Document("moduleName", moduleName)
 					.append("typeName", typeName)
 					.append("version", version));
+			// race condition
 			TypeRecord rec = new TypeRecord();
 			rec.setModuleName(moduleName);
 			rec.setTypeName(typeName);
@@ -748,7 +747,7 @@ public class MongoTypeStorage implements TypeStorage {
 			rec.setModuleVersion(moduleVersion);
 			rec.setDocument(document);
 			rec.setMd5hash(md5);
-			recs.insert(toDBObj(rec));
+			recs.insertOne(toDBObj(rec));
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}
@@ -758,26 +757,27 @@ public class MongoTypeStorage implements TypeStorage {
 	public void addNewModuleRegistrationRequest(String moduleName, String userId)
 			throws TypeStorageException {
 		try {
-			final DBCollection recs = db.getCollection(TABLE_MODULE_REQUEST);
+			final MongoCollection<Document> recs = db.getCollection(TABLE_MODULE_REQUEST);
 			// lots of race conditions here
-			if (recs.count(new BasicDBObject("ownerUserId", userId)) >= MAX_REQUESTS_BY_USER) {
+			if (recs.countDocuments(new Document("ownerUserId", userId)) >= MAX_REQUESTS_BY_USER) {
 				throw new TypeStorageException("User " + userId + " has maximal count " +
 						"of requests: " + MAX_REQUESTS_BY_USER);
 			}
-			if (recs.findOne(new BasicDBObject("moduleName", moduleName)) != null) {
+			if (recs.find(new Document("moduleName", moduleName)).first() != null) {
 				throw new TypeStorageException("Registration of module " + moduleName +
 						" was already requested");
 			}
 			if (checkModuleExist(moduleName)) {
 				throw new TypeStorageException("Module " + moduleName + " was already registered");
 			}
+			// race condition
 			OwnerInfo rec = new OwnerInfo();
 			rec.setOwnerUserId(userId);
 			rec.setWithChangeOwnersPrivilege(true);
 			rec.setModuleName(moduleName);
-			recs.insert(toDBObj(rec));
+			recs.insertOne(toDBObj(rec));
 		} catch (TypeStorageException e) {
-			throw e;
+			throw e;  // don't wrap TSEs in another Exception
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}
@@ -788,8 +788,8 @@ public class MongoTypeStorage implements TypeStorage {
 			throws TypeStorageException {
 		OwnerInfo ret;
 		try {
-			final DBCollection recs = db.getCollection(TABLE_MODULE_REQUEST);
-			ret = toObj(recs.findOne(new BasicDBObject("moduleName", moduleName)),
+			final MongoCollection<Document> recs = db.getCollection(TABLE_MODULE_REQUEST);
+			ret = toObj(recs.find(new Document("moduleName", moduleName)).first(),
 					OwnerInfo.class);
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
@@ -803,14 +803,14 @@ public class MongoTypeStorage implements TypeStorage {
 	public void addOwnerToModule(String moduleName, String userId,
 			boolean withChangeOwnersPrivilege) throws TypeStorageException {
 		try {
-			final DBCollection recs = db.getCollection(TABLE_MODULE_OWNER);
+			final MongoCollection<Document> recs = db.getCollection(TABLE_MODULE_OWNER);
 			// race condition
-			recs.remove(new BasicDBObject("moduleName", moduleName).append("ownerUserId", userId));
+			recs.deleteMany(new Document("moduleName", moduleName).append("ownerUserId", userId));
 			OwnerInfo rec = new OwnerInfo();
 			rec.setOwnerUserId(userId);
 			rec.setWithChangeOwnersPrivilege(withChangeOwnersPrivilege);
 			rec.setModuleName(moduleName);
-			recs.insert(toDBObj(rec));
+			recs.insertOne(toDBObj(rec));
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}
@@ -820,7 +820,7 @@ public class MongoTypeStorage implements TypeStorage {
 	public List<OwnerInfo> getNewModuleRegistrationRequests()
 			throws TypeStorageException {
 		try {
-			return find(TABLE_MODULE_REQUEST, new BasicDBObject(), OwnerInfo.class);
+			return find(TABLE_MODULE_REQUEST, new Document(), OwnerInfo.class);
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}
@@ -831,7 +831,7 @@ public class MongoTypeStorage implements TypeStorage {
 			throws TypeStorageException {
 		try {
 			final List<OwnerInfo> owners = find(TABLE_MODULE_OWNER,
-					new BasicDBObject("moduleName", moduleName), OwnerInfo.class);
+					new Document("moduleName", moduleName), OwnerInfo.class);
 			Map<String, OwnerInfo> ret = new TreeMap<String, OwnerInfo>();
 			for (OwnerInfo oi : owners)
 				ret.put(oi.getOwnerUserId(), oi);
@@ -846,7 +846,7 @@ public class MongoTypeStorage implements TypeStorage {
 			throws TypeStorageException {
 		try {
 			final List<OwnerInfo> owners = find(
-					TABLE_MODULE_OWNER, new BasicDBObject("ownerUserId", userId), OwnerInfo.class);
+					TABLE_MODULE_OWNER, new Document("ownerUserId", userId), OwnerInfo.class);
 			Map<String, OwnerInfo> ret = new TreeMap<String, OwnerInfo>();
 			for (OwnerInfo oi : owners)
 				ret.put(oi.getModuleName(), oi);
@@ -860,8 +860,8 @@ public class MongoTypeStorage implements TypeStorage {
 	public void removeNewModuleRegistrationRequest(String moduleName,
 			String userId) throws TypeStorageException {
 		try {
-			final DBCollection recs = db.getCollection(TABLE_MODULE_REQUEST);
-			recs.remove(new BasicDBObject("moduleName", moduleName).append("ownerUserId", userId));
+			final MongoCollection<Document> recs = db.getCollection(TABLE_MODULE_REQUEST);
+			recs.deleteMany(new Document("moduleName", moduleName).append("ownerUserId", userId));
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}
@@ -871,8 +871,8 @@ public class MongoTypeStorage implements TypeStorage {
 	public void removeOwnerFromModule(String moduleName, String userId)
 			throws TypeStorageException {
 		try {
-			final DBCollection recs = db.getCollection(TABLE_MODULE_OWNER);
-			recs.remove(new BasicDBObject("moduleName", moduleName).append("ownerUserId", userId));
+			final MongoCollection<Document> recs = db.getCollection(TABLE_MODULE_OWNER);
+			recs.deleteMany(new Document("moduleName", moduleName).append("ownerUserId", userId));
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}
@@ -894,7 +894,7 @@ public class MongoTypeStorage implements TypeStorage {
 		};
 		Map<String, Long> ret = new TreeMap<String, Long>();
 		for (String table : tables) {
-			List<Object> rows = find(table, new BasicDBObject(), Object.class);
+			List<Object> rows = find(table, new Document(), Object.class);
 			ret.put(table, (long)rows.size());
 		}
 		return ret;
@@ -904,20 +904,20 @@ public class MongoTypeStorage implements TypeStorage {
 	public void removeModuleVersionAndSwitchIfNotCurrent(String moduleName,
 			long versionToDelete, long versionToSwitchTo)
 			throws TypeStorageException {
-		final DBObject dep = new BasicDBObject("depModule", moduleName)
+		final Document dep = new Document("depModule", moduleName)
 				.append("depModuleVersion", versionToDelete);
-		final DBObject mod = new BasicDBObject("moduleName", moduleName)
+		final Document mod = new Document("moduleName", moduleName)
 				.append("moduleVersion", versionToDelete);
-		final DBObject hist = new BasicDBObject("moduleName", moduleName)
+		final Document hist = new Document("moduleName", moduleName)
 				.append("versionTime", versionToDelete);
 		try {
-			db.getCollection(TABLE_TYPE_REFS).remove(dep);
-			db.getCollection(TABLE_FUNC_REFS).remove(dep);
-			db.getCollection(TABLE_MODULE_TYPE_SCHEMA).remove(mod);
-			db.getCollection(TABLE_MODULE_TYPE_PARSE).remove(mod);
-			db.getCollection(TABLE_MODULE_FUNC_PARSE).remove(mod);
-			db.getCollection(TABLE_MODULE_SPEC_HISTORY).remove(hist);
-			db.getCollection(TABLE_MODULE_INFO_HISTORY).remove(hist);
+			db.getCollection(TABLE_TYPE_REFS).deleteMany(dep);
+			db.getCollection(TABLE_FUNC_REFS).deleteMany(dep);
+			db.getCollection(TABLE_MODULE_TYPE_SCHEMA).deleteMany(mod);
+			db.getCollection(TABLE_MODULE_TYPE_PARSE).deleteMany(mod);
+			db.getCollection(TABLE_MODULE_FUNC_PARSE).deleteMany(mod);
+			db.getCollection(TABLE_MODULE_SPEC_HISTORY).deleteMany(hist);
+			db.getCollection(TABLE_MODULE_INFO_HISTORY).deleteMany(hist);
 		} catch (Exception e) {
 			throw new TypeStorageException(e);
 		}
@@ -937,9 +937,9 @@ public class MongoTypeStorage implements TypeStorage {
 	private Long getLastModuleVersionWithUnreleasedOrNull(String moduleName)
 			throws TypeStorageException {
 		try {
-			final DBCollection vers = db.getCollection(TABLE_MODULE_VERSION);
-			final ModuleVersion ret = toObj(vers.findOne(
-					new BasicDBObject("moduleName", moduleName)), ModuleVersion.class);
+			final MongoCollection<Document> vers = db.getCollection(TABLE_MODULE_VERSION);
+			final ModuleVersion ret = toObj(vers.find(
+					new Document("moduleName", moduleName)).first(), ModuleVersion.class);
 			if (ret == null)
 				return null;
 			return ret.versionTime;
@@ -952,17 +952,18 @@ public class MongoTypeStorage implements TypeStorage {
 	public void setModuleReleaseVersion(String moduleName, long version)
 			throws TypeStorageException {
 		try {
-			final DBCollection vers = db.getCollection(TABLE_MODULE_VERSION);
-			if (vers.findOne(new BasicDBObject("moduleName", moduleName)) == null) {
+			final MongoCollection<Document> vers = db.getCollection(TABLE_MODULE_VERSION);
+			if (vers.find(new Document("moduleName", moduleName)).first() == null) {
 				throw new TypeStorageException("Module " + moduleName + " was not registered");
 			} else {
-				final DBCollection infos = db.getCollection(TABLE_MODULE_INFO_HISTORY);
-				infos.update(new BasicDBObject("moduleName", moduleName)
+				// race condition
+				final MongoCollection<Document> infos = db.getCollection(TABLE_MODULE_INFO_HISTORY);
+				infos.updateOne(new Document("moduleName", moduleName)
 						.append("versionTime", version),
-						new BasicDBObject("$set", new BasicDBObject("released", true)));
-				vers.update(new BasicDBObject("moduleName", moduleName),
-						new BasicDBObject("$set",
-								new BasicDBObject("releasedVersionTime", version)));
+						new Document("$set", new Document("released", true)));
+				vers.updateOne(new Document("moduleName", moduleName),
+						new Document("$set",
+								new Document("releasedVersionTime", version)));
 			}
 		} catch (TypeStorageException e) {
 			throw e;
@@ -977,13 +978,14 @@ public class MongoTypeStorage implements TypeStorage {
 	public void changeModuleSupportedState(String moduleName, boolean supported)
 			throws TypeStorageException {
 		try {
-			final DBCollection vers = db.getCollection(TABLE_MODULE_VERSION);
-			if (vers.findOne(new BasicDBObject("moduleName", moduleName)) == null) {
+			final MongoCollection<Document> vers = db.getCollection(TABLE_MODULE_VERSION);
+			if (vers.find(new Document("moduleName", moduleName)).first() == null) {
 				throw new TypeStorageException("Support information is unavailable for module: " +
 						moduleName);
 			}
-			vers.update(new BasicDBObject("moduleName", moduleName),
-					new BasicDBObject("$set", new BasicDBObject("supported", supported)));
+			// race condition
+			vers.updateOne(new Document("moduleName", moduleName),
+					new Document("$set", new Document("supported", supported)));
 		} catch (TypeStorageException e) {
 			throw e;
 		} catch (Exception e) {

--- a/src/us/kbase/typedobj/db/test/MongoTypeStorageTest.java
+++ b/src/us/kbase/typedobj/db/test/MongoTypeStorageTest.java
@@ -12,8 +12,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.mongodb.DB;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.controllers.mongo.MongoController;
@@ -29,7 +29,7 @@ import us.kbase.typedobj.exceptions.TypeStorageException;
 public class MongoTypeStorageTest {
 
 	private static MongoController MONGO;
-	private static DB MONGO_DB;
+	private static MongoDatabase MONGO_DB;
 	
 	@BeforeClass
 	public static void setUp() throws Exception {
@@ -42,8 +42,9 @@ public class MongoTypeStorageTest {
 		System.out.println("Started test mongo instance at localhost:" +
 				MONGO.getServerPort());
 		
+		@SuppressWarnings("resource")
 		final MongoClient mc = new MongoClient("localhost:" + MONGO.getServerPort());
-		MONGO_DB = mc.getDB("test_" + MongoTypeStorageTest.class.getSimpleName());
+		MONGO_DB = mc.getDatabase("test_" + MongoTypeStorageTest.class.getSimpleName());
 	}
 	
 	@AfterClass

--- a/src/us/kbase/typedobj/db/test/TypeRegisteringTest.java
+++ b/src/us/kbase/typedobj/db/test/TypeRegisteringTest.java
@@ -33,8 +33,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import com.mongodb.DB;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.controllers.mongo.MongoController;
@@ -135,7 +135,7 @@ public class TypeRegisteringTest {
 		db = new TypeDefinitionDB(storage);
 	}
 	
-	public static DB createMongoDbConnection() throws Exception {
+	public static MongoDatabase createMongoDbConnection() throws Exception {
 		if (mongo == null) {
 			mongo = new MongoController(TestCommon.getMongoExe(),
 					Paths.get(TestCommon.getTempDir()),
@@ -143,8 +143,9 @@ public class TypeRegisteringTest {
 			System.out.println("Using mongo temp dir " + 
 					mongo.getTempDir());
 		}
-		DB mdb = new MongoClient("localhost:" + mongo.getServerPort())
-			.getDB("TypeRegisteringTest");
+		@SuppressWarnings("resource")
+		final MongoClient mcli = new MongoClient("localhost:" + mongo.getServerPort());
+		final MongoDatabase mdb = mcli.getDatabase("TypeRegisteringTest");
 		TestCommon.destroyDB(mdb);
 		return mdb;
 	}

--- a/src/us/kbase/workspace/database/mongo/QueryMethods.java
+++ b/src/us/kbase/workspace/database/mongo/QueryMethods.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.bson.Document;
+
 import us.kbase.workspace.database.AllUsers;
 import us.kbase.workspace.database.Permission;
 import us.kbase.workspace.database.ResolvedObjectID;
@@ -21,27 +23,25 @@ import us.kbase.workspace.database.WorkspaceUser;
 import us.kbase.workspace.database.exceptions.CorruptWorkspaceDBException;
 import us.kbase.workspace.database.exceptions.WorkspaceCommunicationException;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.DB;
-import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
-import com.mongodb.DBObject;
 import com.mongodb.MongoException;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
 
 public class QueryMethods {
 	
 	//TODO TEST unit tests
 	//TODO JAVADOC
 	
-	private final DB wsmongo;
+	private final MongoDatabase wsmongo;
 	private final AllUsers allUsers;
 	private final String workspaceCollection;
 	private final String objectCollection;
 	private final String versionCollection;
-	private final DBCollection wsACL;
+	private final MongoCollection<Document> wsACL;
 	
 	QueryMethods(
-			final DB wsmongo,
+			final MongoDatabase wsmongo,
 			final AllUsers allUsers,
 			final String workspaceCollection,
 			final String objectCollection,
@@ -71,23 +71,8 @@ public class QueryMethods {
 		this.wsACL = wsmongo.getCollection(workspaceACLCollection);
 	}
 	
-	
-	DB getDatabase() {
-		return wsmongo;
-	}
-
-	String getWorkspaceCollection() {
-		return workspaceCollection;
-	}
-
-
 	String getObjectCollection() {
 		return objectCollection;
-	}
-
-
-	String getVersionCollection() {
-		return versionCollection;
 	}
 
 
@@ -170,19 +155,19 @@ public class QueryMethods {
 				names.put(wsi.getName(), wsi);
 			}
 		}
-		final List<DBObject> orquery = new LinkedList<DBObject>();
+		final List<Document> orquery = new LinkedList<>();
 		if (!ids.isEmpty()) {
-			orquery.add(new BasicDBObject(Fields.WS_ID,
-					new BasicDBObject("$in", ids.keySet())));
+			orquery.add(new Document(Fields.WS_ID,
+					new Document("$in", ids.keySet())));
 		}
 		if (!names.isEmpty()) {
-			orquery.add(new BasicDBObject(Fields.WS_NAME,
-					new BasicDBObject("$in", names.keySet())));
+			orquery.add(new Document(Fields.WS_NAME,
+					new Document("$in", names.keySet())));
 		}
 		fields.add(Fields.WS_NAME);
 		fields.add(Fields.WS_ID);
-		final BasicDBObject q = new BasicDBObject("$or", orquery);
-		q.put(Fields.WS_CLONING, new BasicDBObject("$exists", false));
+		final Document q = new Document("$or", orquery);
+		q.put(Fields.WS_CLONING, new Document("$exists", false));
 		final List<Map<String, Object>> res = queryCollection(
 				workspaceCollection, q, fields);
 		
@@ -210,12 +195,11 @@ public class QueryMethods {
 			return new HashMap<Long, Map<String, Object>>();
 		}
 		fields.add(Fields.WS_ID);
-		final DBObject q = new BasicDBObject(Fields.WS_ID,
-				new BasicDBObject("$in", wsids));
+		final Document q = new Document(Fields.WS_ID, new Document("$in", wsids));
 		if (excludeDeletedWorkspaces) {
 			q.put(Fields.WS_DEL, false);
 		}
-		q.put(Fields.WS_CLONING, new BasicDBObject("$exists", false));
+		q.put(Fields.WS_CLONING, new Document("$exists", false));
 		final List<Map<String, Object>> queryres =
 				queryCollection(workspaceCollection, q, fields);
 		final Map<Long, Map<String, Object>> result =
@@ -230,6 +214,7 @@ public class QueryMethods {
 			final Set<ObjectIDResolvedWSNoVer> objectIDs,
 			final Set<String> fields)
 			throws WorkspaceCommunicationException {
+		// TODO CODE this method is madness, refactor
 		if (objectIDs.isEmpty()) {
 			return new HashMap<ObjectIDResolvedWSNoVer, Map<String,Object>>();
 		}
@@ -262,32 +247,30 @@ public class QueryMethods {
 		}
 		
 		//TODO PERFORMANCE This $or query might be better as multiple individual queries, test
-		final List<DBObject> orquery = new LinkedList<DBObject>();
+		final List<Document> orquery = new LinkedList<>();
 		for (final ResolvedWorkspaceID rwsi: names.keySet()) {
-			final DBObject query = new BasicDBObject(Fields.OBJ_WS_ID,
-					rwsi.getID());
-			query.put(Fields.OBJ_NAME, new BasicDBObject(
-					"$in", names.get(rwsi).keySet()));
+			final Document query = new Document(Fields.OBJ_WS_ID, rwsi.getID());
+			query.put(Fields.OBJ_NAME, new Document("$in", names.get(rwsi).keySet()));
 			//if ver count < 1, we're in a race condition or the database went
 			//down after saving the object but before saving the version
 			//so don't look at objects with no versions
-			query.put(Fields.OBJ_VCNT, new BasicDBObject("$gt", 0));
+			query.put(Fields.OBJ_VCNT, new Document("$gt", 0));
 			orquery.add(query);
 		}
 		for (final ResolvedWorkspaceID rwsi: ids.keySet()) {
-			final DBObject query = new BasicDBObject(Fields.OBJ_WS_ID,
+			final Document query = new Document(Fields.OBJ_WS_ID,
 					rwsi.getID());
-			query.put(Fields.OBJ_ID, new BasicDBObject(
+			query.put(Fields.OBJ_ID, new Document(
 					"$in", ids.get(rwsi).keySet()));
 			//see notes in loop above
-			query.put(Fields.OBJ_VCNT, new BasicDBObject("$gt", 0));
+			query.put(Fields.OBJ_VCNT, new Document("$gt", 0));
 			orquery.add(query);
 		}
 		fields.add(Fields.OBJ_ID);
 		fields.add(Fields.OBJ_NAME);
 		fields.add(Fields.OBJ_WS_ID);
 		final List<Map<String, Object>> queryres = queryCollection(
-				objectCollection, new BasicDBObject("$or", orquery), fields);
+				objectCollection, new Document("$or", orquery), fields);
 
 		final Map<ObjectIDResolvedWSNoVer, Map<String, Object>> ret =
 				new HashMap<ObjectIDResolvedWSNoVer, Map<String, Object>>();
@@ -380,9 +363,10 @@ public class QueryMethods {
 		return ret;
 	}
 	
-	private Map<ResolvedWorkspaceID, Map<Long, Map<Integer, Map<String, Object>>>>
-			queryVersions(final Map<ResolvedWorkspaceID, Map<Long, List<Integer>>> ids,
-			final Set<String> fields) throws WorkspaceCommunicationException {
+	private Map<ResolvedWorkspaceID, Map<Long, Map<Integer, Map<String, Object>>>> queryVersions(
+			final Map<ResolvedWorkspaceID, Map<Long, List<Integer>>> ids,
+			final Set<String> fields)
+			throws WorkspaceCommunicationException {
 		fields.add(Fields.VER_ID);
 		fields.add(Fields.VER_VER);
 		//disgusting. need to do better.
@@ -390,22 +374,20 @@ public class QueryMethods {
 		//workspace at a time. If profiling shows this is slow investigate
 		//further
 		//actually, $or queries just suck it seems. Way faster to do single queries
-		final Map<ResolvedWorkspaceID, Map<Long, Map<Integer, Map<String, Object>>>>
-			ret = new HashMap<ResolvedWorkspaceID, Map<Long,Map<Integer,Map<String,Object>>>>();
+		final Map<ResolvedWorkspaceID, Map<Long, Map<Integer, Map<String, Object>>>> ret =
+				new HashMap<>();
 		for (final ResolvedWorkspaceID rwsi: ids.keySet()) {
-			ret.put(rwsi, new HashMap<Long, Map<Integer, Map<String,Object>>>());
+			ret.put(rwsi, new HashMap<>());
 			for (final Long objectID: ids.get(rwsi).keySet()) {
-				ret.get(rwsi).put(objectID,
-						new HashMap<Integer, Map<String, Object>>());
-				final DBObject q;
+				ret.get(rwsi).put(objectID, new HashMap<>());
+				final Document q;
 				if (ids.get(rwsi).get(objectID).size() == 0) {
-					q = new BasicDBObject();
+					q = new Document();
 				} else if (ids.get(rwsi).get(objectID).size() == 1) {
-					q = new BasicDBObject(Fields.VER_VER,
-							ids.get(rwsi).get(objectID).get(0));
+					q = new Document(Fields.VER_VER, ids.get(rwsi).get(objectID).get(0));
 				} else {
-					q = new BasicDBObject(Fields.VER_VER,
-						new BasicDBObject("$in", ids.get(rwsi).get(objectID)));
+					q = new Document(Fields.VER_VER,
+							new Document("$in", ids.get(rwsi).get(objectID)));
 				}
 				q.put(Fields.VER_ID, objectID);
 				q.put(Fields.VER_WS_ID, rwsi.getID());
@@ -421,31 +403,36 @@ public class QueryMethods {
 		return ret;
 	}
 	
-	List<Map<String, Object>> queryCollection(final String collection,
-			final DBObject query, final Set<String> fields)
+	List<Map<String, Object>> queryCollection(
+			final String collection,
+			final Document query,
+			final Set<String> fields)
 			throws WorkspaceCommunicationException {
 		return queryCollection(collection, query, fields, null, -1);
 	}
 	
-	List<Map<String, Object>> queryCollection(final String collection,
-	final DBObject query, final Set<String> fields, final int limit)
+	List<Map<String, Object>> queryCollection(
+			final String collection,
+			final Document query,
+			final Set<String> fields,
+			final int limit)
 	throws WorkspaceCommunicationException {
 		return queryCollection(collection, query, fields, null, limit);
 	}
 
 	List<Map<String, Object>> queryCollection(
 			final String collection,
-			final DBObject query,
+			final Document query,
 			final Set<String> fields,
 			// really shouldn't be necessary, but 2.4 sometimes isn't smart
-			final DBObject queryHint,
+			final Document queryHint,
 			final int limit)
 			throws WorkspaceCommunicationException {
 		final List<Map<String, Object>> result =
 				new ArrayList<Map<String,Object>>();
-		try (final DBCursor im = queryCollectionCursor(
-				collection, query, fields, queryHint, limit)) {
-			for (final DBObject o: im) {
+		try {
+			for (final Document o: queryCollectionCursor(
+					collection, query, fields, queryHint, limit)) {
 				result.add(dbObjectToMap(o));
 			}
 		} catch (MongoException me) {
@@ -455,22 +442,21 @@ public class QueryMethods {
 		return result;
 	}
 	
-	DBCursor queryCollectionCursor(
+	FindIterable<Document> queryCollectionCursor(
 			final String collection,
-			final DBObject query,
+			final Document query,
 			final Set<String> fields,
 			// really shouldn't be necessary, but 2.4 sometimes isn't smart
-			final DBObject queryHint,
+			final Document queryHint,
 			final int limit)
 			throws WorkspaceCommunicationException {
-		final DBObject projection = new BasicDBObject();
-		projection.put(Fields.MONGO_ID, 0);
+		final Document projection = new Document(Fields.MONGO_ID, 0);
 		for (final String field: fields) {
 			projection.put(field, 1);
 		}
 		try {
-			final DBCursor im = wsmongo.getCollection(collection)
-					.find(query, projection);
+			final FindIterable<Document> im = wsmongo.getCollection(collection)
+					.find(query).projection(projection);
 			if (limit > 0) {
 				im.limit(limit);
 			}
@@ -484,8 +470,8 @@ public class QueryMethods {
 		}
 	}
 	
-	//since LazyBsonObject.toMap() is not supported
-	static Map<String, Object> dbObjectToMap(final DBObject o) {
+	// TODO CODING why bother with converting? Just use the Document
+	static Map<String, Object> dbObjectToMap(final Document o) {
 		final Map<String, Object> m = new HashMap<String, Object>();
 		for (final String name: o.keySet()) {
 			m.put(name, o.get(name));
@@ -509,7 +495,7 @@ public class QueryMethods {
 			final Permission minPerm,
 			final boolean excludeDeletedWorkspaces)
 			throws WorkspaceCommunicationException, CorruptWorkspaceDBException {
-		final DBObject query = new BasicDBObject();
+		final Document query = new Document();
 		final Map<Long, ResolvedWorkspaceID> idToWS = new HashMap<>();
 		if (rwsis != null && rwsis.size() > 0) {
 			final Set<Long> wsids = new HashSet<>();
@@ -517,25 +503,25 @@ public class QueryMethods {
 				idToWS.put(r.getID(), r);
 				wsids.add(r.getID());
 			}
-			query.put(Fields.ACL_WSID, new BasicDBObject("$in", wsids));
+			query.put(Fields.ACL_WSID, new Document("$in", wsids));
 		}
 		if (user != null ) {
 			query.put(Fields.ACL_USER, user.getUser());
 		}
 		if (minPerm != null & !Permission.NONE.equals(minPerm)) {
-			query.put(Fields.ACL_PERM, new BasicDBObject("$gte", minPerm.getPermission()));
+			query.put(Fields.ACL_PERM, new Document("$gte", minPerm.getPermission()));
 		}
-		final DBObject proj = new BasicDBObject();
+		final Document proj = new Document();
 		proj.put(Fields.MONGO_ID, 0);
 		proj.put(Fields.ACL_USER, 1);
 		proj.put(Fields.ACL_PERM, 1);
 		proj.put(Fields.ACL_WSID, 1);
 		
 		final Map<ResolvedWorkspaceID, Map<User, Permission>> wsidToPerms = new HashMap<>();
-		final Map<Long, List<DBObject>> noWS = new HashMap<>();
-		try (final DBCursor res = wsACL.find(query, proj)) {
-			for (final DBObject m: res) {
-				final Long id = (Long) m.get(Fields.ACL_WSID);
+		final Map<Long, List<Document>> noWS = new HashMap<>();
+		try {
+			for (final Document m: wsACL.find(query).projection(proj)) {
+				final Long id = m.getLong(Fields.ACL_WSID);
 				if (!idToWS.containsKey(id)) {
 					if (!noWS.containsKey(id)) {
 						noWS.put(id, new LinkedList<>());
@@ -566,7 +552,7 @@ public class QueryMethods {
 						(String) ws.get(id).get(Fields.WS_NAME),
 						(Boolean) ws.get(id).get(Fields.WS_LOCKED),
 						(Boolean) ws.get(id).get(Fields.WS_DEL));
-				for (final DBObject m: noWS.get(id)) {
+				for (final Document m: noWS.get(id)) {
 					addPerm(wsidToPerms, m, wsid);
 				}
 			}
@@ -576,14 +562,14 @@ public class QueryMethods {
 
 	private void addPerm(
 			final Map<ResolvedWorkspaceID, Map<User, Permission>> wsidToPerms,
-			final DBObject m,
+			final Document m,
 			final ResolvedWorkspaceID wsid)
 			throws CorruptWorkspaceDBException {
 		if (!wsidToPerms.containsKey(wsid)) {
 			wsidToPerms.put(wsid, new HashMap<>());
 		}
 		wsidToPerms.get(wsid).put(getUser(
-				(String) m.get(Fields.ACL_USER)),
+				m.getString(Fields.ACL_USER)),
 				Permission.fromInt((Integer) m.get(Fields.ACL_PERM)));
 	}
 	

--- a/src/us/kbase/workspace/kbase/AppEventListener.java
+++ b/src/us/kbase/workspace/kbase/AppEventListener.java
@@ -14,6 +14,12 @@ public class AppEventListener implements ServletContextListener {
 	
 	@Override
 	public void contextDestroyed(ServletContextEvent arg0) {
+		// I don't think this does anything any more. Originally this fixed restarting the
+		// workspace app in Glassfish and having the old mongo connections retained (e.g.
+		// a resource leak).
+		// Now we're in dockerized tomcat and so we never restart the app.
+		// Even if we wanted to, it's not clear how we could get a handle to the current
+		// connections and close them.
 		GetMongoDB.closeAllConnections();
 	}
 }

--- a/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
+++ b/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
@@ -16,12 +16,12 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.slf4j.LoggerFactory;
 
-import com.mongodb.DB;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
 import com.mongodb.MongoException;
 import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoDatabase;
 
 import us.kbase.abstracthandle.AbstractHandleClient;
 import us.kbase.auth.AuthConfig;
@@ -251,13 +251,13 @@ public class InitWorkspaceServer {
 			throws WorkspaceInitException {
 		
 		final WorkspaceDependencies deps = new WorkspaceDependencies();
-		//TODO CODE update to new mongo APIs
-		final DB db = buildMongo(cfg, cfg.getDBname()).getDB(cfg.getDBname());
+		final MongoDatabase db = buildMongo(cfg, cfg.getDBname()).getDatabase(cfg.getDBname());
 		
 		final BlobStore bs = setupBlobStore(db, cfg, auth);
 		
 		// see https://jira.mongodb.org/browse/JAVA-2656
-		final DB typeDB = buildMongo(cfg, cfg.getTypeDBName()).getDB(cfg.getTypeDBName());
+		final MongoDatabase typeDB = buildMongo(cfg, cfg.getTypeDBName())
+				.getDatabase(cfg.getTypeDBName());
 		
 		try {
 			deps.typeDB = new TypeDefinitionDB(new MongoTypeStorage(typeDB));
@@ -440,7 +440,7 @@ public class InitWorkspaceServer {
 	}
 
 	private static BlobStore setupBlobStore(
-			final DB db,
+			final MongoDatabase db,
 			final KBaseWorkspaceConfig cfg,
 			final ConfigurableAuthService auth)
 			throws WorkspaceInitException {

--- a/src/us/kbase/workspace/test/UpdateOptionsMatcher.java
+++ b/src/us/kbase/workspace/test/UpdateOptionsMatcher.java
@@ -1,0 +1,35 @@
+package us.kbase.workspace.test;
+
+import org.mockito.ArgumentMatcher;
+
+import com.mongodb.client.model.UpdateOptions;
+
+// unfortunately equals() doesn't seem to be implemented correctly for UpdateOptions
+public class UpdateOptionsMatcher implements ArgumentMatcher<UpdateOptions> {
+
+	private final UpdateOptions expected;
+	
+	public UpdateOptionsMatcher(final UpdateOptions expected) {
+		this.expected = expected;
+	}
+	
+	private <T> boolean nullEquals(final T arg1, final T arg2) {
+		if (arg1 == null) {
+			return arg2 == null;
+		}
+		return arg1.equals(arg2);
+	}
+
+	@Override
+	public boolean matches(final UpdateOptions ui) {
+		return ui.isUpsert() == expected.isUpsert() &&
+				ui.getBypassDocumentValidation() == expected.getBypassDocumentValidation() &&
+				nullEquals(ui.getArrayFilters(), expected.getArrayFilters()) &&
+				nullEquals(ui.getCollation(), expected.getCollation());
+	}
+
+	@Override
+	public String toString() {
+		return "UpdateOptionsMatcher [expected=" + expected + "]";
+	}
+}

--- a/src/us/kbase/workspace/test/WorkspaceTestCommon.java
+++ b/src/us/kbase/workspace/test/WorkspaceTestCommon.java
@@ -1,12 +1,9 @@
 package us.kbase.workspace.test;
 
-import static us.kbase.common.test.TestCommon.destroyDB;
-
 import java.util.Arrays;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
-import com.mongodb.DB;
 
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.typedobj.core.TypeDefName;
@@ -14,11 +11,6 @@ import us.kbase.workspace.database.Types;
 import us.kbase.workspace.database.WorkspaceUser;
 
 public class WorkspaceTestCommon {
-	
-	public static void destroyWSandTypeDBs(DB mdb, String typedb) {
-		destroyDB(mdb);
-		destroyDB(mdb.getSisterDB(typedb));
-	}
 	
 	// this data will pass typechecking for any type created in installBasicSpecs
 	public static final Map<String, String> SAFE_DATA = ImmutableMap.of("thing", "foo");

--- a/src/us/kbase/workspace/test/database/mongo/S3BlobStoreIntegrationTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/S3BlobStoreIntegrationTest.java
@@ -18,8 +18,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.mongodb.DB;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
@@ -52,7 +52,7 @@ public class S3BlobStoreIntegrationTest {
 	//signed certs
 	private static S3BlobStore s3bsTrustCerts;
 	private static S3ClientWithPresign s3client;
-	private static DB mongo;
+	private static MongoDatabase mongo;
 	private static MinioController minio;
 	private static MongoController mongoCon;
 	private static TempFilesManager tfm;
@@ -72,8 +72,9 @@ public class S3BlobStoreIntegrationTest {
 		System.out.println("Started mongo server at localhost:" + mongoCon.getServerPort());
 		
 		String mongohost = "localhost:" + mongoCon.getServerPort();
+		@SuppressWarnings("resource")
 		MongoClient mongoClient = new MongoClient(mongohost);
-		mongo = mongoClient.getDB("MinioBackendTest");
+		mongo = mongoClient.getDatabase("MinioBackendTest");
 
 		minio = new MinioController(
 				TestCommon.getMinioExe(),

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTester.java
@@ -82,8 +82,8 @@ import us.kbase.workspace.test.WorkspaceServerThread;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mongodb.DB;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 /*
  * These tests are specifically for testing the JSON-RPC communications between
@@ -472,12 +472,11 @@ public class JSONRPCLayerTester {
 	}
 	@Before
 	public void clearDB() throws Exception {
-		final DB wsdb1 = new MongoClient("localhost:" + mongo.getServerPort())
-				.getDB(DB_WS_NAME_1);
-		final DB wsdb2 = new MongoClient("localhost:" + mongo.getServerPort())
-				.getDB(DB_WS_NAME_2);
-		final DB wsdb3 = new MongoClient("localhost:" + mongo.getServerPort())
-				.getDB(DB_WS_NAME_AUTH2_ADMINS);
+		@SuppressWarnings("resource")
+		final MongoClient mcli = new MongoClient("localhost:" + mongo.getServerPort());
+		final MongoDatabase wsdb1 = mcli.getDatabase(DB_WS_NAME_1);
+		final MongoDatabase wsdb2 = mcli.getDatabase(DB_WS_NAME_2);
+		final MongoDatabase wsdb3 = mcli.getDatabase(DB_WS_NAME_AUTH2_ADMINS);
 		TestCommon.destroyDB(wsdb1);
 		TestCommon.destroyDB(wsdb2);
 		TestCommon.destroyDB(wsdb3);

--- a/src/us/kbase/workspace/test/kbase/LoggingTest.java
+++ b/src/us/kbase/workspace/test/kbase/LoggingTest.java
@@ -50,8 +50,8 @@ import us.kbase.workspace.WorkspaceClient;
 import us.kbase.workspace.WorkspaceServer;
 import us.kbase.workspace.test.WorkspaceServerThread;
 
-import com.mongodb.DB;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 /** Tests application logging only - not the standard logging that comes with
  * JsonServerServlet.
@@ -236,8 +236,9 @@ public class LoggingTest {
 	@Before
 	public void clearDB() throws Exception {
 		logout.reset();
-		final DB wsdb1 = new MongoClient("localhost:" + mongo.getServerPort())
-				.getDB(DB_WS_NAME);
+		@SuppressWarnings("resource")
+		final MongoClient mcli = new MongoClient("localhost:" + mongo.getServerPort());
+		final MongoDatabase wsdb1 = mcli.getDatabase(DB_WS_NAME);
 		TestCommon.destroyDB(wsdb1);
 	}
 	

--- a/test/performance/ConfigurationsAndThreads.java
+++ b/test/performance/ConfigurationsAndThreads.java
@@ -22,10 +22,10 @@ import org.nocrala.tools.texttablefmt.Table;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.MongoClient;
 
 import us.kbase.auth.AuthService;
 import us.kbase.auth.AuthToken;
-import us.kbase.common.mongo.GetMongoDB;
 import us.kbase.common.service.ServerException;
 import us.kbase.common.service.UObject;
 import us.kbase.common.test.TestCommon;
@@ -103,6 +103,7 @@ public class ConfigurationsAndThreads {
 	
 	private static final ObjectMapper MAP = new ObjectMapper(); 
 	
+	private static MongoClient MC;
 	private static byte[] data;
 	private static JsonNode jsonData;
 	private static Map<String, Object> mapData;
@@ -149,8 +150,11 @@ public class ConfigurationsAndThreads {
 //		us.kbase.workspace.test.WorkspaceTestCommonDeprecated.destroyAndSetupDB(
 //				1, WorkspaceTestCommon.SHOCK, user, null);
 		//NOTE this setup is just to make it compile, not tested yet
+		@SuppressWarnings("resource")
+		final MongoClient mc = new MongoClient(MONGO_HOST);
+		MC = mc;
 		final TypeDefinitionDB typeDefDB = new TypeDefinitionDB(
-				new MongoTypeStorage(GetMongoDB.getDB(MONGO_HOST, TYPE_DB)));
+				new MongoTypeStorage(MC.getDatabase(TYPE_DB)));
 		
 		Types types = new Types(typeDefDB);
 		WorkspaceUser foo = new WorkspaceUser("foo");
@@ -360,7 +364,7 @@ public class ConfigurationsAndThreads {
 		
 		public void initialize(int writes, int id) throws Exception {
 			Random rand = new Random();
-			this.gfsb = new GridFSBlobStore(GetMongoDB.getDB(MONGO_HOST, MONGO_DB));
+			this.gfsb = new GridFSBlobStore(MC.getDatabase(MONGO_DB));
 			for (int i = 0; i < writes; i++) {
 				byte[] r = new byte[16]; //128 bit
 				rand.nextBytes(r);

--- a/test/performance/GetObjectsLibSpeedTest.java
+++ b/test/performance/GetObjectsLibSpeedTest.java
@@ -19,9 +19,9 @@ import org.nocrala.tools.texttablefmt.Table;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mongodb.DB;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
-import us.kbase.common.mongo.GetMongoDB;
 import us.kbase.common.service.JsonTokenStream;
 import us.kbase.common.test.TestCommon;
 import us.kbase.typedobj.core.LocalTypeProvider;
@@ -76,9 +76,11 @@ public class GetObjectsLibSpeedTest {
 		TempFilesManager tfm = new TempFilesManager(
 				new File(TestCommon.getTempDir()));
 		
-		DB db = GetMongoDB.getDB(mongohost, wsDB);
+		@SuppressWarnings("resource")
+		final MongoClient mc = new MongoClient(mongohost);
+		final MongoDatabase db = mc.getDatabase(wsDB);
 		final TypeDefinitionDB typeDefDB = new TypeDefinitionDB(new MongoTypeStorage(
-				GetMongoDB.getDB(mongohost, typeDB)));
+				mc.getDatabase(typeDB)));
 		TypedObjectValidator val = new TypedObjectValidator(
 				new LocalTypeProvider(typeDefDB));
 		MongoWorkspaceDB mwdb = new MongoWorkspaceDB(db, new GridFSBlobStore(db), tfm);


### PR DESCRIPTION
Not really any way to do the switch piecemeal - once you switch from
`getDB()` to `getDatabase()` you're on the new API and have to make changes
everywhere.

Lots and lots of potential refactoring was unearthed while making these
changes, but was only done where not doing it would have been more work
in order to minimize the changed line count, which is already large.