### PR TITLE
DATAUP-725: Switch to primitives in ObjectIdentifier instance vars

### DIFF
--- a/src/us/kbase/workspace/database/ObjectIdentifier.java
+++ b/src/us/kbase/workspace/database/ObjectIdentifier.java
@@ -14,7 +14,8 @@ import static us.kbase.common.utils.StringUtils.checkString;
 
 public class ObjectIdentifier {
 	
-	// TODO NOW TEST unittests (move from WorkspaceTest, mostly covered there)
+	// TODO TEST unittests (move from WorkspaceTest, mostly covered there)
+	// also need to test toString code, but not super high priority
 	// TODO NOW JAVADOC
 	// TODO CODE return Optionals instead of nulls. That's a big change...
 	
@@ -23,8 +24,8 @@ public class ObjectIdentifier {
 	
 	private final WorkspaceIdentifier wsi;
 	private final String name;
-	private final Long id; // TODO NOW change to long and use -1 as missing
-	private final Integer version; // TODO NOW change to int and use -1 as missing
+	private final long id;
+	private final int version;
 	
 	private ObjectIdentifier(
 			final WorkspaceIdentifier wsi,
@@ -33,9 +34,8 @@ public class ObjectIdentifier {
 			final int version) {
 		this.wsi = wsi;
 		this.name = name;
-		// TODO NOW get rid of these ternaries
-		this.id = id < 0 ? null : id;
-		this.version = version < 0 ? null : version;
+		this.id = id;
+		this.version = version;
 	}
 
 	public WorkspaceIdentifier getWorkspaceIdentifier() {
@@ -47,11 +47,11 @@ public class ObjectIdentifier {
 	}
 
 	public Long getId() { // TODO NOW switch to ID
-		return id;
+		return id < 1 ? null : id;
 	}
 
 	public Integer getVersion() {
-		return version;
+		return version < 1 ? null : version;
 	}
 	
 	/** Returns whether this object identifier has a reference path.
@@ -104,12 +104,12 @@ public class ObjectIdentifier {
 	
 	public String getReferenceString() {
 		return getWorkspaceIdentifierString() + REFERENCE_SEP +
-				getIdentifierString() + (version == null ? "" :
+				getIdentifierString() + (version < 1 ? "" :
 					REFERENCE_SEP + version);
 	}
 	
 	public boolean isAbsolute() {
-		return version != null && id != null && wsi.getId() != null;
+		return version > 0 && id > 0 && wsi.getId() != null;
 	}
 	
 	public ObjectIDResolvedWS resolveWorkspace(ResolvedWorkspaceID rwsi) {
@@ -117,13 +117,13 @@ public class ObjectIdentifier {
 			throw new IllegalArgumentException("rwsi cannot be null");
 		}
 		if (name == null) {
-			if (version == null) {
+			if (version < 1) {
 				return new ObjectIDResolvedWS(rwsi, id);
 			} else {
 				return new ObjectIDResolvedWS(rwsi, id, version);
 			}
 		}
-		if (version == null) {
+		if (version < 1) {
 			return new ObjectIDResolvedWS(rwsi, name);
 		} else {
 			return new ObjectIDResolvedWS(rwsi, name, version);
@@ -165,17 +165,17 @@ public class ObjectIdentifier {
 	
 	@Override
 	public String toString() {
-		return "ObjectIdentifier [wsi=" + wsi + ", name=" + name + ", id=" + id
-				+ ", version=" + version + "]";
+		return "ObjectIdentifier [wsi=" + wsi + ", name=" + name + ", id=" + getId()
+				+ ", version=" + getVersion() + "]";
 	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + (int) (id ^ (id >>> 32));
 		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		result = prime * result + ((version == null) ? 0 : version.hashCode());
+		result = prime * result + version;
 		result = prime * result + ((wsi == null) ? 0 : wsi.hashCode());
 		return result;
 	}
@@ -189,20 +189,14 @@ public class ObjectIdentifier {
 		if (getClass() != obj.getClass())
 			return false;
 		ObjectIdentifier other = (ObjectIdentifier) obj;
-		if (id == null) {
-			if (other.id != null)
-				return false;
-		} else if (!id.equals(other.id))
+		if (id != other.id)
 			return false;
 		if (name == null) {
 			if (other.name != null)
 				return false;
 		} else if (!name.equals(other.name))
 			return false;
-		if (version == null) {
-			if (other.version != null)
-				return false;
-		} else if (!version.equals(other.version))
+		if (version != other.version)
 			return false;
 		if (wsi == null) {
 			if (other.wsi != null)

--- a/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
+++ b/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
@@ -885,7 +885,7 @@ public class IdentifierUtilsTest {
 		
 		checkObjectIdentifier(oi, null, 3L, null, 4L, 1L, "3/4/1", "4", true);
 		
-		assertThat("incorrect hasRefPah()", oi.hasRefPath(), is(true));
+		assertThat("incorrect hasRefPath()", oi.hasRefPath(), is(true));
 		final List<ObjectIdentifier> chain = oi.getRefPath();
 		assertThat("incorrect chain size", chain.size(), is(1));
 		assertThat("incorrect isLookupRequired()", oi.isLookupRequired(), is(false));

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -4638,10 +4638,9 @@ public class WorkspaceTest extends WorkspaceTester {
 						"No object with name foo exists in workspace 2 (name copyrevert1)", null));
 		failRevert(user1, cp1b.withName("foo").build(), new NoSuchObjectException(
 				"No object with name foo exists in workspace 2 (name copyrevert1)", null));
-		failRevert(user1, cp1b.withName("orig").withVersion(4).build(),
-				new NoSuchObjectException(
-						"No object with id 2 (name orig) and version 4 exists in workspace 2 " +
-						"(name copyrevert1)", null));
+		failRevert(user1, cp1b.withName("orig").withVersion(4).build(), new NoSuchObjectException(
+				"No object with id 2 (name orig) and version 4 exists in workspace 2 " +
+				"(name copyrevert1)", null));
 		failCopy(user1, cp1b.withName("orig").withVersion(null).build(), cp1b.withID(7L).build(),
 				new NoSuchObjectException(
 						"Copy destination is specified as object id 7 in workspace 2 " +
@@ -4667,9 +4666,8 @@ public class WorkspaceTest extends WorkspaceTester {
 		failCopy(user1, cp2b.withName("foo").build(), cp2b.withName("foo1").build(),
 				new InaccessibleObjectException("Object foo cannot be accessed: Workspace " +
 						"copyrevert2 is deleted", null));
-		failRevert(user1, cp2b.withName("foo").build(),
-				new InaccessibleObjectException("Object foo cannot be accessed: Workspace " +
-						"copyrevert2 is deleted", null));
+		failRevert(user1, cp2b.withName("foo").build(), new InaccessibleObjectException(
+				"Object foo cannot be accessed: Workspace copyrevert2 is deleted", null));
 		
 		ws.setWorkspaceDeleted(user2, cp2, false);
 		ws.setPermissions(user2, cp2, Arrays.asList(user1), Permission.READ);
@@ -6991,9 +6989,6 @@ public class WorkspaceTest extends WorkspaceTester {
 		final ObjectIdentifier.Builder oident1 = ObjectIdentifier.getBuilder(wsi).withName("o1");
 		final ObjectIdentifier.Builder oident2 = ObjectIdentifier.getBuilder(wsi).withID(4L);
 		final ObjectIdentifier.Builder oident3 = ObjectIdentifier.getBuilder(wsi).withName("o3");
-//		ObjectIdentifier oident1 = new ObjectIdentifier(wsi, "o1");
-//		ObjectIdentifier oident2 = new ObjectIdentifier(wsi, 4);
-//		ObjectIdentifier oident3 = ObjectIdentifier.parseObjectReference("subData/o3");
 		
 		List<String> refs1 = Arrays.asList(wsid1 + "/1/1");
 		Map<String, String> refmap1 = new HashMap<String, String>();
@@ -7579,7 +7574,6 @@ public class WorkspaceTest extends WorkspaceTester {
 				SAFE_TYPE1, "leaf2", pU1_1);
 		final ObjectIdentifier.Builder leaf2b = ObjectIdentifier.getBuilder(wsaccessible)
 				.withName("leaf2");
-//		ObjectIdentifier leaf2oi = new ObjectIdentifier(wsaccessible, "leaf2");
 		
 		TypeDefId reftype = new TypeDefId(
 				new TypeDefName("CopyRev", "RefType"), 1, 0);
@@ -7589,8 +7583,6 @@ public class WorkspaceTest extends WorkspaceTester {
 				data2, reftype, "simpleref", pU2_2);
 		final ObjectIdentifier.Builder simpleb = ObjectIdentifier.getBuilder(wsaccessible)
 				.withName("simpleref");
-//		ObjectIdentifier simplerefoi = new ObjectIdentifier(
-//				wsaccessible, "simpleref");
 		
 		// test single call with different types of operations
 		final List<String> refs = Arrays.asList("2/1/1");


### PR DESCRIPTION
Now an easy change to make. Assuming a HotSpot JVM with < 32GB of
heap, should reduce 48B to 12B for storing the numbers

Also some minor cleanup.