### PR TITLE
DATAUP-725: Add subset data and getter for ObjectInformation to WOD builder

### DIFF
--- a/src/us/kbase/workspace/database/Util.java
+++ b/src/us/kbase/workspace/database/Util.java
@@ -75,6 +75,7 @@ public class Util {
 	 * @param message the message for the exception.
 	 */
 	public static void nonNull(final Object o, final String message) {
+		// TODO CODE replace with requireNonNull
 		if (o == null) {
 			throw new NullPointerException(message);
 		}

--- a/src/us/kbase/workspace/database/WorkspaceObjectData.java
+++ b/src/us/kbase/workspace/database/WorkspaceObjectData.java
@@ -202,6 +202,13 @@ public class WorkspaceObjectData {
 			b.extIDs.keySet().stream().forEach(k -> this.extIDs.put(k, b.extIDs.get(k)));
 			this.subset = b.subset;
 		}
+		
+		/** Get the current object information stored in this builder.
+		 * @return the object information.
+		 */
+		public ObjectInformation getObjectInfo() {
+			return info;
+		}
 
 		/** Add the object data to the builder. Passing null removes any current data.
 		 * @param data the data.

--- a/src/us/kbase/workspace/database/WorkspaceObjectData.java
+++ b/src/us/kbase/workspace/database/WorkspaceObjectData.java
@@ -10,6 +10,7 @@ import java.util.TreeMap;
 import java.util.Collections;
 import java.util.LinkedList;
 
+import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.workspace.database.ByteArrayFileCacheManager.ByteArrayFileCache;
 
@@ -33,6 +34,7 @@ public class WorkspaceObjectData {
 	private final Reference copied;
 	private final boolean isCopySourceInaccessible;
 	private final Map<IdReferenceType, List<String>> extIDs;
+	private final SubsetSelection subset;
 
 	private WorkspaceObjectData(
 			final ByteArrayFileCache data,
@@ -41,7 +43,8 @@ public class WorkspaceObjectData {
 			final List<String> references,
 			final Reference copied,
 			final boolean isCopySourceAccessible,
-			final Map<IdReferenceType, List<String>> extIDs) {
+			final Map<IdReferenceType, List<String>> extIDs,
+			final SubsetSelection subset) {
 		this.data = data;
 		this.info = info;
 		this.prov = prov;
@@ -49,6 +52,7 @@ public class WorkspaceObjectData {
 		this.copied = copied;
 		this.isCopySourceInaccessible = isCopySourceAccessible;
 		this.extIDs = Collections.unmodifiableMap(extIDs);
+		this.subset = subset;
 	}
 	
 	/** Returns information about the object.
@@ -108,7 +112,15 @@ public class WorkspaceObjectData {
 		return isCopySourceInaccessible;
 	}
 	
-	/** Destroys any resources used to store the objects. In the case of
+	/** Get the subset selection for this object, which defines which parts of the
+	 * object data are included in this object.
+	 * @return the subset.
+	 */
+	public SubsetSelection getSubsetSelection() {
+		return subset;
+	}
+	
+	/** Destroys any resources used to store the object data. In the case of
 	 * object subsets, also destroys the parent objects. This method should be
 	 * called on a set of objects when further processing is no longer
 	 * required.
@@ -173,6 +185,7 @@ public class WorkspaceObjectData {
 		private Reference copied = null;
 		private boolean isCopySourceInaccessible = false;
 		private final Map<IdReferenceType, List<String>> extIDs = new TreeMap<>();
+		private SubsetSelection subset = SubsetSelection.EMPTY;
 
 		private Builder(final ObjectInformation info, final Provenance prov) {
 			this.info = requireNonNull(info, "info");
@@ -187,6 +200,7 @@ public class WorkspaceObjectData {
 			this.copied = b.copied;
 			this.isCopySourceInaccessible = b.isCopySourceInaccessible;
 			b.extIDs.keySet().stream().forEach(k -> this.extIDs.put(k, b.extIDs.get(k)));
+			this.subset = b.subset;
 		}
 
 		/** Add the object data to the builder. Passing null removes any current data.
@@ -278,12 +292,31 @@ public class WorkspaceObjectData {
 			return this;
 		}
 		
+		/** Set the subset selection for this object, which defines which parts of the object data
+		 * should be included in this builder and built object. Passing null removes any previous
+		 * subset selection from the builder, replacing it with {@link SubsetSelection#EMPTY}.
+		 * @param subset the subset.
+		 * @return this builder.
+		 */
+		public Builder withSubsetSelection(final SubsetSelection subset) {
+			this.subset = subset == null ? SubsetSelection.EMPTY : subset;
+			return this;
+		}
+		
+		/** Get the subset selection currently in this builder, if any.
+		 * @return the subset.
+		 */
+		public SubsetSelection getSubsetSelection() {
+			return subset;
+		}
+		
 		/** Build the {@link WorkspaceObjectData}.
 		 * @return the object data.
 		 */
 		public WorkspaceObjectData build() {
 			return new WorkspaceObjectData(
-					data, info, prov, references, copied, isCopySourceInaccessible, extIDs);
+					data, info, prov, references, copied, isCopySourceInaccessible, extIDs,
+					subset);
 		}
 	}
 }

