### PR TITLE
DATAUP-725: Switch 11 ObjectIdentifier creation methods for 1 fluent builder

### DIFF
--- a/performance/us/kbase/workspace/performance/refsearch/GetReferencedObjectWithBFS.java
+++ b/performance/us/kbase/workspace/performance/refsearch/GetReferencedObjectWithBFS.java
@@ -24,7 +24,6 @@ import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
-import us.kbase.workspace.database.ObjectIdentifier.ObjectIDWithRefPath;
 import us.kbase.workspace.database.ObjectIdentifier;
 import us.kbase.workspace.database.ObjectInformation;
 import us.kbase.workspace.database.Provenance;
@@ -168,8 +167,8 @@ public class GetReferencedObjectWithBFS {
 			System.out.print(breadth + " ");
 			for (int j = 0; j < TEST_REPS; j++) {
 				long start = System.nanoTime();
-				WS.getObjects(u2, Arrays.asList((ObjectIdentifier) new ObjectIDWithRefPath(
-						new ObjectIdentifier(priv, o.getObjectId()))));
+				WS.getObjects(u2, Arrays.asList(ObjectIdentifier.getBuilder(priv)
+						.withID(o.getObjectId()).build()));
 				System.out.print((System.nanoTime() - start) + " ");
 			}
 			System.out.println();
@@ -232,8 +231,8 @@ public class GetReferencedObjectWithBFS {
 			System.out.print(i + " ");
 			for (int j = 0; j < TEST_REPS; j++) {
 				long start = System.nanoTime();
-				WS.getObjects(u2, Arrays.asList((ObjectIdentifier) new ObjectIDWithRefPath(
-						new ObjectIdentifier(priv, i))));
+				WS.getObjects(u2, Arrays.asList(ObjectIdentifier.getBuilder(priv)
+						.withID((long) i).build()));
 				System.out.print((System.nanoTime() - start) + " ");
 			}
 			System.out.println();

--- a/performance/us/kbase/workspace/performance/refsearch/v0_3_5/GetReferencedObjectWithBFS.java
+++ b/performance/us/kbase/workspace/performance/refsearch/v0_3_5/GetReferencedObjectWithBFS.java
@@ -177,7 +177,8 @@ public class GetReferencedObjectWithBFS {
 			System.out.print(breadth + " ");
 			for (int j = 0; j < TEST_REPS; j++) {
 				long start = System.nanoTime();
-				WS.getObjects(u2, Arrays.asList(new ObjectIdentifier(priv, o.getObjectId())), true);
+				WS.getObjects(u2, Arrays.asList(ObjectIdentifier.getBuilder(priv)
+						.withID(o.getObjectId()).build()), true);
 				System.out.print((System.nanoTime() - start) + " ");
 			}
 			System.out.println();
@@ -241,7 +242,8 @@ public class GetReferencedObjectWithBFS {
 			System.out.print(i + " ");
 			for (int j = 0; j < TEST_REPS; j++) {
 				long start = System.nanoTime();
-				WS.getObjects(u2, Arrays.asList(new ObjectIdentifier(priv, i)), true);
+				WS.getObjects(u2, Arrays.asList(ObjectIdentifier.getBuilder(priv)
+						.withID((long) i).build()), true);
 				System.out.print((System.nanoTime() - start) + " ");
 			}
 			System.out.println();

--- a/src/us/kbase/common/test/TestCommon.java
+++ b/src/us/kbase/common/test/TestCommon.java
@@ -275,12 +275,12 @@ public class TestCommon {
 	}
 	
 	@SafeVarargs
-	public static <T> Set<T> set(T... objects) {
+	public static <T> Set<T> set(final T... objects) {
 		return new HashSet<T>(Arrays.asList(objects));
 	}
 	
 	@SafeVarargs
-	public static <T> List<T> list(T... objects) {
+	public static <T> List<T> list(final T... objects) {
 		return Arrays.asList(objects);
 	}
 	

--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -59,7 +59,6 @@ import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.workspace.database.ListObjectsParameters;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
-import us.kbase.workspace.database.ObjectIdentifier.ObjectIDWithRefPath;
 import us.kbase.workspace.database.Types;
 import us.kbase.workspace.database.Workspace;
 import us.kbase.workspace.database.ObjectIdentifier;
@@ -792,8 +791,7 @@ public class WorkspaceServer extends JsonServerServlet {
 		if (refChains == null) {
 			throw new IllegalArgumentException("refChains may not be null");
 		}
-		final List<ObjectIdentifier> chains =
-				new LinkedList<ObjectIdentifier>();
+		final List<ObjectIdentifier> chains = new LinkedList<>();
 		int count = 1;
 		for (List<ObjectIdentity> loy: refChains) {
 			final List<ObjectIdentifier> lor;
@@ -809,8 +807,9 @@ public class WorkspaceServer extends JsonServerServlet {
 						"Error on object chain #%s: The minimum size of a reference chain is 2 ObjectIdentities",
 						count));
 			}
-			chains.add(new ObjectIDWithRefPath(
-					lor.get(0), lor.subList(1, lor.size())));
+			chains.add(ObjectIdentifier.getBuilder(lor.get(0))
+					.withReferencePath(lor.subList(1, lor.size()))
+					.build());
 			count++;
 		}
 		final List<WorkspaceObjectData> objects = ws.getObjects(

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -54,7 +54,6 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory.IdReferenceHandlerFa
 import us.kbase.typedobj.idref.IdReferencePermissionHandlerSet.IdReferencePermissionHandler;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
-import us.kbase.workspace.database.ObjectIdentifier.ObjectIDWithRefPath;
 import us.kbase.workspace.database.ObjectResolver.ObjectResolution;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
 import us.kbase.workspace.database.refsearch.ReferenceSearchMaximumSizeExceededException;
@@ -1831,8 +1830,11 @@ public class Workspace {
 			if (ois.size() == 1) {
 				return ois.get(0);
 			}
-			return new ObjectIDWithRefPath(ois.get(0), ois.subList(1, ois.size()));
-			
+			// probably not worth making a builder starting from a reference to avoid an
+			// extra OI instantiation
+			return ObjectIdentifier.getBuilder(ois.get(0))
+					.withReferencePath(ois.subList(1, ois.size()))
+					.build();
 		}
 
 		//use this method when an ID is bad regardless of the attribute set

--- a/src/us/kbase/workspace/test/workspace/ObjectIDNoWSNoVerTest.java
+++ b/src/us/kbase/workspace/test/workspace/ObjectIDNoWSNoVerTest.java
@@ -76,7 +76,7 @@ public class ObjectIDNoWSNoVerTest {
 	
 	@Test
 	public void create() {
-		checkCreate(null, "foo", new ObjectIDNoWSNoVer("foo"));
+		checkCreate(null, "f|o.A-1_2", new ObjectIDNoWSNoVer("f|o.A-1_2"));
 		checkCreate(6L, null, new ObjectIDNoWSNoVer(6));
 	}
 	

--- a/src/us/kbase/workspace/test/workspace/ObjectResolverTest.java
+++ b/src/us/kbase/workspace/test/workspace/ObjectResolverTest.java
@@ -21,7 +21,6 @@ import us.kbase.common.test.TestCommon;
 import us.kbase.common.test.TestException;
 import us.kbase.workspace.database.AllUsers;
 import us.kbase.workspace.database.ObjectIDResolvedWS;
-import us.kbase.workspace.database.ObjectIdentifier.ObjectIDWithRefPath;
 import us.kbase.workspace.database.ObjectIdentifier;
 import us.kbase.workspace.database.ObjectReferenceSet;
 import us.kbase.workspace.database.ObjectResolver;
@@ -51,7 +50,7 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier("wsfoo");
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier obj = new ObjectIdentifier(wsi, "objfoo");
+		final ObjectIdentifier obj = ObjectIdentifier.getBuilder(wsi).withName("objfoo").build();
 		final ObjectIDResolvedWS objresws = new ObjectIDResolvedWS(rwsi, "objfoo");
 		
 		when(wsdb.resolveWorkspaces(set(wsi), false)).thenReturn(ImmutableMap.of(wsi, rwsi));
@@ -81,7 +80,7 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier("wsfoo");
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier obj = new ObjectIdentifier(wsi, "objfoo");
+		final ObjectIdentifier obj = ObjectIdentifier.getBuilder(wsi).withName("objfoo").build();
 		
 		when(wsdb.resolveWorkspaces(set(wsi), false)).thenReturn(ImmutableMap.of(wsi, rwsi));
 		when(wsdb.getPermissions(user, set(rwsi))).thenReturn(
@@ -104,7 +103,7 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier("wsfoo");
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier obj = new ObjectIdentifier(wsi, "objfoo");
+		final ObjectIdentifier obj = ObjectIdentifier.getBuilder(wsi).withName("objfoo").build();
 		
 		when(wsdb.resolveWorkspaces(set(wsi), false)).thenReturn(ImmutableMap.of(wsi, rwsi));
 		when(wsdb.getPermissions(user, set(rwsi))).thenReturn(
@@ -134,7 +133,7 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier("wsfoo");
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier obj = new ObjectIdentifier(wsi, "objfoo");
+		final ObjectIdentifier obj = ObjectIdentifier.getBuilder(wsi).withName("objfoo").build();
 		final ObjectIDResolvedWS objresws = new ObjectIDResolvedWS(rwsi, "objfoo");
 		
 		when(wsdb.resolveWorkspaces(set(wsi), false)).thenReturn(ImmutableMap.of(wsi, rwsi));
@@ -166,12 +165,11 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier head = new ObjectIdentifier(wsi1, "objfoo");
-		final ObjectIdentifier path1 = new ObjectIdentifier(wsi1, "objfoo2");
-		final ObjectIdentifier path2 = new ObjectIdentifier(wsi2, "objfoo");
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(head, Arrays.asList(
-				path1, path2, pathend));
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi1).withName("objfoo")
+				.withReferencePath(Arrays.asList(
+						ObjectIdentifier.getBuilder(wsi1).withName("objfoo2").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo2").build())).build();
 		
 		final ObjectIDResolvedWS headresws = new ObjectIDResolvedWS(rwsi1, "objfoo");
 		final ObjectIDResolvedWS path1resws = new ObjectIDResolvedWS(rwsi1, "objfoo2");
@@ -231,12 +229,11 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi1 = new WorkspaceIdentifier("wsfoo1");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier head = new ObjectIdentifier(wsi1, "objfoo");
-		final ObjectIdentifier path1 = new ObjectIdentifier(wsi1, "objfoo2");
-		final ObjectIdentifier path2 = new ObjectIdentifier(wsi2, "objfoo");
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(head, Arrays.asList(
-				path1, path2, pathend));
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi1).withName("objfoo")
+				.withReferencePath(Arrays.asList(
+						ObjectIdentifier.getBuilder(wsi1).withName("objfoo2").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo2").build())).build();
 		
 		when(wsdb.resolveWorkspaces(set(wsi1), false)).thenReturn(ImmutableMap.of(wsi1, rwsi1));
 		when(wsdb.getPermissions(user, set(rwsi1))).thenReturn(
@@ -262,12 +259,11 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi1 = new WorkspaceIdentifier("wsfoo1");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier head = new ObjectIdentifier(wsi1, "objfoo");
-		final ObjectIdentifier path1 = new ObjectIdentifier(wsi1, "objfoo2");
-		final ObjectIdentifier path2 = new ObjectIdentifier(wsi2, "objfoo");
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(head, Arrays.asList(
-				path1, path2, pathend));
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi1).withName("objfoo")
+				.withReferencePath(Arrays.asList(
+						ObjectIdentifier.getBuilder(wsi1).withName("objfoo2").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo2").build())).build();
 		
 		when(wsdb.resolveWorkspaces(set(wsi1), false)).thenReturn(ImmutableMap.of(wsi1, rwsi1));
 		when(wsdb.getPermissions(user, set(rwsi1))).thenReturn(
@@ -296,12 +292,11 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi1 = new WorkspaceIdentifier("wsfoo1");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier head = new ObjectIdentifier(wsi1, "objfoo");
-		final ObjectIdentifier path1 = new ObjectIdentifier(wsi1, "objfoo2");
-		final ObjectIdentifier path2 = new ObjectIdentifier(wsi2, "objfoo");
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(head, Arrays.asList(
-				path1, path2, pathend));
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi1).withName("objfoo")
+				.withReferencePath(Arrays.asList(
+						ObjectIdentifier.getBuilder(wsi1).withName("objfoo2").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo2").build())).build();
 		
 		final ObjectIDResolvedWS headresws = new ObjectIDResolvedWS(rwsi1, "objfoo");
 		
@@ -332,12 +327,11 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi1 = new WorkspaceIdentifier("wsfoo1");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier head = new ObjectIdentifier(wsi1, "objfoo");
-		final ObjectIdentifier path1 = new ObjectIdentifier(wsi1, "objfoo2");
-		final ObjectIdentifier path2 = new ObjectIdentifier(wsi2, "objfoo");
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(head, Arrays.asList(
-				path1, path2, pathend));
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi1).withName("objfoo")
+				.withReferencePath(Arrays.asList(
+						ObjectIdentifier.getBuilder(wsi1).withName("objfoo2").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo2").build())).build();
 		
 		final ObjectIDResolvedWS headresws = new ObjectIDResolvedWS(rwsi1, "objfoo");
 		
@@ -372,12 +366,11 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier head = new ObjectIdentifier(wsi1, "objfoo");
-		final ObjectIdentifier path1 = new ObjectIdentifier(wsi1, "objfoo2");
-		final ObjectIdentifier path2 = new ObjectIdentifier(wsi2, "objfoo");
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(head, Arrays.asList(
-				path1, path2, pathend));
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi1).withName("objfoo")
+				.withReferencePath(Arrays.asList(
+						ObjectIdentifier.getBuilder(wsi1).withName("objfoo2").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo2").build())).build();
 		
 		final ObjectIDResolvedWS headresws = new ObjectIDResolvedWS(rwsi1, "objfoo");
 		final ObjectIDResolvedWS path1resws = new ObjectIDResolvedWS(rwsi1, "objfoo2");
@@ -435,12 +428,11 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi1 = new WorkspaceIdentifier("wsfoo1");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier head = new ObjectIdentifier(wsi1, "objfoo");
-		final ObjectIdentifier path1 = new ObjectIdentifier(wsi1, "objfoo2");
-		final ObjectIdentifier path2 = new ObjectIdentifier(wsi2, "objfoo");
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(head, Arrays.asList(
-				path1, path2, pathend));
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi1).withName("objfoo")
+				.withReferencePath(Arrays.asList(
+						ObjectIdentifier.getBuilder(wsi1).withName("objfoo2").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo2").build())).build();
 		
 		final ObjectIDResolvedWS headresws = new ObjectIDResolvedWS(rwsi1, "objfoo");
 		
@@ -470,12 +462,11 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi1 = new WorkspaceIdentifier("wsfoo1");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier head = new ObjectIdentifier(wsi1, "objfoo");
-		final ObjectIdentifier path1 = new ObjectIdentifier(wsi1, "objfoo2");
-		final ObjectIdentifier path2 = new ObjectIdentifier(wsi2, "objfoo");
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(head, Arrays.asList(
-				path1, path2, pathend));
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi1).withName("objfoo")
+				.withReferencePath(Arrays.asList(
+						ObjectIdentifier.getBuilder(wsi1).withName("objfoo2").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo").build(),
+						ObjectIdentifier.getBuilder(wsi2).withName("objfoo2").build())).build();
 		
 		final ObjectIDResolvedWS headresws = new ObjectIDResolvedWS(rwsi1, "objfoo");
 		
@@ -508,8 +499,8 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference pathendref = new Reference("4/1/1");
@@ -553,8 +544,8 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference pathendref = new Reference("4/1/1");
@@ -595,8 +586,8 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference pathendref = new Reference("4/1/1");
@@ -641,8 +632,8 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference pathendref = new Reference("4/1/1");
@@ -683,8 +674,8 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference pathendref = new Reference("4/1/1");
@@ -730,8 +721,8 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference pathendref = new Reference("4/1/1");
@@ -772,8 +763,8 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference pathendref = new Reference("4/1/1");
@@ -815,8 +806,8 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference pathendref = new Reference("4/1/1");
@@ -863,8 +854,8 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference headref = new Reference("3/6/3");
@@ -929,8 +920,8 @@ public class ObjectResolverTest {
 		
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		when(wsdb.getPermissions(user, Permission.READ, false)).thenReturn(
 				PermissionSet.getBuilder(user, new AllUsers('*'))
@@ -951,8 +942,8 @@ public class ObjectResolverTest {
 		
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		when(wsdb.getPermissions(user, Permission.READ, false)).thenReturn(
 				PermissionSet.getBuilder(user, new AllUsers('*'))
@@ -980,8 +971,8 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
 		final ResolvedWorkspaceID rwsireadable = new ResolvedWorkspaceID(5, "wsfoo3", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference headref = new Reference("3/6/3");
@@ -1040,8 +1031,8 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
 		final ResolvedWorkspaceID rwsireadable = new ResolvedWorkspaceID(5, "wsfoo3", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference headref = new Reference("3/6/3");
@@ -1105,8 +1096,8 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference headref = new Reference("3/6/3");
@@ -1168,8 +1159,8 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference headref = new Reference("3/6/3");
@@ -1236,8 +1227,8 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		
@@ -1271,8 +1262,8 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		
@@ -1310,8 +1301,8 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		when(wsdb.getPermissions(user, Permission.READ, false)).thenReturn(
 				PermissionSet.getBuilder(user, new AllUsers('*'))
@@ -1338,8 +1329,8 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		when(wsdb.getPermissions(user, Permission.READ, false)).thenReturn(
 				PermissionSet.getBuilder(user, new AllUsers('*'))
@@ -1371,8 +1362,8 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference headref = new Reference("3/6/3");
@@ -1446,8 +1437,8 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference headref = new Reference("3/6/3");
@@ -1517,8 +1508,8 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		final Reference headref = new Reference("3/6/3");
@@ -1593,8 +1584,8 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		
@@ -1629,8 +1620,8 @@ public class ObjectResolverTest {
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
 		final ResolvedWorkspaceID rwsi2 = new ResolvedWorkspaceID(4, "wsfoo2", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		final ObjectIDResolvedWS pathendresws = new ObjectIDResolvedWS(rwsi2, "objfoo2");
 		
@@ -1668,8 +1659,8 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		when(wsdb.getPermissions(user, Permission.READ, false)).thenReturn(
 				PermissionSet.getBuilder(user, new AllUsers('*'))
@@ -1701,8 +1692,8 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi2 = new WorkspaceIdentifier("wsfoo2");
 		final ResolvedWorkspaceID rwsi1 = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier pathend = new ObjectIdentifier(wsi2, "objfoo2");
-		final ObjectIDWithRefPath objpath = new ObjectIDWithRefPath(pathend);
+		final ObjectIdentifier objpath = ObjectIdentifier.getBuilder(wsi2).withName("objfoo2")
+				.withLookupRequired(true).build();
 		
 		when(wsdb.getPermissions(user, Permission.READ, false)).thenReturn(
 				PermissionSet.getBuilder(user, new AllUsers('*'))
@@ -1731,9 +1722,9 @@ public class ObjectResolverTest {
 		final WorkspaceUser user = new WorkspaceUser("userfoo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier("wsfoo");
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(3, "wsfoo", false, false);
-		final ObjectIdentifier objid = new ObjectIdentifier(wsi, "objfoo");
-		
-		final ObjectIDWithRefPath obj = new ObjectIDWithRefPath(objid);
+		final ObjectIdentifier obj = ObjectIdentifier.getBuilder(wsi).withName("objfoo")
+				.withLookupRequired(true).build();
+
 		final ObjectIDResolvedWS objresws = new ObjectIDResolvedWS(rwsi, "objfoo");
 		final Reference ref = new Reference("3/24/1");
 		final Reference topref = new Reference("3/27/1");

--- a/src/us/kbase/workspace/test/workspace/PermissionsCheckerFactoryTest.java
+++ b/src/us/kbase/workspace/test/workspace/PermissionsCheckerFactoryTest.java
@@ -471,8 +471,9 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceUser u = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
 		final WorkspaceIdentifier wsi42 = new WorkspaceIdentifier("thing");
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
-		final ObjectIdentifier obj42 = new ObjectIdentifier(wsi42, "entity");
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
+		final ObjectIdentifier obj42 = ObjectIdentifier.getBuilder(wsi42).withName("entity")
+				.build();
 		final ResolvedWorkspaceID res3 = new ResolvedWorkspaceID(3, "yay", false, false);
 		final ResolvedWorkspaceID res42 = new ResolvedWorkspaceID(42, "thing", false, false);
 		
@@ -503,8 +504,9 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceUser u = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
 		final WorkspaceIdentifier wsi42 = new WorkspaceIdentifier("thing");
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
-		final ObjectIdentifier obj42 = new ObjectIdentifier(wsi42, "entity");
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
+		final ObjectIdentifier obj42 = ObjectIdentifier.getBuilder(wsi42).withName("entity")
+				.build();
 		final ResolvedWorkspaceID res3 = new ResolvedWorkspaceID(3, "yay", true, false);
 		final ResolvedWorkspaceID res42 = new ResolvedWorkspaceID(42, "thing", false, false);
 		
@@ -535,8 +537,9 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceUser u = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
 		final WorkspaceIdentifier wsi42 = new WorkspaceIdentifier("thing");
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
-		final ObjectIdentifier obj42 = new ObjectIdentifier(wsi42, "entity");
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
+		final ObjectIdentifier obj42 = ObjectIdentifier.getBuilder(wsi42).withName("entity")
+				.build();
 		final ResolvedWorkspaceID res3 = new ResolvedWorkspaceID(3, "yay", false, false);
 		final ResolvedWorkspaceID res42 = new ResolvedWorkspaceID(42, "thing", false, false);
 		
@@ -567,8 +570,9 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceUser u = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
 		final WorkspaceIdentifier wsi42 = new WorkspaceIdentifier("thing");
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
-		final ObjectIdentifier obj42 = new ObjectIdentifier(wsi42, "entity");
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
+		final ObjectIdentifier obj42 = ObjectIdentifier.getBuilder(wsi42).withName("entity")
+				.build();
 		final ResolvedWorkspaceID res3 = new ResolvedWorkspaceID(3, "yay", false, false);
 		
 		final PermissionsCheckerFactory permfac = new PermissionsCheckerFactory(db, u);
@@ -596,8 +600,9 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceUser u = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
 		final WorkspaceIdentifier wsi42 = new WorkspaceIdentifier("thing");
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
-		final ObjectIdentifier obj42 = new ObjectIdentifier(wsi42, "entity");
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
+		final ObjectIdentifier obj42 = ObjectIdentifier.getBuilder(wsi42).withName("entity")
+				.build();
 		final ResolvedWorkspaceID res3 = new ResolvedWorkspaceID(3, "yay", false, false);
 		final ResolvedWorkspaceID res42 = new ResolvedWorkspaceID(42, "thing", false, true);
 		
@@ -628,8 +633,9 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceUser u = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
 		final WorkspaceIdentifier wsi42 = new WorkspaceIdentifier("thing");
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
-		final ObjectIdentifier obj42 = new ObjectIdentifier(wsi42, "entity");
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
+		final ObjectIdentifier obj42 = ObjectIdentifier.getBuilder(wsi42).withName("entity")
+				.build();
 		final ResolvedWorkspaceID res3 = new ResolvedWorkspaceID(3, "yay", false, false);
 		final ResolvedWorkspaceID res42 = new ResolvedWorkspaceID(42, "thing", false, true);
 		
@@ -662,8 +668,9 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceUser u = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
 		final WorkspaceIdentifier wsi42 = new WorkspaceIdentifier("thing");
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
-		final ObjectIdentifier obj42 = new ObjectIdentifier(wsi42, "entity");
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
+		final ObjectIdentifier obj42 = ObjectIdentifier.getBuilder(wsi42).withName("entity")
+				.build();
 		final ResolvedWorkspaceID res3 = new ResolvedWorkspaceID(3, "yay", false, false);
 		final ResolvedWorkspaceID res42 = new ResolvedWorkspaceID(42, "thing", false, true);
 		
@@ -692,7 +699,7 @@ public class PermissionsCheckerFactoryTest {
 	@Test
 	public void checkObjectsFailGetBuilder() throws Exception {
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(1);
-		final ObjectIdentifier oi = new ObjectIdentifier(wsi, 2);
+		final ObjectIdentifier oi = ObjectIdentifier.getBuilder(wsi).withID(2L).build();
 		final List<ObjectIdentifier> wsis = Arrays.asList(oi);
 		
 		failGetObjectsChecker(null, Permission.READ, new NullPointerException("objects"));
@@ -723,9 +730,10 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceUser u = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
 		final WorkspaceIdentifier wsi42 = new WorkspaceIdentifier("thing");
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
-		final ObjectIdentifier obj42 = new ObjectIdentifier(wsi42, "entity");
-		
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
+		final ObjectIdentifier obj42 = ObjectIdentifier.getBuilder(wsi42).withName("entity")
+				.build();
+
 		final PermissionsCheckerFactory permfac = new PermissionsCheckerFactory(db, u);
 		
 		when(db.resolveWorkspaces(set(wsi3, wsi42), false))
@@ -744,8 +752,9 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceUser u = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
 		final WorkspaceIdentifier wsi42 = new WorkspaceIdentifier("thing");
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
-		final ObjectIdentifier obj42 = new ObjectIdentifier(wsi42, "entity");
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
+		final ObjectIdentifier obj42 = ObjectIdentifier.getBuilder(wsi42).withName("entity")
+				.build();
 		final ResolvedWorkspaceID res3 = new ResolvedWorkspaceID(3, "yay", true, false);
 		final ResolvedWorkspaceID res42 = new ResolvedWorkspaceID(42, "thing", false, false);
 		
@@ -776,8 +785,9 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceUser u = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
 		final WorkspaceIdentifier wsi42 = new WorkspaceIdentifier("thing");
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
-		final ObjectIdentifier obj42 = new ObjectIdentifier(wsi42, "entity");
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
+		final ObjectIdentifier obj42 = ObjectIdentifier.getBuilder(wsi42).withName("entity")
+				.build();
 		// locked to test that permissions errors take precedence over locking
 		final ResolvedWorkspaceID res3 = new ResolvedWorkspaceID(3, "yay", true, false);
 		final ResolvedWorkspaceID res42 = new ResolvedWorkspaceID(42, "thing", false, false);
@@ -809,8 +819,9 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceUser u = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
 		final WorkspaceIdentifier wsi42 = new WorkspaceIdentifier("thing");
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
-		final ObjectIdentifier obj42 = new ObjectIdentifier(wsi42, "entity");
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
+		final ObjectIdentifier obj42 = ObjectIdentifier.getBuilder(wsi42).withName("entity")
+				.build();
 		// locked to test that permissions errors take precedence over locking
 		final ResolvedWorkspaceID res3 = new ResolvedWorkspaceID(3, "yay", true, false);
 		final ResolvedWorkspaceID res42 = new ResolvedWorkspaceID(42, "thing", false, false);
@@ -845,8 +856,9 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceUser u = null;
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
 		final WorkspaceIdentifier wsi42 = new WorkspaceIdentifier("thing");
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
-		final ObjectIdentifier obj42 = new ObjectIdentifier(wsi42, "entity");
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
+		final ObjectIdentifier obj42 = ObjectIdentifier.getBuilder(wsi42).withName("entity")
+				.build();
 		// locked to test that permissions errors take precedence over locking
 		final ResolvedWorkspaceID res3 = new ResolvedWorkspaceID(3, "yay", true, false);
 		final ResolvedWorkspaceID res42 = new ResolvedWorkspaceID(42, "thing", false, false);
@@ -899,7 +911,7 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
 		final WorkspaceUser u = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
 		final ResolvedWorkspaceID res3 = new ResolvedWorkspaceID(3, "yay", false, false);
 		
 		final PermissionsCheckerFactory permfac = new PermissionsCheckerFactory(db, u);
@@ -922,7 +934,7 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
 		final WorkspaceUser u = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
 		
 		final SingleObjectPermissionsChecker checker = new PermissionsCheckerFactory(db, u)
 				.getObjectChecker(obj3, Permission.READ);
@@ -947,7 +959,7 @@ public class PermissionsCheckerFactoryTest {
 	@Test
 	public void checkObjectFailGetBuilder() throws Exception {
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(1);
-		final ObjectIdentifier oi = new ObjectIdentifier(wsi, 2);
+		final ObjectIdentifier oi = ObjectIdentifier.getBuilder(wsi).withID(2L).build();
 		
 		failGetObjectChecker(null, Permission.READ, new NullPointerException(
 				"Object identifier cannot be null"));
@@ -972,7 +984,7 @@ public class PermissionsCheckerFactoryTest {
 		final WorkspaceDatabase db = mock(WorkspaceDatabase.class);
 		final WorkspaceUser u = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi3 = new WorkspaceIdentifier(3);
-		final ObjectIdentifier obj3 = new ObjectIdentifier(wsi3, 2);
+		final ObjectIdentifier obj3 = ObjectIdentifier.getBuilder(wsi3).withID(2L).build();
 		// locked to test that permissions errors take precedence over locking
 		final ResolvedWorkspaceID res3 = new ResolvedWorkspaceID(3, "yay", true, false);
 		

--- a/src/us/kbase/workspace/test/workspace/WorkspaceIntegrationWithGridFSTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceIntegrationWithGridFSTest.java
@@ -318,8 +318,10 @@ public class WorkspaceIntegrationWithGridFSTest {
 		checkSort(p, Collections.emptyList());
 		
 		// case 10: hidden and deleted objects
-		WORK.setObjectsDeleted(USER, Arrays.asList(new ObjectIdentifier(WS1, 7)), true);
-		WORK.setObjectsHidden(USER, Arrays.asList(new ObjectIdentifier(WS1, 4)), true);
+		WORK.setObjectsDeleted(USER, Arrays.asList(
+				ObjectIdentifier.getBuilder(WS1).withID(7L).build()), true);
+		WORK.setObjectsHidden(USER, Arrays.asList(
+				ObjectIdentifier.getBuilder(WS1).withID(4L).build()), true);
 		p = lob.withStartFrom(RefLimit.build(1L, 2L, 1)).build();
 		expected = Arrays.asList(
 				oinf(RWS1, 2, 1, ATYPE2_2_0),

--- a/src/us/kbase/workspace/test/workspace/WorkspaceListenerTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceListenerTest.java
@@ -673,7 +673,7 @@ public class WorkspaceListenerTest {
 		
 		final WorkspaceUser user = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
-		final ObjectIdentifier oi = new ObjectIdentifier(wsi, "whee");
+		final ObjectIdentifier oi = ObjectIdentifier.getBuilder(wsi).withName("whee").build();
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ugh", false, false);
 		final ObjectIDResolvedWS roi = new ObjectIDResolvedWS(rwsi, "whee");
 		
@@ -697,7 +697,7 @@ public class WorkspaceListenerTest {
 		
 		final WorkspaceUser user = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
-		final ObjectIdentifier oi = new ObjectIdentifier(wsi, "whee");
+		final ObjectIdentifier oi = ObjectIdentifier.getBuilder(wsi).withName("whee").build();
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ugh", false, false);
 		final ObjectIDResolvedWS roi = new ObjectIDResolvedWS(rwsi, "whee");
 		
@@ -722,7 +722,7 @@ public class WorkspaceListenerTest {
 		
 		final WorkspaceUser user = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
-		final ObjectIdentifier oi = new ObjectIdentifier(wsi, "whee");
+		final ObjectIdentifier oi = ObjectIdentifier.getBuilder(wsi).withName("whee").build();
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ugh", false, false);
 		final ObjectIDResolvedWS roi = new ObjectIDResolvedWS(rwsi, "whee");
 		
@@ -756,7 +756,7 @@ public class WorkspaceListenerTest {
 		
 		final WorkspaceUser user = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
-		final ObjectIdentifier oi = new ObjectIdentifier(wsi, "whee");
+		final ObjectIdentifier oi = ObjectIdentifier.getBuilder(wsi).withName("whee").build();
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ugh", false, false);
 		final ObjectIDResolvedWS roi = new ObjectIDResolvedWS(rwsi, "whee");
 		
@@ -790,8 +790,8 @@ public class WorkspaceListenerTest {
 		
 		final WorkspaceUser user = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
-		final ObjectIdentifier oi1 = new ObjectIdentifier(wsi, "whee");
-		final ObjectIdentifier oi2 = new ObjectIdentifier(wsi, "whoo");
+		final ObjectIdentifier oi1 = ObjectIdentifier.getBuilder(wsi).withName("whee").build();
+		final ObjectIdentifier oi2 = ObjectIdentifier.getBuilder(wsi).withName("whoo").build();
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ugh", false, false);
 		final ObjectIDResolvedWS roi1 = new ObjectIDResolvedWS(rwsi, "whee");
 		final ObjectIDResolvedWS roi2 = new ObjectIDResolvedWS(rwsi, "whoo");
@@ -820,8 +820,8 @@ public class WorkspaceListenerTest {
 		
 		final WorkspaceUser user = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
-		final ObjectIdentifier oi1 = new ObjectIdentifier(wsi, "whee");
-		final ObjectIdentifier oi2 = new ObjectIdentifier(wsi, "whoo");
+		final ObjectIdentifier oi1 = ObjectIdentifier.getBuilder(wsi).withName("whee").build();
+		final ObjectIdentifier oi2 = ObjectIdentifier.getBuilder(wsi).withName("whoo").build();
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ugh", false, false);
 		final ObjectIDResolvedWS roi1 = new ObjectIDResolvedWS(rwsi, "whee");
 		final ObjectIDResolvedWS roi2 = new ObjectIDResolvedWS(rwsi, "whoo");
@@ -852,8 +852,8 @@ public class WorkspaceListenerTest {
 		
 		final WorkspaceUser user = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
-		final ObjectIdentifier oi1 = new ObjectIdentifier(wsi, "whee");
-		final ObjectIdentifier oi2 = new ObjectIdentifier(wsi, "whoo");
+		final ObjectIdentifier oi1 = ObjectIdentifier.getBuilder(wsi).withName("whee").build();
+		final ObjectIdentifier oi2 = ObjectIdentifier.getBuilder(wsi).withName("whoo").build();
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ugh", false, false);
 		final ObjectIDResolvedWS roi1 = new ObjectIDResolvedWS(rwsi, "whee");
 		final ObjectIDResolvedWS roi2 = new ObjectIDResolvedWS(rwsi, "whoo");
@@ -882,8 +882,8 @@ public class WorkspaceListenerTest {
 		
 		final WorkspaceUser user = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
-		final ObjectIdentifier oi1 = new ObjectIdentifier(wsi, "whee");
-		final ObjectIdentifier oi2 = new ObjectIdentifier(wsi, "whoo");
+		final ObjectIdentifier oi1 = ObjectIdentifier.getBuilder(wsi).withName("whee").build();
+		final ObjectIdentifier oi2 = ObjectIdentifier.getBuilder(wsi).withName("whoo").build();
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ugh", false, false);
 		final ObjectIDResolvedWS roi1 = new ObjectIDResolvedWS(rwsi, "whee");
 		final ObjectIDResolvedWS roi2 = new ObjectIDResolvedWS(rwsi, "whoo");
@@ -914,8 +914,8 @@ public class WorkspaceListenerTest {
 		
 		final WorkspaceUser user = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
-		final ObjectIdentifier from = new ObjectIdentifier(wsi, "whoo");
-		final ObjectIdentifier to = new ObjectIdentifier(wsi, "whee");
+		final ObjectIdentifier from = ObjectIdentifier.getBuilder(wsi).withName("whoo").build();
+		final ObjectIdentifier to = ObjectIdentifier.getBuilder(wsi).withName("whee").build();
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ugh", false, false);
 		final ObjectIDResolvedWS rfrom = new ObjectIDResolvedWS(rwsi, "whoo");
 		final ObjectIDResolvedWS rto = new ObjectIDResolvedWS(rwsi, "whee");
@@ -950,8 +950,8 @@ public class WorkspaceListenerTest {
 		
 		final WorkspaceUser user = new WorkspaceUser("foo");
 		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
-		final ObjectIdentifier from = new ObjectIdentifier(wsi, "whoo");
-		final ObjectIdentifier to = new ObjectIdentifier(wsi, "whee");
+		final ObjectIdentifier from = ObjectIdentifier.getBuilder(wsi).withName("whoo").build();
+		final ObjectIdentifier to = ObjectIdentifier.getBuilder(wsi).withName("whee").build();
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ugh", false, false);
 		final ObjectIDResolvedWS rfrom = new ObjectIDResolvedWS(rwsi, "whoo");
 		final ObjectIDResolvedWS rto = new ObjectIDResolvedWS(rwsi, "whee");

--- a/src/us/kbase/workspace/test/workspace/WorkspaceLongTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceLongTest.java
@@ -27,7 +27,6 @@ import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.typedobj.core.TypeDefName;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
-import us.kbase.workspace.database.ObjectIdentifier.ObjIDWithRefPathAndSubset;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIdentifier;
 import us.kbase.workspace.database.ObjectInformation;
@@ -94,8 +93,10 @@ public class WorkspaceLongTest extends WorkspaceTester {
 		
 		//printMem("*** released refs ***");
 		
-		ByteArrayFileCache newdata = ws.getObjects(userfoo, 
-				Arrays.asList(new ObjectIdentifier(bigdataws, 1))).get(0).getSerializedData();
+		ByteArrayFileCache newdata = ws.getObjects(
+				userfoo,
+				Arrays.asList(ObjectIdentifier.getBuilder(bigdataws).withID(1L).build()))
+				.get(0).getSerializedData();
 //		printMem("*** retrieved object ***");
 //		System.gc();
 //		printMem("*** ran gc after retrieve ***");
@@ -179,8 +180,9 @@ public class WorkspaceLongTest extends WorkspaceTester {
 						emptyprov, false)),
 				getIdFactory());
 		
-		WorkspaceObjectData wod = ws.getObjects(userfoo,
-				Arrays.asList(new ObjectIdentifier(wspace, "last")))
+		WorkspaceObjectData wod = ws.getObjects(
+				userfoo,
+				Arrays.asList(ObjectIdentifier.getBuilder(wspace).withName("last").build()))
 				.get(0);
 		try {
 			@SuppressWarnings("unchecked")
@@ -230,7 +232,8 @@ public class WorkspaceLongTest extends WorkspaceTester {
 				new WorkspaceSaveObject(getRandomName(), data, SAFE_TYPE1, null,
 						new Provenance(userfoo), false)), getIdFactory());
 		final List<WorkspaceObjectData> objects = ws.getObjects(
-				userfoo, Arrays.asList(new ObjectIdentifier(unicode, 1)));
+				userfoo,
+				Arrays.asList(ObjectIdentifier.getBuilder(unicode).withID(1L).build()));
 		final Map<String, Object> newdata;
 		try {
 			@SuppressWarnings("unchecked")
@@ -254,7 +257,8 @@ public class WorkspaceLongTest extends WorkspaceTester {
 				new WorkspaceSaveObject(getRandomName(), data, SAFE_TYPE1, null,
 						new Provenance(userfoo), false)), getIdFactory());
 		final List<WorkspaceObjectData> objects2 = ws.getObjects(
-				userfoo, Arrays.asList(new ObjectIdentifier(unicode, 2)));
+				userfoo,
+				Arrays.asList(ObjectIdentifier.getBuilder(unicode).withID(2L).build()));
 		try {
 			@SuppressWarnings("unchecked")
 			Map<String, Object> newdata2 = (Map<String, Object>) getData(objects2.get(0));
@@ -338,8 +342,8 @@ public class WorkspaceLongTest extends WorkspaceTester {
 		int iterCount1 = 100;
 		for (int iter = 0; iter < iterCount1; iter++) {
 			long time1 = System.currentTimeMillis();
-			WorkspaceObjectData wod1 = ws.getObjects(userfoo,
-					Arrays.asList(new ObjectIdentifier(wspace, oi.getObjectId()))).get(0);
+			WorkspaceObjectData wod1 = ws.getObjects(userfoo, Arrays.asList(
+					ObjectIdentifier.getBuilder(wspace).withID(oi.getObjectId()).build())).get(0);
 			Map<String, Object> ret1 = (Map<String, Object>) getData(wod1);
 			String data1 = UObject.getMapper().writeValueAsString(ret1);
 			Map<String, Object> contigIdsToFeatures = (Map<String, Object>)ret1.get("data");
@@ -394,9 +398,8 @@ public class WorkspaceLongTest extends WorkspaceTester {
 				included.add("data/" + contigId + "/" + rnd.nextInt(featureCount));
 			long time2 = System.currentTimeMillis();
 			List<ObjectIdentifier> a = new LinkedList<ObjectIdentifier>();
-			a.add(new ObjIDWithRefPathAndSubset(
-					new ObjectIdentifier(wspace, oi.getObjectId()), null,
-						new SubsetSelection(included)));
+			a.add(ObjectIdentifier.getBuilder(wspace).withID(oi.getObjectId())
+					.withSubsetSelection(new SubsetSelection(included)).build());
 			WorkspaceObjectData wod2 = ws.getObjects(userfoo, a).get(0);
 			String data2 = UObject.getMapper().writeValueAsString(getData(wod2));
 			time2 = System.currentTimeMillis() - time2;

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -59,10 +59,8 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.workspace.database.AllUsers;
 import us.kbase.workspace.database.ListObjectsParameters;
-import us.kbase.workspace.database.ObjectIdentifier.ObjIDWithRefPathAndSubset;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIDResolvedWS;
-import us.kbase.workspace.database.ObjectIdentifier.ObjectIDWithRefPath;
 import us.kbase.workspace.database.ObjectIdentifier;
 import us.kbase.workspace.database.ObjectInformation;
 import us.kbase.workspace.database.Permission;
@@ -911,7 +909,7 @@ public class WorkspaceTester {
 	
 	protected void failGetReferencedObjects(
 			final WorkspaceUser user,
-			final List<ObjectIDWithRefPath> objs,
+			final List<ObjectIdentifier> objs,
 			final Exception e)
 			throws Exception {
 		
@@ -920,7 +918,7 @@ public class WorkspaceTester {
 	
 	protected void failGetReferencedObjects(
 			final WorkspaceUser user,
-			final List<ObjectIDWithRefPath> objs,
+			final List<ObjectIdentifier> objs,
 			final Exception e,
 			final Set<Integer> nulls)
 			throws Exception {
@@ -930,13 +928,13 @@ public class WorkspaceTester {
 	
 	protected void failGetReferencedObjects(
 			final WorkspaceUser user,
-			final List<ObjectIDWithRefPath> objs,
+			final List<ObjectIdentifier> objs,
 			final Exception e,
 			final boolean onlyTestReturningData)
 			throws Exception {
 		Set<Integer> nulls = new HashSet<Integer>();
 		int count = 0;
-		for (@SuppressWarnings("unused") ObjectIDWithRefPath foo: objs) {
+		for (@SuppressWarnings("unused") ObjectIdentifier foo: objs) {
 			nulls.add(count);
 			count++;
 		}
@@ -945,7 +943,7 @@ public class WorkspaceTester {
 	
 	protected void failGetReferencedObjects(
 			final WorkspaceUser user,
-			final List<ObjectIDWithRefPath> objs,
+			final List<ObjectIdentifier> objs,
 			final Exception e,
 			final boolean onlyTestReturningData,
 			final Set<Integer> nulls)
@@ -957,7 +955,7 @@ public class WorkspaceTester {
 	public static void failGetReferencedObjects(
 			final Workspace ws,
 			final WorkspaceUser user,
-			final List<ObjectIDWithRefPath> objs,
+			final List<ObjectIdentifier> objs,
 			final Exception e,
 			final boolean onlyTestReturningData,
 			final Set<Integer> nulls)
@@ -999,7 +997,7 @@ public class WorkspaceTester {
 	
 	protected void failGetSubset(
 			final WorkspaceUser user,
-			final List<ObjIDWithRefPathAndSubset> objs,
+			final List<ObjectIdentifier> objs,
 			final Exception e)
 			throws Exception {
 		failGetSubset(ws, user, objs, e);
@@ -1009,7 +1007,7 @@ public class WorkspaceTester {
 	public static void failGetSubset(
 			final Workspace ws,
 			final WorkspaceUser user,
-			final List<ObjIDWithRefPathAndSubset> objs,
+			final List<ObjectIdentifier> objs,
 			final Exception e)
 			throws Exception {
 		try {
@@ -1140,41 +1138,33 @@ public class WorkspaceTester {
 			new ResolvedWorkspaceID(1, "foo", false, false);
 	
 	protected void testObjectIdentifier(String goodId) {
-		new ObjectIdentifier(new WorkspaceIdentifier("foo"), goodId);
 		new ObjectIDResolvedWS(RWSID, goodId);
 //		new ObjectIDResolvedWSNoVer(fakews, goodId);
 		new ObjectIDNoWSNoVer(goodId);
 	}
 	
 	protected void testObjectIdentifier(String goodId, int version) {
-		new ObjectIdentifier(new WorkspaceIdentifier("foo"), goodId, version);
 		new ObjectIDResolvedWS(RWSID, goodId, version);
 //		new ObjectIDResolvedWSNoVer(fakews, goodId);
 		new ObjectIDNoWSNoVer(goodId);
 	}
 	
 	protected void testObjectIdentifier(int goodId) {
-		new ObjectIdentifier(new WorkspaceIdentifier("foo"), goodId);
 		new ObjectIDResolvedWS(RWSID, goodId);
 //		new ObjectIDResolvedWSNoVer(fakews, goodId);
 		new ObjectIDNoWSNoVer(goodId);
 	}
 	
 	protected void testObjectIdentifier(int goodId, int version) {
-		new ObjectIdentifier(new WorkspaceIdentifier("foo"), goodId, version);
 		new ObjectIDResolvedWS(RWSID, goodId, version);
 //		new ObjectIDResolvedWSNoVer(fakews, goodId);
 		new ObjectIDNoWSNoVer(goodId);
 	}
 	
-	protected void testObjectIdentifier(WorkspaceIdentifier badWS, String badId,
+	protected void testObjectIdentifier(
+			final WorkspaceIdentifier badWS,
+			final String badId,
 			String exception) {
-		try {
-			new ObjectIdentifier(badWS, badId);
-			fail("Initialized invalid object id");
-		} catch (IllegalArgumentException e) {
-			assertThat("correct exception string", e.getLocalizedMessage(), is(exception));
-		}
 		ResolvedWorkspaceID fakews = null;
 		if (badWS != null) {
 			fakews = RWSID;
@@ -1197,14 +1187,11 @@ public class WorkspaceTester {
 		}
 	}
 	
-	protected void testObjectIdentifier(WorkspaceIdentifier badWS, String badId,
-			int version, String exception) {
-		try {
-			new ObjectIdentifier(new WorkspaceIdentifier("foo"), badId, version);
-			fail("Initialized invalid object id");
-		} catch (IllegalArgumentException e) {
-			assertThat("correct exception string", e.getLocalizedMessage(), is(exception));
-		}
+	protected void testObjectIdentifier(
+			final WorkspaceIdentifier badWS,
+			final String badId,
+			final int version,
+			String exception) {
 		ResolvedWorkspaceID fakews = null;
 		if (badWS != null) {
 			fakews = RWSID;
@@ -1219,14 +1206,10 @@ public class WorkspaceTester {
 		}
 	}
 	
-	protected void testObjectIdentifier(WorkspaceIdentifier badWS, int badId,
+	protected void testObjectIdentifier(
+			final WorkspaceIdentifier badWS,
+			final int badId,
 			String exception) {
-		try {
-			new ObjectIdentifier(badWS, badId);
-			fail("Initialized invalid object id");
-		} catch (IllegalArgumentException e) {
-			assertThat("correct exception string", e.getLocalizedMessage(), is(exception));
-		}
 		ResolvedWorkspaceID fakews = null;
 		if (badWS != null) {
 			fakews = RWSID;
@@ -1255,14 +1238,11 @@ public class WorkspaceTester {
 		}
 	}
 	
-	protected void testObjectIdentifier(WorkspaceIdentifier badWS,
-			int badId, int version, String exception) {
-		try {
-			new ObjectIdentifier(badWS, badId, version);
-			fail("Initialized invalid object id");
-		} catch (IllegalArgumentException e) {
-			assertThat("correct exception string", e.getLocalizedMessage(), is(exception));
-		}
+	protected void testObjectIdentifier(
+			final WorkspaceIdentifier badWS,
+			final int badId,
+			final int version,
+			String exception) {
 		ResolvedWorkspaceID fakews = null;
 		if (badWS != null) {
 			fakews = RWSID;
@@ -1277,40 +1257,12 @@ public class WorkspaceTester {
 		}
 	}
 	
-	protected void testCreate(WorkspaceIdentifier goodWs, String name,
-			Long id) {
-		ObjectIdentifier.create(goodWs, name, id);
-		ObjectIDNoWSNoVer.create(name, id);
-		
-	}
-	
-	protected void testCreateVer(WorkspaceIdentifier goodWs, String name, Long id,
-			Integer ver) {
-		ObjectIdentifier.create(goodWs, name, id, ver);
-	}
-	
-	protected void testCreate(WorkspaceIdentifier badWS, String name,
-			Long id, String exception) {
+	protected void testCreate(
+			final String name,
+			final Long id,
+			final String exception) {
 		try {
-			ObjectIdentifier.create(badWS, name, id);
-			fail("Initialized invalid object id");
-		} catch (IllegalArgumentException e) {
-			assertThat("correct exception string", e.getLocalizedMessage(), is(exception));
-		}
-		if (badWS != null) {
-			try {
-				ObjectIDNoWSNoVer.create(name, id);
-				fail("Initialized invalid object id");
-			} catch (IllegalArgumentException e) {
-				assertThat("correct exception string", e.getLocalizedMessage(), is(exception));
-			}
-		}
-	}
-	
-	protected void testCreateVer(WorkspaceIdentifier badWS, String name,
-			Long id, Integer ver, String exception) {
-		try {
-			ObjectIdentifier.create(badWS, name, id, ver);
+			ObjectIDNoWSNoVer.create(name, id);
 			fail("Initialized invalid object id");
 		} catch (IllegalArgumentException e) {
 			assertThat("correct exception string", e.getLocalizedMessage(), is(exception));
@@ -1414,9 +1366,16 @@ public class WorkspaceTester {
 		return makeSimpleMeta("m", "" + id);
 	}
 
-	protected void compareObjectAndInfo(ObjectInformation original,
-			ObjectInformation copied, WorkspaceUser user, long wsid, String wsname, 
-			long objectid, String objname, int version) throws Exception {
+	protected void compareObjectAndInfo(
+			final ObjectInformation original,
+			final ObjectInformation copied,
+			final WorkspaceUser user,
+			final long wsid,
+			final String wsname, 
+			final long objectid,
+			final String objname,
+			final int version)
+			throws Exception {
 		compareObjectInfo(original, copied, user, wsid, wsname, objectid,
 				objname, version);
 		
@@ -1429,11 +1388,14 @@ public class WorkspaceTester {
 			
 			//getObjects
 			orig = ws.getObjects(original.getSavedBy(), Arrays.asList(
-					new ObjectIdentifier(new WorkspaceIdentifier(original.getWorkspaceId()),
-							original.getObjectId(), original.getVersion()))).get(0);
+					ObjectIdentifier.getBuilder(new WorkspaceIdentifier(original.getWorkspaceId()))
+						.withID(original.getObjectId()).withVersion(original.getVersion())
+						.build()))
+					.get(0);
 			copy = ws.getObjects(copied.getSavedBy(), Arrays.asList(
-					new ObjectIdentifier(new WorkspaceIdentifier(copied.getWorkspaceId()),
-							copied.getObjectId(), copied.getVersion()))).get(0);
+					ObjectIdentifier.getBuilder(new WorkspaceIdentifier(copied.getWorkspaceId()))
+						.withID(copied.getObjectId()).withVersion(copied.getVersion()).build()))
+					.get(0);
 			compareObjectInfo(orig.getObjectInfo(), copy.getObjectInfo(), user, wsid, wsname, objectid,
 					objname, version);
 			assertThat("returned data same", getData(copy), is(getData(orig)));
@@ -1443,14 +1405,16 @@ public class WorkspaceTester {
 					null, original.getWorkspaceId());
 			
 			//getObjectProvenance
-			WorkspaceObjectData originfo = ws.getObjects(original.getSavedBy(),
-					Arrays.asList(
-							new ObjectIdentifier(new WorkspaceIdentifier(original.getWorkspaceId()),
-							original.getObjectId(), original.getVersion())), true).get(0);
-			WorkspaceObjectData copyinfo = ws.getObjects(copied.getSavedBy(),
-					Arrays.asList(
-					new ObjectIdentifier(new WorkspaceIdentifier(copied.getWorkspaceId()),
-							copied.getObjectId(), copied.getVersion())), true).get(0);
+			WorkspaceObjectData originfo = ws.getObjects(original.getSavedBy(), Arrays.asList(
+					ObjectIdentifier.getBuilder(new WorkspaceIdentifier(original.getWorkspaceId()))
+							.withID(original.getObjectId()).withVersion(original.getVersion())
+							.build()), true)
+					.get(0);
+			WorkspaceObjectData copyinfo = ws.getObjects(copied.getSavedBy(), Arrays.asList(
+					ObjectIdentifier.getBuilder(new WorkspaceIdentifier(copied.getWorkspaceId()))
+							.withID(copied.getObjectId()).withVersion(copied.getVersion())
+							.build()), true)
+					.get(0);
 			compareObjectInfo(originfo.getObjectInfo(), copyinfo.getObjectInfo(), user, wsid, wsname, objectid,
 					objname, version);
 			assertThat("returned refs same", copyinfo.getReferences(), is(originfo.getReferences()));
@@ -1899,7 +1863,7 @@ public class WorkspaceTester {
 	
 	protected void checkReferencedObject(
 			final WorkspaceUser user,
-			final ObjectIDWithRefPath chain,
+			final ObjectIdentifier chain,
 			final ObjectInformation oi,
 			final Provenance p,
 			final Map<String, ? extends Object> data,
@@ -1916,16 +1880,6 @@ public class WorkspaceTester {
 			destroyGetObjectsResources(Arrays.asList(wod));
 		}
 		assertThat("object info same", info, is(oi));
-	}
-	
-	protected void failCreateObjectChain(ObjectIdentifier oi, List<ObjectIdentifier> chain,
-			Exception e) {
-		try {
-			new ObjectIDWithRefPath(oi, chain);
-			fail("bad args to object chain");
-		} catch (Exception exp) {
-			assertExceptionCorrect(exp, e);
-		}
 	}
 	
 	protected Set<ObjectInformation> oiset(ObjectInformation... ois) {

--- a/test/performance/GetObjectsLibSpeedTest.java
+++ b/test/performance/GetObjectsLibSpeedTest.java
@@ -109,7 +109,7 @@ public class GetObjectsLibSpeedTest {
 						o, td, null, new Provenance(user), false)), fac);
 		o = null;
 		
-		ObjectIdentifier oi = new ObjectIdentifier(wsi, "auto1");
+		ObjectIdentifier oi = ObjectIdentifier.getBuilder(wsi).withName("auto1").build(); 
 		
 		List<PerformanceMeasurement> pms;
 		if (op == Op.XLATEOPS) {


### PR DESCRIPTION
Delete the 11 (count 'em) different methods for creating an
`ObjectIdentifer` and use the fluent builder interface everywhere.

Real code changes aren't too crazy but the test changes are pretty
bonkers.

Still to do:
* Add unit tests for the rest of the class (maybe? having second thoughts about this given how long this has already taken, and the class has [good coverage](https://app.codecov.io/gh/kbase/workspace_deluxe/blob/develop/src/us/kbase/workspace/database/ObjectIdentifier.java) other than `toString` methods)
* Handle any remaining NOW TODOs in the class