### PR TITLE
Add all ObjectIdentifier subclass methods to superclass

### DIFF
--- a/src/us/kbase/workspace/database/ObjectResolver.java
+++ b/src/us/kbase/workspace/database/ObjectResolver.java
@@ -15,7 +15,6 @@ import java.util.Set;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-import us.kbase.workspace.database.ObjectIdentifier.ObjectIDWithRefPath;
 import us.kbase.workspace.database.exceptions.CorruptWorkspaceDBException;
 import us.kbase.workspace.database.exceptions.InaccessibleObjectException;
 import us.kbase.workspace.database.exceptions.NoSuchObjectException;
@@ -188,7 +187,7 @@ public class ObjectResolver {
 		final Set<ObjectIdentifier> lookup = new HashSet<>();
 		List<ObjectIdentifier> nolookup = new LinkedList<>();
 		for (final ObjectIdentifier o: objects) {
-			if (o instanceof ObjectIDWithRefPath && ((ObjectIDWithRefPath) o).isLookupRequired()) {
+			if (o.isLookupRequired()) {
 				lookup.add(o);
 			} else {
 				nolookup.add(o);
@@ -204,16 +203,15 @@ public class ObjectResolver {
 		}
 		nolookup = null; //gc
 		
-		final List<ObjectIDWithRefPath> refpaths = new LinkedList<>();
+		final List<ObjectIdentifier> refpaths = new LinkedList<>();
 		final Map<ObjectIdentifier, ObjectIDResolvedWS> heads = new HashMap<>();
 		for (final ObjectIdentifier o: objects) {
 			if (lookup.contains(o)) { // need to do a lookup on this one, skip
 				refpaths.add(null); //maintain count for error reporting
 			} else if (!ws.containsKey(o)) { // skip, workspace wasn't resolved
 				// error reporting is off, so no need to keep track of location in list
-			} else if (o instanceof ObjectIDWithRefPath &&
-					((ObjectIDWithRefPath) o).hasRefPath()) {
-				refpaths.add((ObjectIDWithRefPath) o);
+			} else if (o.hasRefPath()) {
+				refpaths.add(o);
 				heads.put(o, ws.get(o));
 			} else {
 				refpaths.add(null); // maintain count for error reporting
@@ -424,7 +422,7 @@ public class ObjectResolver {
 	}
 	
 	private void resolveReferencePaths(
-			final List<ObjectIDWithRefPath> objsWithRefpaths,
+			final List<ObjectIdentifier> objsWithRefpaths,
 			final Map<ObjectIdentifier, ObjectIDResolvedWS> heads)
 			throws WorkspaceCommunicationException,
 				InaccessibleObjectException, CorruptWorkspaceDBException,
@@ -435,7 +433,7 @@ public class ObjectResolver {
 		}
 		//TODO CODE should probably have a limit on total path size per call, like 10000 or so
 		final List<ObjectIdentifier> allRefPathEntries = new LinkedList<>();
-		for (final ObjectIDWithRefPath oc: objsWithRefpaths) {
+		for (final ObjectIdentifier oc: objsWithRefpaths) {
 			if (oc != null) {
 				/* allow nulls in list to maintain object count in the case
 				 * calling method input includes objectIDs with and without
@@ -457,7 +455,7 @@ public class ObjectResolver {
 				getObjectOutgoingReferences(resolvedRefPathObjs, true, true);
 		
 		int chnum = 1;
-		for (final ObjectIDWithRefPath owrp: objsWithRefpaths) {
+		for (final ObjectIdentifier owrp: objsWithRefpaths) {
 			if (owrp != null) {
 				final ObjectReferenceSet refs = headrefs.get(heads.get(owrp));
 				if (refs != null) {
@@ -497,7 +495,7 @@ public class ObjectResolver {
 	}
 	
 	private List<Reference> getResolvedRefPath(
-			final ObjectIDWithRefPath head,
+			final ObjectIdentifier head,  // expected to have a ref path
 			final ObjectReferenceSet headrefs,
 			final Map<ObjectIdentifier, ObjectIDResolvedWS> resRefPathObjs,
 			final Map<ObjectIDResolvedWS, ObjectReferenceSet> outgoingRefs,

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -55,7 +55,6 @@ import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermis
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
 import us.kbase.workspace.database.ObjectIdentifier.ObjectIDWithRefPath;
-import us.kbase.workspace.database.ObjectIdentifier.ObjIDWithRefPathAndSubset;
 import us.kbase.workspace.database.ObjectResolver.ObjectResolution;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
 import us.kbase.workspace.database.refsearch.ReferenceSearchMaximumSizeExceededException;
@@ -1092,12 +1091,6 @@ public class Workspace {
 			
 			final List<WorkspaceObjectData> ret = new ArrayList<>();
 			for (final ObjectIdentifier o: loi) {
-				final SubsetSelection ss;
-				if (o instanceof ObjIDWithRefPathAndSubset) {
-					ss = ((ObjIDWithRefPathAndSubset) o).getSubSet();
-				} else {
-					ss = SubsetSelection.EMPTY;
-				}
 				final WorkspaceObjectData wod;
 				final ObjectResolution objres = res.getObjectResolution(o);
 				if (objres.equals(ObjectResolution.INACCESSIBLE)) {
@@ -1106,13 +1099,13 @@ public class Workspace {
 					final ObjectIDResolvedWS resobj = res.getResolvedObject(o);
 					if (objres.equals(ObjectResolution.NO_PATH)) {
 						if (stddata.containsKey(resobj)) {
-							wod = stddata.get(resobj).get(ss);
+							wod = stddata.get(resobj).get(o.getSubSet());
 						} else {
 							wod = null; //object was deleted or missing
 						}
 					} else {
 						// since was resolved by path, object must exist
-						final WorkspaceObjectData prewod = refdata.get(resobj).get(ss);
+						final WorkspaceObjectData prewod = refdata.get(resobj).get(o.getSubSet());
 						wod = prewod.updateObjectReferencePath(res.getReferencePath(o));
 					}
 				}
@@ -1191,11 +1184,7 @@ public class Workspace {
 			if (!paths.containsKey(roi)) {
 				paths.put(roi, new HashSet<>());
 			}
-			if (o instanceof ObjIDWithRefPathAndSubset) {
-				paths.get(roi).add(((ObjIDWithRefPathAndSubset) o).getSubSet());
-			} else {
-				paths.get(roi).add(SubsetSelection.EMPTY);
-			}
+			paths.get(roi).add(o.getSubSet());
 		}
 		return paths;
 	}

--- a/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
+++ b/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
@@ -973,7 +973,7 @@ public class IdentifierUtilsTest {
 		checkObjectIdentifier(oi, null, 3L, null, 2L, null, "3/2", "2", false);
 		
 		final ObjectIDWithRefPath oirc = (ObjectIDWithRefPath) oi;
-		assertThat("incorrect hasChain()", oirc.hasRefPath(), is(false));
+		assertThat("incorrect hasRefPath()", oirc.hasRefPath(), is(false));
 		assertThat("incorrect isLookupRequired()", oirc.isLookupRequired(), is(true));
 	}
 	
@@ -995,7 +995,7 @@ public class IdentifierUtilsTest {
 		
 		checkObjectIdentifier(oi, null, 3L, null, 2L, null, "3/2", "2", false);
 		
-		assertThat("incorrect hasChain()", oi.hasRefPath(), is(false));
+		assertThat("incorrect hasRefPath()", oi.hasRefPath(), is(false));
 		assertThat("incorrect isLookupRequired()", oi.isLookupRequired(), is(true));
 		final SubsetSelection op = oi.getSubSet();
 		final List<String> paths = new LinkedList<>();

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -8337,7 +8337,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		failCreateObjectChain(null, new ArrayList<ObjectIdentifier>(),
 				new IllegalArgumentException("id cannot be null"));
 		failCreateObjectChain(oi, Arrays.asList(oi, null, oi),
-				new IllegalArgumentException("Nulls are not allowed in reference chains"));
+				new IllegalArgumentException("Nulls are not allowed in reference paths"));
 	}
 	
 	@Test


### PR DESCRIPTION
No need to do bizarre instanceof checking, can now hide the subclass
implementations

Future PRs:
* Write a builder to replace the 9 constructors and 2 create methods
that picks the right class to return
* Hide the 2 subclasses and refactor code that uses them
* Write unit tests for the ObjectIdentifier class