### PR TITLE
DATAUP-725: Use the new data addition method in WS.getObjects()

### DIFF
--- a/src/us/kbase/common/test/TestCommon.java
+++ b/src/us/kbase/common/test/TestCommon.java
@@ -254,6 +254,7 @@ public class TestCommon {
 							break;
 					}
 				}
+				// this is weird. Should it just be a fail()?
 				assertThat("There are tempfiles: " + tfm.getTempFileList(),
 						tfm.isEmpty(), is(true));
 			}

--- a/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
@@ -43,13 +43,11 @@ import us.kbase.typedobj.core.TypeDefName;
 import us.kbase.typedobj.core.TypedObjectValidator;
 import us.kbase.typedobj.db.MongoTypeStorage;
 import us.kbase.typedobj.db.TypeDefinitionDB;
-import us.kbase.typedobj.exceptions.TypedObjectExtractionException;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.typedobj.idref.RemappedId;
 import us.kbase.typedobj.test.DummyValidatedTypedObject;
-import us.kbase.workspace.database.ByteArrayFileCacheManager;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIDResolvedWS;
 import us.kbase.workspace.database.ObjectIdentifier;
@@ -67,7 +65,6 @@ import us.kbase.workspace.database.WorkspaceInformation;
 import us.kbase.workspace.database.WorkspaceSaveObject;
 import us.kbase.workspace.database.WorkspaceUser;
 import us.kbase.workspace.database.WorkspaceUserMetadata;
-import us.kbase.workspace.database.exceptions.CorruptWorkspaceDBException;
 import us.kbase.workspace.database.exceptions.InaccessibleObjectException;
 import us.kbase.workspace.database.exceptions.NoSuchObjectException;
 import us.kbase.workspace.database.exceptions.NoSuchWorkspaceException;
@@ -768,22 +765,14 @@ public class MongoInternalsTest {
 	}
 
 	private void failGetObjectsNoSuchObjectExcp(
-			Set<ObjectIDResolvedWS> oidsetver, String msg)
-			throws WorkspaceCommunicationException,
-			CorruptWorkspaceDBException, TypedObjectExtractionException {
-		final Map<ObjectIDResolvedWS, Set<SubsetSelection>> paths =
-				new HashMap<ObjectIDResolvedWS, Set<SubsetSelection>>();
-		for (final ObjectIDResolvedWS o: oidsetver) {
-			paths.put(o, null);
-		}
-		final ByteArrayFileCacheManager man = new ByteArrayFileCacheManager(
-				10000, 10000, ws.getTempFilesManager());
+			final Set<ObjectIDResolvedWS> oidsetver,
+			final String msg)
+			throws WorkspaceCommunicationException {
 		try {
-			mwdb.getObjects(paths, man, 0, true, false, true);
+			mwdb.getObjects(oidsetver, true, false, true);
 			fail("operated on object with no version");
 		} catch (NoSuchObjectException nsoe) {
-			assertThat("correct exception message", nsoe.getMessage(),
-					is(msg));
+			assertThat("correct exception message", nsoe.getMessage(), is(msg));
 		}
 	}
 

--- a/src/us/kbase/workspace/test/database/mongo/MongoWorkspaceDBTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoWorkspaceDBTest.java
@@ -32,7 +32,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoDatabase;
 
@@ -149,17 +148,11 @@ public class MongoWorkspaceDBTest {
 						.append("actions.0.wsobjs", null)));
 		
 		
-		final Map<ObjectIDResolvedWS, Map<SubsetSelection, WorkspaceObjectData.Builder>> res =
-				mocks.mdb.getObjects(
-						ImmutableMap.of(new ObjectIDResolvedWS(wsid, 1), set()),
-						null,
-						0,
-						true,
-						false,
-						true);
+		final Map<ObjectIDResolvedWS, WorkspaceObjectData.Builder> res = mocks.mdb.getObjects(
+				set(new ObjectIDResolvedWS(wsid, 1)), true, false, true);
 		
 		final Provenance pgot = res.get(new ObjectIDResolvedWS(wsid, 1))
-				.get(SubsetSelection.EMPTY).build().getProvenance();
+				.build().getProvenance();
 		
 		//TODO TEST add equals methods to provenance classes & test & use here
 		assertThat("incorrect user", pgot.getUser(), is(new WorkspaceUser("u")));
@@ -191,17 +184,10 @@ public class MongoWorkspaceDBTest {
 				new Document(),
 				new Document("$unset", new Document(Fields.VER_EXT_IDS, "")));
 		
-		final Map<ObjectIDResolvedWS, Map<SubsetSelection, WorkspaceObjectData.Builder>> res =
-				mocks.mdb.getObjects(
-						ImmutableMap.of(new ObjectIDResolvedWS(wsid, 1), set()),
-						null,
-						0,
-						true,
-						false,
-						true);
+		final Map<ObjectIDResolvedWS, WorkspaceObjectData.Builder> res = mocks.mdb.getObjects(
+				set(new ObjectIDResolvedWS(wsid, 1)), true, false, true);
 		
-		final WorkspaceObjectData wod = res.get(new ObjectIDResolvedWS(wsid, 1))
-				.get(SubsetSelection.EMPTY).build();
+		final WorkspaceObjectData wod = res.get(new ObjectIDResolvedWS(wsid, 1)).build();
 		assertThat("incorrect data", wod.getSerializedData(), is(Optional.empty()));
 		assertThat("incorrect ext ids", wod.getExtractedIds(), is(Collections.emptyMap()));
 	}

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -8699,10 +8699,10 @@ public class WorkspaceTest extends WorkspaceTester {
 			List<ObjectIdentifier> all = new LinkedList<ObjectIdentifier>();
 			all.addAll(ois1l2);
 			all.addAll(bothoi);
-			ws.setResourceConfig(build.withMaxReturnedDataSize(60).build());
+			ws.setResourceConfig(build.withMaxReturnedDataSize(80).build());
 			destroyGetObjectsResources(ws.getObjects(user, all));
-			ws.setResourceConfig(build.withMaxReturnedDataSize(59).build());
-			err = new IllegalArgumentException(String.format(errstr, 60, 59));
+			ws.setResourceConfig(build.withMaxReturnedDataSize(79).build());
+			err = new IllegalArgumentException(String.format(errstr, 80, 79));
 			failGetSubset(user, all, err);
 			TestCommon.assertNoTempFilesExist(tfm);
 		} finally {


### PR DESCRIPTION
Next: rewrite the BAFCM constructor to just take a boolean that tells it
to store data on disk or in memory, and get rid of the thread unsafe
size calculations.

Seems like the code is quite a bit simpler overall by splitting
MWSDB.getOBjects() into two methods