### PR TITLE
Fix build & update copyright

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - echo $PYVER
   - pyenv local $PYVER
   - python --version
-  - pip3 install pipenv
+  - pip3 install pipenv==2021.5.29
 
 install:
   - export HOMEDIR=`pwd`

--- a/docsource/conf.py
+++ b/docsource/conf.py
@@ -43,7 +43,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'KBase Workspace'
-copyright = u'2012-2019, KBase'
+copyright = u'2012-present, KBase'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Build is failing due to `gunicorn` and `uwsgi` not being in the path.
The last build that succeeded was on `pipenv-2021.5.29`, failed builds
were on `pipenv-2021.11.5.post0`. See https://github.com/pypa/pipenv/issues/4831



Going to the `dev-gavin-incoming` branch so a build will succeed when merging to develop