### PR TITLE
DATAUP-725: Add object identifier builder starting from OI

### DIFF
--- a/src/us/kbase/workspace/database/ObjectIdentifier.java
+++ b/src/us/kbase/workspace/database/ObjectIdentifier.java
@@ -557,6 +557,14 @@ public class ObjectIdentifier {
 		return new Builder(wsi);
 	}
 	
+	/** Get a builder for an {@link ObjectIdentifier} starting with the same.
+	 * @param oi the object identifier from which to initialize the build.
+	 * @return a new builder.
+	 */
+	public static Builder getBuilder(final ObjectIdentifier oi) {
+		return new Builder(oi);
+	}
+	
 	/** A builder for an {@link ObjectIdentifier}. */
 	public static class Builder {
 		
@@ -571,6 +579,16 @@ public class ObjectIdentifier {
 
 		private Builder(final WorkspaceIdentifier wsi) {
 			this.wsi = requireNonNull(wsi, "wsi");
+		}
+
+		private Builder(final ObjectIdentifier oi) {
+			this.wsi = requireNonNull(oi, "oi").getWorkspaceIdentifier();
+			this.id = oi.getId() == null ? -1 : oi.getId();
+			this.name = oi.getName();
+			this.version = oi.getVersion() == null ? -1 : oi.getVersion();
+			this.refpath = oi.getRefPath().isEmpty() ? null : oi.getRefPath();
+			this.lookup = oi.isLookupRequired();
+			this.subset = oi.getSubSet();
 		}
 
 		/** Set a name for the object. This will remove any previously set ID.

--- a/src/us/kbase/workspace/test/workspace/ObjectIdentifierTest.java
+++ b/src/us/kbase/workspace/test/workspace/ObjectIdentifierTest.java
@@ -52,6 +52,11 @@ public class ObjectIdentifierTest {
 		assertThat("incorrect name", oi.getName(), is("f|o.A-1_2"));
 		assertThat("incorrect id", oi.getId(), is(nullValue()));
 		assertMinimalState(oi);
+		
+		final ObjectIdentifier newoi = ObjectIdentifier.getBuilder(oi).build();
+		assertThat("incorrect name", newoi.getName(), is("f|o.A-1_2"));
+		assertThat("incorrect id", newoi.getId(), is(nullValue()));
+		assertMinimalState(newoi);
 	}
 	
 	@Test
@@ -61,6 +66,11 @@ public class ObjectIdentifierTest {
 		assertThat("incorrect name", oi.getName(), is(nullValue()));
 		assertThat("incorrect id", oi.getId(), is(1L));
 		assertMinimalState(oi);
+		
+		final ObjectIdentifier newoi = ObjectIdentifier.getBuilder(oi).build();
+		assertThat("incorrect name", newoi.getName(), is(nullValue()));
+		assertThat("incorrect id", newoi.getId(), is(1L));
+		assertMinimalState(newoi);
 	}
 	
 	@Test
@@ -72,7 +82,15 @@ public class ObjectIdentifierTest {
 				.withLookupRequired(true)
 				.withSubsetSelection(new SubsetSelection(Arrays.asList("path1")))
 				.build();
+		assertOnBuildMaximalNameLookupVersionAndSubset(oi, wsi);
 		
+		final ObjectIdentifier newoi = ObjectIdentifier.getBuilder(oi).build();
+		assertOnBuildMaximalNameLookupVersionAndSubset(newoi, wsi);
+	}
+
+	public void assertOnBuildMaximalNameLookupVersionAndSubset(
+			final ObjectIdentifier oi,
+			final WorkspaceIdentifier wsi) {
 		assertThat("incorrect wsi", oi.getWorkspaceIdentifier(), is(wsi));
 		assertThat("incorrect name", oi.getName(), is(TEXT255));
 		assertThat("incorrect id", oi.getId(), is(nullValue()));
@@ -96,7 +114,17 @@ public class ObjectIdentifierTest {
 				.withVersion(1023)
 				.withReferencePath(Arrays.asList(oi1, oi2))
 				.build();
+		assertOnBuildMaximalIDWithRefPath(oi, wsi, oi1, oi2);
 		
+		final ObjectIdentifier newoi = ObjectIdentifier.getBuilder(oi).build();
+		assertOnBuildMaximalIDWithRefPath(newoi, wsi, oi1, oi2);
+	}
+
+	public void assertOnBuildMaximalIDWithRefPath(
+			final ObjectIdentifier oi,
+			final WorkspaceIdentifier wsi,
+			final ObjectIdentifier oi1,
+			final ObjectIdentifier oi2) {
 		assertThat("incorrect wsi", oi.getWorkspaceIdentifier(), is(wsi));
 		assertThat("incorrect name", oi.getName(), is(nullValue()));
 		assertThat("incorrect id", oi.getId(), is(42L));
@@ -387,10 +415,16 @@ public class ObjectIdentifierTest {
 	@Test
 	public void getBuilderFail() throws Exception {
 		try {
-			ObjectIdentifier.getBuilder(null);
+			ObjectIdentifier.getBuilder((WorkspaceIdentifier) null);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, new NullPointerException("wsi"));
+		}
+		try {
+			ObjectIdentifier.getBuilder((ObjectIdentifier) null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("oi"));
 		}
 	}
 	


### PR DESCRIPTION
Quickly became clear that doing otherwise was going to result in a *lot*
of refactoring that probably wasn't worth it

Handy anyway