### PR TITLE
DATAUP-725: Make a builder for creating an ObjectInformation from a ref

### DIFF
--- a/src/us/kbase/workspace/database/ObjectIdentifier.java
+++ b/src/us/kbase/workspace/database/ObjectIdentifier.java
@@ -405,6 +405,7 @@ public class ObjectIdentifier {
 	 * @return a new builder.
 	 */
 	public static Builder getBuilder(final String reference) {
+		// TODO CODE add a builder for a reference path like X/Y/Z;X/Y;X/Y/Z and replace parsers
 		return new Builder(reference);
 	}
 	

--- a/src/us/kbase/workspace/database/Reference.java
+++ b/src/us/kbase/workspace/database/Reference.java
@@ -37,7 +37,7 @@ public class Reference implements RemappedId {
 	 * @param ref a reference string.
 	 */
 	public Reference(final String ref) {
-		final ObjectIdentifier oi = ObjectIdentifier.parseObjectReference(ref);
+		final ObjectIdentifier oi = ObjectIdentifier.getBuilder(ref).build();
 		if (!oi.isAbsolute()) {
 			throw new IllegalArgumentException(String.format(
 					"ref %s is not an absolute reference", ref));

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -1811,7 +1811,7 @@ public class Workspace {
 			final List<ObjectIdentifier> ois = new LinkedList<>();
 			for (int i = 0; i < refs.length; i++) {
 				try {
-					ois.add(ObjectIdentifier.parseObjectReference(refs[i].trim()));
+					ois.add(ObjectIdentifier.getBuilder(refs[i].trim()).build());
 					//Illegal arg is probably not the right exception
 				} catch (IllegalArgumentException iae) {
 					final List<String> attribs = getAnyAttributeSet(associatedObject, id);

--- a/src/us/kbase/workspace/database/mongo/ObjectIDResolvedWSNoVer.java
+++ b/src/us/kbase/workspace/database/mongo/ObjectIDResolvedWSNoVer.java
@@ -5,6 +5,9 @@ import us.kbase.workspace.database.ObjectIDResolvedWS;
 import us.kbase.workspace.database.ResolvedWorkspaceID;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 
+// TODO CODE is this class even necessary? can it be removed?
+// TODO NOW CODE make class & all methods package only & remove unused methods
+
 //these class names are getting ridiculous, need to think of a better way
 public class ObjectIDResolvedWSNoVer {
 	

--- a/src/us/kbase/workspace/kbase/IdentifierUtils.java
+++ b/src/us/kbase/workspace/kbase/IdentifierUtils.java
@@ -98,7 +98,7 @@ public class IdentifierUtils {
 		checkAddlArgs(oi.getAdditionalProperties(), oi.getClass());
 		if (oi.getRef() != null) {
 			verifyRefOnly(oi);
-			return ObjectIdentifier.parseObjectReference(oi.getRef());
+			return ObjectIdentifier.getBuilder(oi.getRef()).build();
 		}
 		return processObjectIdentifier(oi.getWorkspace(), oi.getWsid(),
 				oi.getName(), oi.getObjid(), oi.getVer());
@@ -330,7 +330,7 @@ public class IdentifierUtils {
 		final List<ObjectIdentifier> ret = new LinkedList<>();
 		for (final String r: objRefPath) {
 			try {
-				ret.add(ObjectIdentifier.parseObjectReference(r));
+				ret.add(ObjectIdentifier.getBuilder(r).build());
 			} catch (IllegalArgumentException | NullPointerException e) {
 				throw new IllegalArgumentException(String.format(
 						"Invalid object reference (%s) at position #%s: %s",

--- a/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
+++ b/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
@@ -202,7 +202,7 @@ public class IdentifierUtilsTest {
 			final String idstring,
 			final boolean isAbsolute)
 			throws Exception {
-		ObjectIdentifier poi = ObjectIdentifier.parseObjectReference(ref);
+		ObjectIdentifier poi = ObjectIdentifier.getBuilder(ref).build();
 		checkObjectIdentifier(poi, wsname, wsid, name, id, ver, refstring,
 				idstring, isAbsolute);
 	}
@@ -778,7 +778,7 @@ public class IdentifierUtilsTest {
 		final ObjectIdentifier oi =  ret.get(0);
 		
 		checkObjectIdentifier(oi, "foo", null, opt("bar"), EL, EI, "foo/bar", "bar", false);
-		assertThat("incorrect hasRefpath()", oi.hasRefPath(), is(false));
+		assertThat("incorrect hasRefPath()", oi.hasRefPath(), is(false));
 		assertThat("incorrect isLookupRequired()", oi.isLookupRequired(), is(false));
 		assertThat("has ref chain", oi.getRefPath(), is(Collections.emptyList()));
 		final SubsetSelection op = oi.getSubSet();

--- a/src/us/kbase/workspace/test/workspace/ObjectIdentifierTest.java
+++ b/src/us/kbase/workspace/test/workspace/ObjectIdentifierTest.java
@@ -42,7 +42,7 @@ public class ObjectIdentifierTest {
 		}
 	}
 	
-	private void assertNoAddressState(final ObjectIdentifier oi) {
+	private void assertNoNonAddressState(final ObjectIdentifier oi) {
 		assertThat("incorrect lookup", oi.isLookupRequired(), is(false));
 		assertThat("incorrect hasrefpath", oi.hasRefPath(), is(false));
 		assertThat("incorrect refpath", oi.getRefPath(), is(Collections.emptyList()));
@@ -52,7 +52,7 @@ public class ObjectIdentifierTest {
 	private void assertMinimalState(final ObjectIdentifier oi) {
 		assertThat("incorrect wsi", oi.getWorkspaceIdentifier(), is(WSI));
 		assertThat("incorrect version", oi.getVersion(), is(EI));
-		assertNoAddressState(oi);
+		assertNoNonAddressState(oi);
 	}
 	
 	@Test
@@ -423,11 +423,11 @@ public class ObjectIdentifierTest {
 	}
 	
 	private final static class RefTestCase {
-		String ref;
-		WorkspaceIdentifier wsi;
-		Optional<String> name;
-		Optional<Long> id;
-		Optional<Integer> version;
+		final String ref;
+		final WorkspaceIdentifier wsi;
+		final Optional<String> name;
+		final Optional<Long> id;
+		final Optional<Integer> version;
 
 		public RefTestCase(
 				final String ref,
@@ -477,7 +477,7 @@ public class ObjectIdentifierTest {
 			assertThat("incorrect name for ref " + t.ref, oi.getName(), is(t.name));
 			assertThat("incorrect id for ref " + t.ref, oi.getID(), is(t.id));
 			assertThat("incorrect version for ref f" + t.ref, oi.getVersion(), is(t.version));
-			assertNoAddressState(oi);
+			assertNoNonAddressState(oi);
 		}
 	}
 	
@@ -546,7 +546,6 @@ public class ObjectIdentifierTest {
 				TestCommon.assertExceptionCorrect(got, testCases.get(ref));
 			}
 		}
-		
 	}
 	
 	@Test

--- a/src/us/kbase/workspace/test/workspace/WorkspaceLongTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceLongTest.java
@@ -192,7 +192,7 @@ public class WorkspaceLongTest extends WorkspaceTester {
 			Map<String, String> retrefs = (Map<String, String>) ret.get("map");
 			for (Entry<String, String> es: retrefs.entrySet()) {
 				long expected = Long.parseLong(es.getValue().split(" ")[1]);
-				ObjectIdentifier oi = ObjectIdentifier.parseObjectReference(es.getKey());
+				ObjectIdentifier oi = ObjectIdentifier.getBuilder(es.getKey()).build();
 				assertThat("reference ws is correct", oi.getWorkspaceIdentifier().getId(), is(wsid));
 				assertThat("reference id is correct", oi.getID(), is(opt(expected)));
 				assertThat("reference ver is correct", oi.getVersion(), is(opt(1)));

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -3901,8 +3901,8 @@ public class WorkspaceTest extends WorkspaceTester {
 		final List<ObjectIdentifier> idents = new LinkedList<>();
 		for (final ObjectInformation oi: ois) {
 			// should probably add a ref -> oi method
-			idents.add(ObjectIdentifier.parseObjectReference(
-					oi.getReferencePath().get(0).toString()));
+			idents.add(ObjectIdentifier.getBuilder(
+					oi.getReferencePath().get(0).toString()).build());
 		}
 		List<WorkspaceObjectData> d = null;
 		try {
@@ -3992,21 +3992,6 @@ public class WorkspaceTest extends WorkspaceTester {
 		testCreate("boo", 1L, "Must provide one and only one of object name (was: boo) or id (was: 1)");
 		testCreate("-1", null, "Object names cannot be integers: -1");
 		testCreate("15", null, "Object names cannot be integers: 15");
-		testRef("foo/bar");
-		testRef("foo/bar/1");
-		testRef("foo/bar/1/2", "Illegal number of separators / in object reference foo/bar/1/2");
-		testRef("foo/" + TEXT256 + "/1", "Object name exceeds the maximum length of 255");
-		testRef("foo/bar/n", "Unable to parse version portion of object reference foo/bar/n to an integer");
-		testRef("foo", "Illegal number of separators / in object reference foo");
-		testRef("1/2");
-		testRef("1/2/3");
-		testRef("1/2/3/4", "Illegal number of separators / in object reference 1/2/3/4");
-		testRef("1/2/n", "Unable to parse version portion of object reference 1/2/n to an integer");
-		testRef("1", "Illegal number of separators / in object reference 1");
-		testRef("foo/2");
-		testRef("2/foo");
-		testRef("foo/2/1");
-		testRef("2/foo/1");
 	}
 	
 	@Test
@@ -4487,8 +4472,8 @@ public class WorkspaceTest extends WorkspaceTester {
 		//copy entire stack of hidden objects
 		cp1LastDate = ws.getWorkspaceInformation(user1, cp1).getModDate();
 		ObjectInformation copied = ws.copyObject(user1,
-				ObjectIdentifier.parseObjectReference("copyrevert1/hide"),
-				ObjectIdentifier.parseObjectReference("copyrevert1/copyhide"));
+				ObjectIdentifier.getBuilder("copyrevert1/hide").build(),
+				ObjectIdentifier.getBuilder("copyrevert1/copyhide").build());
 		cp1LastDate = assertWorkspaceDateUpdated(user1, cp1, cp1LastDate, "ws date updated on copy");
 		compareObjectAndInfo(save13, copied, user1, wsid1, cp1.getName(), 4, "copyhide", 3);
 		List<ObjectInformation> copystack = ws.getObjectHistory(user1, cp1b.withID(4L).build());
@@ -4504,8 +4489,8 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		//copy stack of unhidden objects
 		copied = ws.copyObject(user1,
-				ObjectIdentifier.parseObjectReference("copyrevert1/orig"),
-				ObjectIdentifier.parseObjectReference("copyrevert1/copied"));
+				ObjectIdentifier.getBuilder("copyrevert1/orig").build(),
+				ObjectIdentifier.getBuilder("copyrevert1/copied").build());
 		cp1LastDate = assertWorkspaceDateUpdated(user1, cp1, cp1LastDate, "ws date updated on copy");
 		compareObjectAndInfo(save13, copied, user1, wsid1, cp1.getName(), 5, "copied", 3);
 		copystack = ws.getObjectHistory(user1, cp1b.withName("copied").build());
@@ -4516,7 +4501,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		//copy visible object to pre-existing hidden object
 		copied = ws.copyObject(user1,
-				ObjectIdentifier.parseObjectReference("copyrevert1/orig"),
+				ObjectIdentifier.getBuilder("copyrevert1/orig").build(),
 				cp1b.withName("hidetarget").build());
 		cp1LastDate = assertWorkspaceDateUpdated(user1, cp1, cp1LastDate, "ws date updated on copy");
 		compareObjectAndInfo(save13, copied, user1, wsid1, cp1.getName(), 3, "hidetarget", 2);
@@ -4538,7 +4523,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		final ObjectIdentifier oi122 = ObjectIdentifier.getBuilder(new WorkspaceIdentifier(wsid1))
 				.withID(2L).withVersion(2).build();
 		copied = ws.copyObject(
-				user1, oi122, ObjectIdentifier.parseObjectReference("copyrevert1/copied"));
+				user1, oi122, ObjectIdentifier.getBuilder("copyrevert1/copied").build());
 		compareObjectAndInfo(save12, copied, user1, wsid1, cp1.getName(), 5, "copied", 5);
 		copystack = ws.getObjectHistory(user1, cp1b.withName("copied").build());
 		compareObjectAndInfo(save11, copystack.get(0), user1, wsid1, cp1.getName(), 5, "copied", 1);
@@ -4550,7 +4535,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		//copy specific version to  hidden existing object
 		copied = ws.copyObject(
-				user1, oi122, ObjectIdentifier.parseObjectReference("copyrevert1/hidetarget"));
+				user1, oi122, ObjectIdentifier.getBuilder("copyrevert1/hidetarget").build());
 		compareObjectAndInfo(save12, copied, user1, wsid1, cp1.getName(), 3, "hidetarget", 3);
 		copystack = ws.getObjectHistory(user1, cp1b.withName("hidetarget").build());
 		//0 is original object
@@ -4560,7 +4545,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		//copy specific version to new object
 		copied = ws.copyObject(
-				user1, oi122, ObjectIdentifier.parseObjectReference("copyrevert1/newobj"));
+				user1, oi122, ObjectIdentifier.getBuilder("copyrevert1/newobj").build());
 		compareObjectAndInfo(save12, copied, user1, wsid1, cp1.getName(), 6, "newobj", 1);
 		copystack = ws.getObjectHistory(user1, cp1b.withName("newobj").build());
 		compareObjectAndInfo(save12, copystack.get(0), user1, wsid1, cp1.getName(), 6, "newobj", 1);
@@ -4569,7 +4554,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		//revert normal object
 		cp1LastDate = ws.getWorkspaceInformation(user1, cp1).getModDate();
 		copied = ws.revertObject(user1,
-				ObjectIdentifier.parseObjectReference("copyrevert1/copied/2"));
+				ObjectIdentifier.getBuilder("copyrevert1/copied/2").build());
 		cp1LastDate = assertWorkspaceDateUpdated(user1, cp1, cp1LastDate, "ws date updated on revert");
 		compareObjectAndInfo(save12, copied, user1, wsid1, cp1.getName(), 5, "copied", 6);
 		copystack = ws.getObjectHistory(user1, cp1b.withName("copied").build());
@@ -4583,7 +4568,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		//revert hidden object
 		copied = ws.revertObject(user1,
-				ObjectIdentifier.parseObjectReference("copyrevert1/hidetarget/2"));
+				ObjectIdentifier.getBuilder("copyrevert1/hidetarget/2").build());
 		cp1LastDate = assertWorkspaceDateUpdated(user1, cp1, cp1LastDate, "ws date updated on revert");
 		compareObjectAndInfo(save13, copied, user1, wsid1, cp1.getName(), 3, "hidetarget", 4);
 		copystack = ws.getObjectHistory(user1, cp1b.withName("hidetarget").build());
@@ -4597,8 +4582,8 @@ public class WorkspaceTest extends WorkspaceTester {
 		ws.setPermissions(user2, cp2, Arrays.asList(user1), Permission.WRITE);
 		cp2LastDate = ws.getWorkspaceInformation(user1, cp2).getModDate();
 		copied = ws.copyObject(user1,
-				ObjectIdentifier.parseObjectReference("copyrevert1/orig"),
-				ObjectIdentifier.parseObjectReference("copyrevert2/copied"));
+				ObjectIdentifier.getBuilder("copyrevert1/orig").build(),
+				ObjectIdentifier.getBuilder("copyrevert2/copied").build());
 		cp2LastDate = assertWorkspaceDateUpdated(user1, cp2, cp2LastDate, "ws date updated on copy");
 		compareObjectAndInfo(save13, copied, user1, wsid2, cp2.getName(), 1, "copied", 3);
 		copystack = ws.getObjectHistory(user1, cp2b.withName("copied").build());
@@ -4610,10 +4595,10 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		//copy to deleted object
 		ws.setObjectsDeleted(user1, Arrays.asList(
-				ObjectIdentifier.parseObjectReference("copyrevert1/copied")), true);
+				ObjectIdentifier.getBuilder("copyrevert1/copied").build()), true);
 		copied = ws.copyObject(user1,
-				ObjectIdentifier.parseObjectReference("copyrevert1/orig"),
-				ObjectIdentifier.parseObjectReference("copyrevert1/copied"));
+				ObjectIdentifier.getBuilder("copyrevert1/orig").build(),
+				ObjectIdentifier.getBuilder("copyrevert1/copied").build());
 		compareObjectAndInfo(save13, copied, user1, wsid1, cp1.getName(), 5, "copied", 7);
 		copystack = ws.getObjectHistory(user1, cp1b.withName("copied").build());
 		compareObjectAndInfo(save11, copystack.get(0), user1, wsid1, cp1.getName(), 5, "copied", 1);
@@ -7743,13 +7728,13 @@ public class WorkspaceTest extends WorkspaceTester {
 		
 		
 		//check target objects can't be accessed
-		failGetObjects(user1, Arrays.asList(ObjectIdentifier.parseObjectReference(leaf1_1ref)),
+		failGetObjects(user1, Arrays.asList(ObjectIdentifier.getBuilder(leaf1_1ref).build()),
 				new InaccessibleObjectException("Object leaf1 cannot be accessed: User " +
 						"u1 may not read workspace wsu2", null));
-		failGetObjects(user1, Arrays.asList(ObjectIdentifier.parseObjectReference(leaf1_2ref)),
+		failGetObjects(user1, Arrays.asList(ObjectIdentifier.getBuilder(leaf1_2ref).build()),
 				new InaccessibleObjectException("Object leaf1 cannot be accessed: User " +
 						"u1 may not read workspace wsu2", null));
-		failGetObjects(user1, Arrays.asList(ObjectIdentifier.parseObjectReference(delLeafRef)),
+		failGetObjects(user1, Arrays.asList(ObjectIdentifier.getBuilder(delLeafRef).build()),
 				new InaccessibleObjectException("Object delleaf cannot be accessed: User " +
 						"u1 may not read workspace wsu2", null));
 		

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -1139,25 +1139,21 @@ public class WorkspaceTester {
 	
 	protected void testObjectIdentifier(String goodId) {
 		new ObjectIDResolvedWS(RWSID, goodId);
-//		new ObjectIDResolvedWSNoVer(fakews, goodId);
 		new ObjectIDNoWSNoVer(goodId);
 	}
 	
 	protected void testObjectIdentifier(String goodId, int version) {
 		new ObjectIDResolvedWS(RWSID, goodId, version);
-//		new ObjectIDResolvedWSNoVer(fakews, goodId);
 		new ObjectIDNoWSNoVer(goodId);
 	}
 	
 	protected void testObjectIdentifier(int goodId) {
 		new ObjectIDResolvedWS(RWSID, goodId);
-//		new ObjectIDResolvedWSNoVer(fakews, goodId);
 		new ObjectIDNoWSNoVer(goodId);
 	}
 	
 	protected void testObjectIdentifier(int goodId, int version) {
 		new ObjectIDResolvedWS(RWSID, goodId, version);
-//		new ObjectIDResolvedWSNoVer(fakews, goodId);
 		new ObjectIDNoWSNoVer(goodId);
 	}
 	
@@ -1222,12 +1218,6 @@ public class WorkspaceTester {
 		} catch (IllegalArgumentException e) {
 			assertThat("correct exception string", e.getLocalizedMessage(), is(exception));
 		}
-//		try {
-//			new ObjectIDResolvedWSNoVer(fakews, badId);
-//			fail("Initialized invalid object id");
-//		} catch (IllegalArgumentException e) {
-//			assertThat("correct exception string", e.getLocalizedMessage(), is(exception));
-//		}
 		if (badWS != null) {
 			try {
 				new ObjectIDNoWSNoVer(badId);
@@ -1269,19 +1259,6 @@ public class WorkspaceTester {
 		}
 	}
 	
-	protected void testRef(String ref) {
-		ObjectIdentifier.parseObjectReference(ref);
-	}
-	
-	protected void testRef(String ref, String exception) {
-		try {
-			ObjectIdentifier.parseObjectReference(ref);
-			fail("Initialized invalid object id");
-		} catch (IllegalArgumentException e) {
-			assertThat("correct exception string", e.getLocalizedMessage(), is(exception));
-		}
-	}
-
 	protected void checkNonDeletedObjs(WorkspaceUser foo,
 			Map<ObjectIdentifier, Object> idToData) throws Exception {
 		List<ObjectIdentifier> objs = new ArrayList<ObjectIdentifier>(idToData.keySet());


### PR DESCRIPTION
... so all builds work the same way. Missed this one originally.

Also move all the ref tests into the OI unit tests where they should be.