### PR TITLE
DATAUP-725: Return object data builder from DB layer & use

### DIFF
--- a/performance/README.md
+++ b/performance/README.md
@@ -1,0 +1,12 @@
+The performance folder contains various utilities for measuring the performance of the
+workspace or parts thereof.
+
+Note that as of 2022/3/3 all the code is very old and has been updated numereous times to
+simply make it compile without verifying that it still serves its intended purpose.
+
+The code in these folders may be useful as a reference for constructing new performance tests but
+may not work correctly as is.
+
+The code is also generally quick and dirty and assumes a high degree of familiarity with workspace
+operations and architecture - it's intended for users with a fairly high amount of experience
+with the workspace.

--- a/performance/us/kbase/workspace/performance/workspace/GetObjectsMongoWSDB.java
+++ b/performance/us/kbase/workspace/performance/workspace/GetObjectsMongoWSDB.java
@@ -62,11 +62,11 @@ public class GetObjectsMongoWSDB {
 			}
 			
 			final long preiter = System.nanoTime();
-			final Map<ObjectIDResolvedWS, Map<SubsetSelection, WorkspaceObjectData>> res =
+			final Map<ObjectIDResolvedWS, Map<SubsetSelection, WorkspaceObjectData.Builder>> res =
 					mws.getObjects(objs, man, 0, true, false, true);
-			for (final Map<SubsetSelection, WorkspaceObjectData> ss2wos: res.values()) {
-				for (final WorkspaceObjectData wos: ss2wos.values()) {
-					wos.destroy();
+			for (final Map<SubsetSelection, WorkspaceObjectData.Builder> ss2wos: res.values()) {
+				for (final WorkspaceObjectData.Builder wos: ss2wos.values()) {
+					wos.build().destroy();
 				}
 			}
 			printElapse("get", preiter);

--- a/src/us/kbase/workspace/database/WorkspaceDatabase.java
+++ b/src/us/kbase/workspace/database/WorkspaceDatabase.java
@@ -351,7 +351,8 @@ public interface WorkspaceDatabase {
 	 * effect if exceptIfDeleted is set.
 	 * @param exceptIfMissing throw an exception if the object does not exist
 	 * in the database.
-	 * @return a mapping of object id -> subdata paths -> data.
+	 * @return a mapping of object id -> subdata paths -> data builder. The data is returned
+	 * as a builder so that copy status and reference paths can be updated as necessary.
 	 * @throws NoSuchObjectException if there is no such object.
 	 * @throws WorkspaceCommunicationException if a communication error with
 	 * the backend occurs.
@@ -359,7 +360,7 @@ public interface WorkspaceDatabase {
 	 * @throws TypedObjectExtractionException if the subdata could not be
 	 * extracted.
 	 */
-	public Map<ObjectIDResolvedWS, Map<SubsetSelection, WorkspaceObjectData>>
+	public Map<ObjectIDResolvedWS, Map<SubsetSelection, WorkspaceObjectData.Builder>>
 			getObjects(
 					Map<ObjectIDResolvedWS, Set<SubsetSelection>> objects,
 					ByteArrayFileCacheManager dataManager,
@@ -368,7 +369,7 @@ public interface WorkspaceDatabase {
 					boolean includeDeleted,
 					boolean exceptIfMissing)
 			throws NoSuchObjectException,WorkspaceCommunicationException,
-			CorruptWorkspaceDBException, TypedObjectExtractionException;
+				CorruptWorkspaceDBException, TypedObjectExtractionException;
 	
 	/** Resolve a set of objects to absolute references. If the object cannot be found, it is not
 	 * included in the returned map. Includes deleted objects.

--- a/src/us/kbase/workspace/test/database/mongo/MongoWorkspaceDBTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoWorkspaceDBTest.java
@@ -111,7 +111,7 @@ public class MongoWorkspaceDBTest {
 						.append("actions.0.wsobjs", null)));
 		
 		
-		final Map<ObjectIDResolvedWS, Map<SubsetSelection, WorkspaceObjectData>> res =
+		final Map<ObjectIDResolvedWS, Map<SubsetSelection, WorkspaceObjectData.Builder>> res =
 				mocks.mdb.getObjects(
 						ImmutableMap.of(new ObjectIDResolvedWS(wsid, 1), set()),
 						null,
@@ -121,7 +121,7 @@ public class MongoWorkspaceDBTest {
 						true);
 		
 		final Provenance pgot = res.get(new ObjectIDResolvedWS(wsid, 1))
-				.get(SubsetSelection.EMPTY).getProvenance();
+				.get(SubsetSelection.EMPTY).build().getProvenance();
 		
 		//TODO TEST add equals methods to provenance classes & test & use here
 		assertThat("incorrect user", pgot.getUser(), is(new WorkspaceUser("u")));
@@ -153,7 +153,7 @@ public class MongoWorkspaceDBTest {
 				new Document(),
 				new Document("$unset", new Document(Fields.VER_EXT_IDS, "")));
 		
-		final Map<ObjectIDResolvedWS, Map<SubsetSelection, WorkspaceObjectData>> res =
+		final Map<ObjectIDResolvedWS, Map<SubsetSelection, WorkspaceObjectData.Builder>> res =
 				mocks.mdb.getObjects(
 						ImmutableMap.of(new ObjectIDResolvedWS(wsid, 1), set()),
 						null,
@@ -163,7 +163,7 @@ public class MongoWorkspaceDBTest {
 						true);
 		
 		final WorkspaceObjectData wod = res.get(new ObjectIDResolvedWS(wsid, 1))
-				.get(SubsetSelection.EMPTY);
+				.get(SubsetSelection.EMPTY).build();
 		assertThat("incorrect data", wod.getSerializedData(), is(Optional.empty()));
 		assertThat("incorrect ext ids", wod.getExtractedIds(), is(Collections.emptyMap()));
 	}


### PR DESCRIPTION
Sets the stage for separating getting the object info / provenance /
etc. and then adding the data later, after the max data size has been
calculated. Since the max size is calculated up front, before getting the data,
we can ditch the non-thread safe data size management code.