--- a/src/us/kbase/workspace/test/workspace/WorkspaceObjectDataTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceObjectDataTest.java
@@ -235,6 +235,18 @@ public class WorkspaceObjectDataTest {
 	}
 	
 	@Test
+	public void builderGetObjectInfo() throws Exception {
+		final ObjectInformation info2 = INFO.updateReferencePath(Arrays.asList(
+				new Reference(7, 8, 9), new Reference(1, 1, 1)));
+		
+		final WorkspaceObjectData.Builder b = WorkspaceObjectData.getBuilder(INFO, PROV);
+		assertThat("incorrect object info", b.getObjectInfo(), is(INFO));
+		
+		b.withUpdatedReferencePath(Arrays.asList(new Reference(7, 8, 9), new Reference(1, 1, 1)));
+		assertThat("incorrect object info", b.getObjectInfo(), is(info2));
+	}
+	
+	@Test
 	public void builderGetCopyReference() throws Exception {
 		final WorkspaceObjectData.Builder b = WorkspaceObjectData.getBuilder(INFO, PROV)
 				.withCopyReference(new Reference(8, 9, 10));

--- a/src/us/kbase/workspace/test/workspace/WorkspaceObjectDataTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceObjectDataTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableMap;
 
 import us.kbase.common.test.TestCommon;
+import us.kbase.typedobj.core.SubsetSelection;
 import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.workspace.database.ByteArrayFileCacheManager;
@@ -36,6 +37,7 @@ public class WorkspaceObjectDataTest {
 	
 	private static final Optional<ByteArrayFileCache> OD = Optional.empty();
 	private static final Optional<Reference> OR = Optional.empty();
+	private static final SubsetSelection OS = SubsetSelection.EMPTY;
 	
 	// Provenance really needs a rework and has no hashCode(), so we use identity equality for now
 	private static final Provenance PROV = new Provenance(new WorkspaceUser("foo"));
@@ -80,6 +82,7 @@ public class WorkspaceObjectDataTest {
 		assertThat("incorrect refs", wod.getReferences(), is(Collections.emptyList()));
 		assertThat("incorrect has data", wod.hasData(), is(false));
 		assertThat("incorrect copy inaccessible", wod.isCopySourceInaccessible(), is(false));
+		assertThat("incorrect subset", wod.getSubsetSelection(), is(OS));
 	}
 	
 	@Test
@@ -95,7 +98,8 @@ public class WorkspaceObjectDataTest {
 				.withUpdatedReferencePath(Arrays.asList(
 						new Reference(3, 4, 5), new Reference(1, 1, 1)))
 				.withExternalIDs(new IdReferenceType("t1"), Arrays.asList("foo", "bar"))
-				.withExternalIDs(new IdReferenceType("t2"), Arrays.asList("whoo", "whee"));
+				.withExternalIDs(new IdReferenceType("t2"), Arrays.asList("whoo", "whee"))
+				.withSubsetSelection(new SubsetSelection(Arrays.asList("/foo")));
 
 		// test the builder from a builder builder
 		final WorkspaceObjectData wod2 = WorkspaceObjectData.getBuilder(wodb).build();
@@ -119,6 +123,8 @@ public class WorkspaceObjectDataTest {
 		assertThat("incorrect refs", wod.getReferences(), is(Arrays.asList("3/4/5", "10/11/12")));
 		assertThat("incorrect has data", wod.hasData(), is(true));
 		assertThat("incorrect copy inaccessible", wod.isCopySourceInaccessible(), is(false));
+		assertThat("incorrect subset", wod.getSubsetSelection(),
+				is(new SubsetSelection(Arrays.asList("/foo"))));
 	}
 	
 	@Test
@@ -144,6 +150,7 @@ public class WorkspaceObjectDataTest {
 		assertThat("incorrect refs", wod.getReferences(), is(Collections.emptyList()));
 		assertThat("incorrect has data", wod.hasData(), is(false));
 		assertThat("incorrect copy inaccessible", wod.isCopySourceInaccessible(), is(true));
+		assertThat("incorrect subset", wod.getSubsetSelection(), is(OS));
 	}
 	
 	@Test
@@ -169,6 +176,7 @@ public class WorkspaceObjectDataTest {
 		assertThat("incorrect refs", wod.getReferences(), is(Collections.emptyList()));
 		assertThat("incorrect has data", wod.hasData(), is(false));
 		assertThat("incorrect copy inaccessible", wod.isCopySourceInaccessible(), is(false));
+		assertThat("incorrect subset", wod.getSubsetSelection(), is(OS));
 	}
 	
 	@Test
@@ -181,10 +189,12 @@ public class WorkspaceObjectDataTest {
 				.withReferences(Arrays.asList("3/4/5", "10/11/12"))
 				.withExternalIDs(new IdReferenceType("t1"), Arrays.asList("foo", "bar"))
 				.withExternalIDs(new IdReferenceType("t2"), Arrays.asList("whoo", "whee"))
+				.withSubsetSelection(new SubsetSelection(Arrays.asList("/foo")))
 				.withData(null)
 				.withCopyReference(null)
 				.withReferences(null)
 				.withExternalIDs(new IdReferenceType("t1"), null)
+				.withSubsetSelection(null)
 				.build();
 		
 		assertThat("incorrect info", wod.getObjectInfo(), is(INFO));
@@ -197,6 +207,7 @@ public class WorkspaceObjectDataTest {
 		assertThat("incorrect refs", wod.getReferences(), is(Collections.emptyList()));
 		assertThat("incorrect has data", wod.hasData(), is(false));
 		assertThat("incorrect copy inaccessible", wod.isCopySourceInaccessible(), is(false));
+		assertThat("incorrect subset", wod.getSubsetSelection(), is(OS));
 	}
 	
 	@Test
@@ -220,6 +231,7 @@ public class WorkspaceObjectDataTest {
 		assertThat("incorrect refs", wod.getReferences(), is(Collections.emptyList()));
 		assertThat("incorrect has data", wod.hasData(), is(false));
 		assertThat("incorrect copy inaccessible", wod.isCopySourceInaccessible(), is(false));
+		assertThat("incorrect subset", wod.getSubsetSelection(), is(OS));
 	}
 	
 	@Test
@@ -231,6 +243,18 @@ public class WorkspaceObjectDataTest {
 		
 		b.withCopyReference(null);
 		assertThat("incorrect copy ref", b.getCopyReference(), is(OR));
+	}
+	
+	@Test
+	public void builderGetSubsetSelection() throws Exception {
+		final WorkspaceObjectData.Builder b = WorkspaceObjectData.getBuilder(INFO, PROV)
+				.withSubsetSelection(new SubsetSelection(Arrays.asList("/bar")));
+		
+		assertThat("incorrect subset", b.getSubsetSelection(),
+				is(new SubsetSelection(Arrays.asList("/bar"))));
+		
+		b.withSubsetSelection(null);
+		assertThat("incorrect subset", b.getSubsetSelection(), is(OS));
 	}
 	
 	@Test


### PR DESCRIPTION
* Subset data will be necessary for the rewritten object data pulling code that will take `WorkspaceObjectData.Builder`s as input, since that method will do the subsetting
* Getting the object information from the builder is necessary to get access to the object size in bytes, which will be used to calculate the total size of the requested data and, based on that size, either
    * store it in memory
    * store it on disk
    * throw an error because it's too big

The WOD won't be built until after the data is added, so the size needs to be available from the builder API.