### PR TITLE
DATAUP-725: Add method to add data to WorkspaceObjectData builder

### DIFF
--- a/src/us/kbase/workspace/database/ByteArrayFileCacheManager.java
+++ b/src/us/kbase/workspace/database/ByteArrayFileCacheManager.java
@@ -27,6 +27,8 @@ import us.kbase.workspace.database.exceptions.FileCacheLimitExceededException;
 public class ByteArrayFileCacheManager {
 	
 	//TODO TEST unit tests
+	//TODO JAVADOC
+	// this class is going to get a pretty huge overhaul so wait on tests & javadoc
 	
 	private int sizeInMem = 0;
 	private final int maxSizeInMem;
@@ -317,6 +319,10 @@ public class ByteArrayFileCacheManager {
 			} catch (IOException | IllegalStateException ex) {
 				throw new TypedObjectExtractionException(ex.getMessage(), ex);
 			}
+		}
+		
+		public boolean isDestroyed() {
+			return destroyed;
 		}
 		
 		/** Destroys any data associated with this cache and calls destroy()

--- a/src/us/kbase/workspace/database/ObjectInformation.java
+++ b/src/us/kbase/workspace/database/ObjectInformation.java
@@ -47,12 +47,12 @@ public class ObjectInformation {
 	public ObjectInformation(
 			final long id,
 			final String name,
-			final String typeString,
+			final String typeString, // TODO CODE use absolute typedef?
 			final Date savedDate, //TODO CODE use instant
 			final int version,
 			final WorkspaceUser savedBy,
 			final ResolvedWorkspaceID workspaceID,
-			final String chksum,
+			final String chksum,  // TODO CODE use MD5? 
 			final long size,
 			final UncheckedUserMetadata meta) {
 		//no error checking for now, add if needed
@@ -202,7 +202,7 @@ public class ObjectInformation {
 	 * @return the object metadata.
 	 */
 	public UncheckedUserMetadata getUserMetaData() {
-		return meta;
+		return meta;  // TODO CODE switch to Optional
 	}
 
 	/** Returns the resolved reference path to this object from a user-accessible object. There may

--- a/src/us/kbase/workspace/database/WorkspaceDatabase.java
+++ b/src/us/kbase/workspace/database/WorkspaceDatabase.java
@@ -1,6 +1,7 @@
 package us.kbase.workspace.database;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -12,6 +13,7 @@ import us.kbase.typedobj.exceptions.TypedObjectExtractionException;
 import us.kbase.workspace.database.ListObjectsParameters.ResolvedListObjectParameters;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
 import us.kbase.workspace.database.exceptions.CorruptWorkspaceDBException;
+import us.kbase.workspace.database.exceptions.NoObjectDataException;
 import us.kbase.workspace.database.exceptions.NoSuchObjectException;
 import us.kbase.workspace.database.exceptions.NoSuchWorkspaceException;
 import us.kbase.workspace.database.exceptions.PreExistingWorkspaceException;
@@ -370,6 +372,24 @@ public interface WorkspaceDatabase {
 					boolean exceptIfMissing)
 			throws NoSuchObjectException,WorkspaceCommunicationException,
 				CorruptWorkspaceDBException, TypedObjectExtractionException;
+	
+	/** Adds object data to the given builder, specifically calling
+	 * {@link WorkspaceObjectData.Builder#withData(ByteArrayFileCacheManager.ByteArrayFileCache)},
+	 * and taking the contents of {@link WorkspaceObjectData.Builder#getSubsetSelection()}
+	 * into account. If this method throws an exception any data in the objects will be removed
+	 * and destroyed.
+	 * @param objects the object builders to update.
+	 * @param dataManager the data manager.
+	 * @throws WorkspaceCommunicationException if a communication error with the backend occurs.
+	 * @throws TypedObjectExtractionException if the subdata could not be extracted.
+	 * @throws NoObjectDataException if there is no data in the backend for the corresponding
+	 * object. 
+	 */
+	public void addDataToObjects(
+			final Collection<WorkspaceObjectData.Builder> objects,
+			final ByteArrayFileCacheManager dataManager)
+			throws WorkspaceCommunicationException, TypedObjectExtractionException,
+				NoObjectDataException;
 	
 	/** Resolve a set of objects to absolute references. If the object cannot be found, it is not
 	 * included in the returned map. Includes deleted objects.

--- a/src/us/kbase/workspace/database/exceptions/NoObjectDataException.java
+++ b/src/us/kbase/workspace/database/exceptions/NoObjectDataException.java
@@ -1,0 +1,20 @@
+package us.kbase.workspace.database.exceptions;
+
+/** 
+ * Thrown when the requested object data doesn't exist.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class NoObjectDataException extends WorkspaceDBException {
+
+	private static final long serialVersionUID = 1L;
+	
+	public NoObjectDataException(final String message) {
+		super(message);
+	}
+	
+	public NoObjectDataException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+	
+}


### PR DESCRIPTION
Next step is to return no data from the MWDB.getObjects method and
use this method to populate the builder with data. Then the data size
calculation can be done in the Workspace class and the
ByteArrayFileCacheManager can be initialized up front to save to memory
or disk, getting rid of the thread unsafe dynamic reallocation code.