### PR TITLE
Move WS DB dependency to class where it's actually used

### DIFF
--- a/performance/us/kbase/workspace/performance/refsearch/GetReferencedObjectWithBFS.java
+++ b/performance/us/kbase/workspace/performance/refsearch/GetReferencedObjectWithBFS.java
@@ -98,9 +98,9 @@ public class GetReferencedObjectWithBFS {
 		
 		final TypeDefinitionDB typeDB = new TypeDefinitionDB(new MongoTypeStorage(tdb));
 		final TypedObjectValidator val = new TypedObjectValidator(new LocalTypeProvider(typeDB));
-		final MongoWorkspaceDB mwdb = new MongoWorkspaceDB(WSDB, new GridFSBlobStore(WSDB), tfm);
+		final MongoWorkspaceDB mwdb = new MongoWorkspaceDB(WSDB, new GridFSBlobStore(WSDB));
 		
-		WS = new Workspace(mwdb, new ResourceUsageConfigurationBuilder().build(), val);
+		WS = new Workspace(mwdb, new ResourceUsageConfigurationBuilder().build(), val, tfm);
 		WS.setMaximumObjectSearchCount(10000000);
 		installTypes(new Types(typeDB));
 		if (DO_LINEAR) {

--- a/performance/us/kbase/workspace/performance/workspace/GetObjectsMongoWSDB.java
+++ b/performance/us/kbase/workspace/performance/workspace/GetObjectsMongoWSDB.java
@@ -45,7 +45,7 @@ public class GetObjectsMongoWSDB {
 		
 		final BlobStore blob = new GridFSBlobStore(db);
 		final TempFilesManager tfm = new TempFilesManager(new File("temp_getobjmongoWS"));
-		final MongoWorkspaceDB mws = new MongoWorkspaceDB(db, blob, tfm);
+		final MongoWorkspaceDB mws = new MongoWorkspaceDB(db, blob);
 		
 		final ResolvedWorkspaceID rwsi = mws.resolveWorkspace(new WorkspaceIdentifier(WORKSPACE));
 		final ByteArrayFileCacheManager man = new ByteArrayFileCacheManager(

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -93,36 +93,31 @@ public class Workspace {
 	private final WorkspaceDatabase db;
 	private ResourceUsageConfiguration rescfg;
 	private final TypedObjectValidator validator;
+	private final TempFilesManager tfm;
 	private final List<WorkspaceEventListener> listeners;
 	private int maximumObjectSearchCount;
 	
 	public Workspace(
 			final WorkspaceDatabase db,
 			final ResourceUsageConfiguration cfg,
-			final TypedObjectValidator validator) {
-		this(db, cfg, validator, Collections.emptyList());
+			final TypedObjectValidator validator,
+			final TempFilesManager tfm) {
+		this(db, cfg, validator, tfm, Collections.emptyList());
 	}
 	
 	public Workspace(
 			final WorkspaceDatabase db,
 			final ResourceUsageConfiguration cfg,
 			final TypedObjectValidator validator,
+			final TempFilesManager tfm,
 			final List<WorkspaceEventListener> listeners) {
-		if (db == null) {
-			throw new NullPointerException("db cannot be null");
-		}
-		if (cfg == null) {
-			throw new NullPointerException("cfg cannot be null");
-		}
-		if (validator == null) {
-			throw new NullPointerException("validator cannot be null");
-		}
+		this.db = requireNonNull(db, "db");
+		rescfg = requireNonNull(cfg, "cfg");
+		//TODO DBCONSIST check that a few object types exist to make sure the type provider is ok.
+		this.validator = requireNonNull(validator, "validator");
+		this.tfm = requireNonNull(tfm, "tfm");
 		nonNull(listeners, "listeners");
 		noNulls(listeners, "null item in listeners");
-		this.db = db;
-		//TODO DBCONSIST check that a few object types exist to make sure the type provider is ok.
-		this.validator = validator;
-		rescfg = cfg;
 		this.listeners = Collections.unmodifiableList(listeners);
 		db.setResourceUsageConfiguration(rescfg);
 		this.maximumObjectSearchCount = MAX_OBJECT_SEARCH_COUNT_DEFAULT;
@@ -153,7 +148,7 @@ public class Workspace {
 	}
 	
 	public TempFilesManager getTempFilesManager() {
-		return db.getTempFilesManager();
+		return tfm;
 	}
 	
 	public List<DependencyStatus> status() {
@@ -1181,7 +1176,7 @@ public class Workspace {
 					 * originals will then be discarded
 					 */
 					rescfg.getMaxReturnedDataSize() * 2L,
-					db.getTempFilesManager());
+					tfm);
 		}
 	}
 

--- a/src/us/kbase/workspace/database/WorkspaceDatabase.java
+++ b/src/us/kbase/workspace/database/WorkspaceDatabase.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import us.kbase.typedobj.core.SubsetSelection;
-import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.exceptions.TypedObjectExtractionException;
 import us.kbase.workspace.database.ListObjectsParameters.ResolvedListObjectParameters;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
@@ -605,8 +604,6 @@ public interface WorkspaceDatabase {
 	public void addAdmin(WorkspaceUser user)
 			throws WorkspaceCommunicationException;
 	
-	public TempFilesManager getTempFilesManager();
-
 	public void setResourceUsageConfiguration(
 			ResourceUsageConfiguration rescfg);
 	

--- a/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
+++ b/src/us/kbase/workspace/database/mongo/MongoWorkspaceDB.java
@@ -42,7 +42,6 @@ import us.kbase.typedobj.core.AbsoluteTypeDefId;
 import us.kbase.typedobj.core.ExtractedMetadata;
 import us.kbase.typedobj.core.MD5;
 import us.kbase.typedobj.core.SubsetSelection;
-import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.TypeDefName;
 import us.kbase.typedobj.exceptions.ExceededMaxMetadataSizeException;
 import us.kbase.typedobj.exceptions.TypedObjectExtractionException;
@@ -151,7 +150,6 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 	private final QueryMethods query;
 	private final ObjectInfoUtils objutils;
 	
-	private final TempFilesManager tfm;
 	// TODO TEST add more unit tests using the mocked clock 
 	private final Clock clock;
 	
@@ -254,33 +252,27 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 	/** Create a workspace database using MongoDB as a backend.
 	 * @param workspaceDB the MongoDB in which to store data
 	 * @param blobStore the blob store in which to store object data
-	 * @param tfm the temporary files manager
 	 * @throws WorkspaceCommunicationException if the backend cannot be reached
 	 * @throws WorkspaceDBInitializationException if the database cannot be initialized
 	 * @throws CorruptWorkspaceDBException if the database is corrupt.
 	 */
-	public MongoWorkspaceDB(
-			final MongoDatabase workspaceDB,
-			final BlobStore blobStore,
-			final TempFilesManager tfm)
+	public MongoWorkspaceDB(final MongoDatabase workspaceDB, final BlobStore blobStore)
 			throws WorkspaceCommunicationException,
 				WorkspaceDBInitializationException, CorruptWorkspaceDBException {
-		this(workspaceDB, blobStore, tfm, Clock.systemDefaultZone());
+		this(workspaceDB, blobStore, Clock.systemDefaultZone());
 	}
 	
 	// for tests
 	private MongoWorkspaceDB(
 			final MongoDatabase workspaceDB,
 			final BlobStore blobStore,
-			final TempFilesManager tfm,
 			final Clock clock)
 			throws WorkspaceCommunicationException,
 				WorkspaceDBInitializationException, CorruptWorkspaceDBException {
-		if (workspaceDB == null || blobStore == null || tfm == null) {
+		if (workspaceDB == null || blobStore == null) {
 			throw new NullPointerException("No arguments can be null");
 		}
 		rescfg = new ResourceUsageConfigurationBuilder().build();
-		this.tfm = tfm;
 		this.clock = clock;
 		wsmongo = workspaceDB;
 		query = new QueryMethods(wsmongo, (AllUsers) ALL_USERS, COL_WORKSPACES,
@@ -420,11 +412,6 @@ public class MongoWorkspaceDB implements WorkspaceDatabase {
 	public void setResourceUsageConfiguration(
 			final ResourceUsageConfiguration rescfg) {
 		this.rescfg = rescfg;
-	}
-	
-	@Override
-	public TempFilesManager getTempFilesManager() {
-		return tfm;
 	}
 	
 	private static void checkConfig(final MongoDatabase wsmongo)

--- a/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
+++ b/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
@@ -172,11 +172,12 @@ public class InitWorkspaceServer {
 		final AdministratorHandler ah;
 		final Workspace ws;
 		try {
-			wsdeps = getDependencies(cfg, tfm, auth, rep);
+			wsdeps = getDependencies(cfg, auth, rep);
 			ws = new Workspace(
 					wsdeps.mongoWS,
 					new ResourceUsageConfigurationBuilder().build(),
 					wsdeps.validator,
+					tfm,
 					wsdeps.listeners);
 			ah = getAdminHandler(cfg, ws);
 		} catch (WorkspaceInitException wie) {
@@ -245,7 +246,6 @@ public class InitWorkspaceServer {
 	
 	private static WorkspaceDependencies getDependencies(
 			final KBaseWorkspaceConfig cfg,
-			final TempFilesManager tfm,
 			final ConfigurableAuthService auth,
 			final InitReporter rep) // DO NOT use the rep to report failures. Throw instead.
 			throws WorkspaceInitException {
@@ -267,7 +267,7 @@ public class InitWorkspaceServer {
 		}
 		deps.validator = new TypedObjectValidator(new LocalTypeProvider(deps.typeDB));
 		try {
-			deps.mongoWS = new MongoWorkspaceDB(db, bs, tfm);
+			deps.mongoWS = new MongoWorkspaceDB(db, bs);
 		} catch (WorkspaceDBException wde) {
 			throw new WorkspaceInitException(
 					"Error initializing the workspace database: " +

--- a/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
@@ -117,13 +117,12 @@ public class MongoInternalsTest {
 		TestCommon.destroyDB(db);
 		TestCommon.destroyDB(tdb);
 		
-		TempFilesManager tfm = new TempFilesManager(
-				new File(TestCommon.getTempDir()));
+		final TempFilesManager tfm = new TempFilesManager(new File(TestCommon.getTempDir()));
 		final TypeDefinitionDB typeDefDB = new TypeDefinitionDB(new MongoTypeStorage(tdb));
 		TypedObjectValidator val = new TypedObjectValidator(
 				new LocalTypeProvider(typeDefDB));
-		mwdb = new MongoWorkspaceDB(db, new GridFSBlobStore(db), tfm);
-		ws = new Workspace(mwdb, new ResourceUsageConfigurationBuilder().build(), val);
+		mwdb = new MongoWorkspaceDB(db, new GridFSBlobStore(db));
+		ws = new Workspace(mwdb, new ResourceUsageConfigurationBuilder().build(), val, tfm);
 
 		//make a general spec that tests that don't worry about typechecking can use
 		WorkspaceUser foo = new WorkspaceUser("foo");
@@ -780,7 +779,7 @@ public class MongoInternalsTest {
 			paths.put(o, null);
 		}
 		final ByteArrayFileCacheManager man = new ByteArrayFileCacheManager(
-				10000, 10000, mwdb.getTempFilesManager());
+				10000, 10000, ws.getTempFilesManager());
 		try {
 			mwdb.getObjects(paths, man, 0, true, false, true);
 			fail("operated on object with no version");

--- a/src/us/kbase/workspace/test/database/mongo/MongoStartUpTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoStartUpTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.fail;
 import static us.kbase.common.test.TestCommon.assertExceptionCorrect;
 import static us.kbase.common.test.TestCommon.set;
 
-import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Paths;
@@ -30,7 +29,6 @@ import com.mongodb.client.MongoDatabase;
 
 import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.controllers.mongo.MongoController;
-import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.typedobj.core.TypeDefName;
 import us.kbase.workspace.database.WorkspaceInformation;
@@ -74,8 +72,7 @@ public class MongoStartUpTest {
 		
 		TestCommon.destroyDB(mdb);
 		
-		TempFilesManager tfm = new TempFilesManager(new File(TestCommon.getTempDir()));
-		new MongoWorkspaceDB(mdb, new GridFSBlobStore(mdb), tfm);
+		new MongoWorkspaceDB(mdb, new GridFSBlobStore(mdb));
 	}
 
 	@AfterClass
@@ -93,8 +90,7 @@ public class MongoStartUpTest {
 	@Test
 	public void startUpAndCheckConfigDoc() throws Exception {
 		final MongoDatabase db = mongoClient.getDatabase("startUpAndCheckConfigDoc");
-		TempFilesManager tfm = new TempFilesManager(new File(TestCommon.getTempDir()));
-		new MongoWorkspaceDB(db, new GridFSBlobStore(db), tfm);
+		new MongoWorkspaceDB(db, new GridFSBlobStore(db));
 		
 		final MongoCursor<Document> c = db.getCollection("config").find().iterator();
 		final Document cd = c.next();
@@ -104,7 +100,7 @@ public class MongoStartUpTest {
 		assertThat("Only one config doc", c.hasNext(), is(false));
 		
 		//check startup works with the config object in place
-		MongoWorkspaceDB m = new MongoWorkspaceDB(db,  new GridFSBlobStore(db), tfm);
+		MongoWorkspaceDB m = new MongoWorkspaceDB(db,  new GridFSBlobStore(db));
 		WorkspaceInformation ws = m.createWorkspace(
 				new WorkspaceUser("foo"), "bar", false, null, new WorkspaceUserMetadata());
 		assertThat("check a ws field", ws.getName(), is("bar"));
@@ -156,9 +152,8 @@ public class MongoStartUpTest {
 
 	private void failMongoWSStart(final MongoDatabase db, final Exception exp)
 			throws Exception {
-		TempFilesManager tfm = new TempFilesManager(new File(TestCommon.getTempDir()));
 		try {
-			new MongoWorkspaceDB(db, new GridFSBlobStore(db), tfm);
+			new MongoWorkspaceDB(db, new GridFSBlobStore(db));
 			fail("started mongo with bad config");
 		} catch (Exception e) {
 			assertExceptionCorrect(e, exp);

--- a/src/us/kbase/workspace/test/database/mongo/PartialMock.java
+++ b/src/us/kbase/workspace/test/database/mongo/PartialMock.java
@@ -8,7 +8,6 @@ import java.time.Clock;
 
 import com.mongodb.client.MongoDatabase;
 
-import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.workspace.database.mongo.BlobStore;
 import us.kbase.workspace.database.mongo.MongoWorkspaceDB;
 
@@ -21,19 +20,17 @@ public class PartialMock {
 	
 	public final MongoWorkspaceDB mdb;
 	public final BlobStore bsmock;
-	public final TempFilesManager tfmmock;
 	public final Clock clockmock;
 	
 	public PartialMock(final MongoDatabase db) {
 		bsmock = mock(BlobStore.class);
-		tfmmock = mock(TempFilesManager.class);
 		clockmock = mock(Clock.class);
 		Constructor<MongoWorkspaceDB> con;
 		try {
 			con = MongoWorkspaceDB.class.getDeclaredConstructor(
-					MongoDatabase.class, BlobStore.class, TempFilesManager.class, Clock.class);
+					MongoDatabase.class, BlobStore.class, Clock.class);
 			con.setAccessible(true);
-			mdb = con.newInstance(db, bsmock, tfmmock, clockmock);
+			mdb = con.newInstance(db, bsmock, clockmock);
 		} catch (NoSuchMethodException | SecurityException | InstantiationException |
 				IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
 			throw new RuntimeException(

--- a/src/us/kbase/workspace/test/workspace/WorkspaceConstructorTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceConstructorTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.junit.Test;
 
 import us.kbase.common.test.TestCommon;
+import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
@@ -24,13 +25,15 @@ public class WorkspaceConstructorTest {
 	public void construct3() throws Exception {
 		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
 		final TypedObjectValidator tv = mock(TypedObjectValidator.class);
+		final TempFilesManager tfm = mock(TempFilesManager.class);
 		final ResourceUsageConfiguration cfg = new ResourceUsageConfigurationBuilder()
 				.withMaxObjectSize(3).build();
 		
-		final Workspace ws = new Workspace(db, cfg, tv);
+		final Workspace ws = new Workspace(db, cfg, tv, tfm);
 		
 		assertThat("incorrect resource cfg", ws.getResourceConfig(), is(cfg));
 		assertThat("incorrect max search count", ws.getMaximumObjectSearchCount(), is(10000));
+		assertThat("incorrect tfm", ws.getTempFilesManager(), is(tfm));
 		
 		// not worth the trouble to run something to check that the db and val are set. If not,
 		// lots of other tests will fail
@@ -40,46 +43,52 @@ public class WorkspaceConstructorTest {
 	public void construct4() throws Exception {
 		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
 		final TypedObjectValidator tv = mock(TypedObjectValidator.class);
+		final TempFilesManager tfm = mock(TempFilesManager.class);
 		final ResourceUsageConfiguration cfg = new ResourceUsageConfigurationBuilder()
 				.withMaxObjectSize(3).build();
 		final WorkspaceEventListener l = mock(WorkspaceEventListener.class);
 		
-		final Workspace ws = new Workspace(db, cfg, tv, Arrays.asList(l));
+		final Workspace ws = new Workspace(db, cfg, tv, tfm, Arrays.asList(l));
 		
 		assertThat("incorrect resource cfg", ws.getResourceConfig(), is(cfg));
 		assertThat("incorrect max search count", ws.getMaximumObjectSearchCount(), is(10000));
+		assertThat("incorrect tfm", ws.getTempFilesManager(), is(tfm));
 		
 		// not worth the trouble to run something to check that the db, val, and l are set. If not,
 		// lots of other tests will fail
 	}
 	
 	@Test
-	public void construct3Fail() throws Exception {
-		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
-		final TypedObjectValidator tv = mock(TypedObjectValidator.class);
-		final ResourceUsageConfiguration cfg = new ResourceUsageConfigurationBuilder()
-				.withMaxObjectSize(3).build();
-		
-		failConstruct(null, cfg, tv, new NullPointerException("db cannot be null"));
-		failConstruct(db, null, tv, new NullPointerException("cfg cannot be null"));
-		failConstruct(db, cfg, null, new NullPointerException("validator cannot be null"));
-	}
-	
-	@Test
 	public void construct4Fail() throws Exception {
 		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
 		final TypedObjectValidator tv = mock(TypedObjectValidator.class);
+		final TempFilesManager tfm = mock(TempFilesManager.class);
 		final ResourceUsageConfiguration cfg = new ResourceUsageConfigurationBuilder()
 				.withMaxObjectSize(3).build();
+		
+		failConstruct(null, cfg, tv, tfm, new NullPointerException("db"));
+		failConstruct(db, null, tv, tfm, new NullPointerException("cfg"));
+		failConstruct(db, cfg, null, tfm, new NullPointerException("validator"));
+		failConstruct(db, cfg, tv, null, new NullPointerException("tfm"));
+	}
+	
+	@Test
+	public void construct5Fail() throws Exception {
+		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
+		final TypedObjectValidator tv = mock(TypedObjectValidator.class);
+		final ResourceUsageConfiguration cfg = new ResourceUsageConfigurationBuilder()
+				.withMaxObjectSize(3).build();
+		final TempFilesManager tfm = mock(TempFilesManager.class);
 		final WorkspaceEventListener wel = mock(WorkspaceEventListener.class);
 		final List<WorkspaceEventListener> l = Arrays.asList(wel);
 		
 		
-		failConstruct(null, cfg, tv, l, new NullPointerException("db cannot be null"));
-		failConstruct(db, null, tv, l, new NullPointerException("cfg cannot be null"));
-		failConstruct(db, cfg, null, l, new NullPointerException("validator cannot be null"));
-		failConstruct(db, cfg, tv, null, new NullPointerException("listeners"));
-		failConstruct(db, cfg, tv, Arrays.asList(wel, null),
+		failConstruct(null, cfg, tv, tfm, l, new NullPointerException("db"));
+		failConstruct(db, null, tv, tfm, l, new NullPointerException("cfg"));
+		failConstruct(db, cfg, null, tfm, l, new NullPointerException("validator"));
+		failConstruct(db, cfg, tv, tfm, null, new NullPointerException("listeners"));
+		failConstruct(db, cfg, tv, null, l, new NullPointerException("tfm"));
+		failConstruct(db, cfg, tv, tfm, Arrays.asList(wel, null),
 				new NullPointerException("null item in listeners"));
 	}
 
@@ -87,9 +96,10 @@ public class WorkspaceConstructorTest {
 			final WorkspaceDatabase db,
 			final ResourceUsageConfiguration cfg,
 			final TypedObjectValidator tv,
+			final TempFilesManager tfm,
 			final Exception e) {
 		try {
-			new Workspace(db, cfg, tv);
+			new Workspace(db, cfg, tv, tfm);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);
@@ -100,10 +110,11 @@ public class WorkspaceConstructorTest {
 			final WorkspaceDatabase db,
 			final ResourceUsageConfiguration cfg,
 			final TypedObjectValidator tv,
+			final TempFilesManager tfm,
 			final List<WorkspaceEventListener> l,
 			final Exception e) {
 		try {
-			new Workspace(db, cfg, tv, l);
+			new Workspace(db, cfg, tv, tfm, l);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);

--- a/src/us/kbase/workspace/test/workspace/WorkspaceIntegrationWithGridFSTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceIntegrationWithGridFSTest.java
@@ -118,9 +118,10 @@ public class WorkspaceIntegrationWithGridFSTest {
 		final TypeDefinitionDB typeDB = new TypeDefinitionDB(new MongoTypeStorage(tdb));
 		final TypedObjectValidator val = new TypedObjectValidator(new LocalTypeProvider(typeDB));
 		WORK = new Workspace(
-				new MongoWorkspaceDB(wsdb, new GridFSBlobStore(wsdb), TFM),
+				new MongoWorkspaceDB(wsdb, new GridFSBlobStore(wsdb)),
 				new ResourceUsageConfigurationBuilder().build(),
-				val);
+				val,
+				TFM);
 		WorkspaceTestCommon.installBasicSpecs(new WorkspaceUser("user"), new Types(typeDB));
 	}
 	

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -300,9 +300,9 @@ public class WorkspaceTester {
 		final TypeDefinitionDB typeDefDB = new TypeDefinitionDB(new MongoTypeStorage(tdb));
 		final TypedObjectValidator val = new TypedObjectValidator(
 				new LocalTypeProvider(typeDefDB));
-		final MongoWorkspaceDB mwdb = new MongoWorkspaceDB(wsdb, bs, tfm);
+		final MongoWorkspaceDB mwdb = new MongoWorkspaceDB(wsdb, bs);
 		final Workspace work = new Workspace(
-				mwdb, new ResourceUsageConfigurationBuilder().build(), val);
+				mwdb, new ResourceUsageConfigurationBuilder().build(), val, tfm);
 		final Types t = new Types(typeDefDB);
 		if (maxMemoryUsePerCall != null) {
 			final ResourceUsageConfigurationBuilder build =

--- a/src/us/kbase/workspace/test/workspace/WorkspaceUnitTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceUnitTest.java
@@ -22,6 +22,7 @@ import us.kbase.workspace.database.WorkspaceUser;
 import us.kbase.workspace.database.WorkspaceUserMetadata;
 import us.kbase.workspace.exceptions.WorkspaceAuthorizationException;
 import us.kbase.common.test.TestCommon;
+import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.workspace.database.AllUsers;
 import us.kbase.workspace.database.Permission;
@@ -51,11 +52,12 @@ public class WorkspaceUnitTest {
 	private TestMocks initMocks() {
 		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
 		final TypedObjectValidator val = mock(TypedObjectValidator.class);
+		final TempFilesManager tfm = mock(TempFilesManager.class);
 		
 		final ResourceUsageConfiguration b = new ResourceUsageConfigurationBuilder().build();
-		final Workspace ws = new Workspace(db, b, val);
+		final Workspace ws = new Workspace(db, b, val, tfm);
 		
-		return new TestMocks(db, val, b, ws);
+		return new TestMocks(db, val, b, ws, tfm);
 	}
 	
 	private class TestMocks {
@@ -65,16 +67,20 @@ public class WorkspaceUnitTest {
 		@SuppressWarnings("unused")
 		private final ResourceUsageConfiguration cfg;
 		private final Workspace ws;
+		@SuppressWarnings("unused")
+		private TempFilesManager tfm;
 		
 		private TestMocks(
 				final WorkspaceDatabase db,
 				final TypedObjectValidator val,
 				final ResourceUsageConfiguration cfg,
-				final Workspace ws) {
+				final Workspace ws,
+				final TempFilesManager tfm) {
 			this.db = db;
 			this.val = val;
 			this.cfg = cfg;
 			this.ws = ws;
+			this.tfm = tfm;
 		}
 	}
 	

--- a/test/performance/GetObjectsLibSpeedTest.java
+++ b/test/performance/GetObjectsLibSpeedTest.java
@@ -73,8 +73,7 @@ public class GetObjectsLibSpeedTest {
 		//need to redo set up if this is used again
 //		us.kbase.workspace.test.WorkspaceTestCommonDeprecated.destroyAndSetupDB(
 //				1, WorkspaceTestCommon.SHOCK, shockuser, null);
-		TempFilesManager tfm = new TempFilesManager(
-				new File(TestCommon.getTempDir()));
+		final TempFilesManager tfm = new TempFilesManager(new File(TestCommon.getTempDir()));
 		
 		@SuppressWarnings("resource")
 		final MongoClient mc = new MongoClient(mongohost);
@@ -83,8 +82,9 @@ public class GetObjectsLibSpeedTest {
 				mc.getDatabase(typeDB)));
 		TypedObjectValidator val = new TypedObjectValidator(
 				new LocalTypeProvider(typeDefDB));
-		MongoWorkspaceDB mwdb = new MongoWorkspaceDB(db, new GridFSBlobStore(db), tfm);
-		Workspace ws = new Workspace(mwdb, new ResourceUsageConfigurationBuilder().build(), val);
+		final MongoWorkspaceDB mwdb = new MongoWorkspaceDB(db, new GridFSBlobStore(db));
+		final Workspace ws = new Workspace(
+				mwdb, new ResourceUsageConfigurationBuilder().build(), val, tfm);
 		Types types = new Types(typeDefDB);
 		
 		WorkspaceUser user = new WorkspaceUser("foo");


### PR DESCRIPTION
This was too stupid not to fix. Maybe `MongoWorkspaceDB` at some point
used `TempFilesManager` but now it doesn't touch TFM. Make the
`Workspace` class responsible for it since WS actually uses it.