### PR TITLE
Drop Jodatime and move Dates to Instants

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -33,7 +33,6 @@
     <include name="jna/jna-3.4.0.jar"/>
     <include name="servlet/servlet-api-2.5.jar"/>
     <include name="syslog4j/syslog4j-0.9.46.jar"/>
-    <include name="joda/joda-time-2.2.jar"/>
     <include name="annotation/javax.annotation-api-1.3.2.jar"/>
   </fileset>
 
@@ -41,11 +40,12 @@
     <include name="junit/junit-4.12.jar"/>
     <include name="hamcrest/hamcrest-core-1.3.jar"/>
     <include name="kbase/common/kbase-common-0.1.0.jar"/>
+    <!-- joda is required for kbase-common -->
+    <include name="joda/joda-time-2.2.jar"/>
     <include name="kbase/auth/kbase-auth-0.4.4.jar"/>
     <include name="jackson/jackson-annotations-2.9.9.jar"/>
     <include name="jackson/jackson-core-2.9.9.jar"/>
     <include name="jackson/jackson-databind-2.9.9.jar"/>
-    <include name="${commonjar}"/>
   </fileset>
 
   <fileset dir="${jardir}" id="shocklib">

--- a/src/us/kbase/workspace/kbase/WorkspaceServerMethods.java
+++ b/src/us/kbase/workspace/kbase/WorkspaceServerMethods.java
@@ -2,7 +2,6 @@ package us.kbase.workspace.kbase;
 
 import static us.kbase.common.utils.ServiceUtils.checkAddlArgs;
 import static us.kbase.workspace.kbase.ArgUtils.checkLong;
-import static us.kbase.workspace.kbase.ArgUtils.chooseDate;
 import static us.kbase.workspace.kbase.ArgUtils.chooseInstant;
 import static us.kbase.workspace.kbase.ArgUtils.getGlobalWSPerm;
 import static us.kbase.workspace.kbase.ArgUtils.wsInfoToTuple;
@@ -522,16 +521,17 @@ public class WorkspaceServerMethods {
 		checkAddlArgs(params.getAdditionalProperties(), params.getClass());
 		final Permission p = params.getPerm() == null ? null :
 				translatePermission(params.getPerm());
-		final Date after = chooseDate(params.getAfter(),
+		final Instant after = chooseInstant(params.getAfter(),
 				params.getAfterEpoch(),
 				"Cannot specify both timestamp and epoch for after parameter");
-		final Date before = chooseDate(params.getBefore(),
+		final Instant before = chooseInstant(params.getBefore(),
 				params.getBeforeEpoch(),
 				"Cannot specify both timestamp and epoch for before parameter");
 		return wsInfoToTuple(ws.listWorkspaces(user,
 				p, convertUsers(params.getOwners()),
 				new WorkspaceUserMetadata(params.getMeta()),
-				after, before,
+				after == null ? null : Date.from(after),
+				before == null ? null : Date.from(before),
 				longToBoolean(params.getExcludeGlobal()),
 				longToBoolean(params.getShowDeleted()),
 				longToBoolean(params.getShowOnlyDeleted())));

--- a/src/us/kbase/workspace/test/kbase/ArgUtilsTest.java
+++ b/src/us/kbase/workspace/test/kbase/ArgUtilsTest.java
@@ -1,0 +1,151 @@
+package us.kbase.workspace.test.kbase;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static us.kbase.workspace.kbase.ArgUtils.chooseInstant;
+import static us.kbase.common.test.TestCommon.inst;
+
+import java.time.Instant;
+
+import org.junit.Test;
+
+import us.kbase.common.test.TestCommon;
+
+public class ArgUtilsTest {
+	
+	// TODO TEST add more ArgUtils unit tests
+	
+	@Test
+	public void chooseInstantSuccess() throws Exception {
+		checkChooseInstant(null, -1000L, inst(-1000));
+		checkChooseInstant(null, 0L, inst(0));
+		checkChooseInstant(null, 1000L, inst(1000));
+		checkChooseInstant(null, 897086L, inst(897086));
+		
+		checkChooseInstant("2013-04-26T23:52:06-1111", null, inst(1367060586000L));
+		checkChooseInstant("2013-04-26T23:52:06-0000", null, inst(1367020326000L));
+		checkChooseInstant("2013-04-26T23:52:06-00:00", null, inst(1367020326000L));
+		checkChooseInstant("2013-04-26T23:52:06Z", null, inst(1367020326000L));
+		checkChooseInstant("2013-04-26T23:52:06.Z", null, inst(1367020326000L));
+		checkChooseInstant("2013-04-26T23:52:06.-0500", null, inst(1367038326000L));
+		checkChooseInstant("2013-04-26T23:52:06.7Z", null, inst(1367020326700L));
+		checkChooseInstant("2013-04-26T23:52:06.78Z", null, inst(1367020326780L));
+		checkChooseInstant("2013-04-26T23:52:06.789Z", null, inst(1367020326789L));
+		checkChooseInstant("2013-04-26T23:52:06.789-0000", null, inst(1367020326789L));
+		checkChooseInstant("2013-04-26T23:52:06.789-0600", null, inst(1367041926789L));
+		checkChooseInstant("2013-04-26T23:52:06.789-06:00", null, inst(1367041926789L));
+		// this is a weird case. Changing either of the time zone offsets to -7 causes a failure as
+		// expected, as does switching the order of the offsets.
+		// Presumably this is due to the format string accepting time zone offsets
+		// both with or without a colon. Not sure how to fix and not particularly concerned since
+		// the time is unambiguous and no one is likely to format time stamps like this.
+		checkChooseInstant("2013-04-26T23:52:06.789-08:00-0800", null, inst(1367049126789L));
+		// another weird case. Obvs there isn't 31 days in April but the smart resolver
+		// automatically switches it to 30. I set the resolver to strict mode but then everything
+		// started failing with completely unhelpful error messages. So f this for now.
+		checkChooseInstant("2013-04-31T23:52:06-0800", null, inst(1367394726000L));
+	}
+	
+	private void checkChooseInstant(
+			final String timestamp,
+			final Long epochMillis,
+			final Instant expected)
+			throws Exception {
+		final Instant got = chooseInstant(timestamp, epochMillis, "foo");
+		assertThat("incorrect instant, got epoch of " + got.toEpochMilli(), got, is(expected));
+	}
+
+	@Test
+	public void chooseInstantFail() throws Exception {
+		failChooseInstant("ts", 1L, iae("can't provide both error"));
+
+		failChooseInstant("2O13-00-26T23:52:06-0800", 0, true);
+
+		failChooseInstant("2013--01-26T23:52:06-0800", 5, true);
+		failChooseInstant("2013-00-26T23:52:06-0800",
+				"Invalid value for MonthOfYear (valid values 1 - 12): 0");
+		failChooseInstant("2013-13-26T23:52:06-0800",
+				"Invalid value for MonthOfYear (valid values 1 - 12): 13");
+		failChooseInstant("2013-O1-26T23:52:06-0800", 5, true);
+		
+		failChooseInstant("2013-04-00T23:52:06-0800",
+				"Invalid value for DayOfMonth (valid values 1 - 28/31): 0");
+		failChooseInstant("2013-04-32T23:52:06-0800",
+				"Invalid value for DayOfMonth (valid values 1 - 28/31): 32");
+		failChooseInstant("2013-01-O1T23:52:06-0800", 8, true);
+		
+		failChooseInstant("2013-04-01T24:52:06-0800",
+				"Invalid value for HourOfDay (valid values 0 - 23): 24");
+		failChooseInstant("2013-01-01TO2:52:06-0800", 11, true);
+		
+		failChooseInstant("2013-04-01T23:60:06-0800",
+				"Invalid value for MinuteOfHour (valid values 0 - 59): 60");
+		failChooseInstant("2013-01-01T02:O4:06-0800", 14, true);
+		
+		failChooseInstant("2013-04-01T23:59:60-0800",
+				"Invalid value for SecondOfMinute (valid values 0 - 59): 60");
+		failChooseInstant("2013-01-01T02:07:O9-0800", 17, true);
+		
+		failChooseInstant("2013-04-26T23:52:0", 17, true);
+		failChooseInstant("2013-04-26T23:52:06", null, iae(
+				"Date '2013-04-26T23:52:06' does not have time zone information"));
+		failChooseInstant("2013-04-26T23:52Z", 16, true);
+		failChooseInstant("2013-04-26T23:52-0800", 16, true);
+		failChooseInstant("2013-04-26T23:52:06.7893Z", 23, false);
+		failChooseInstant("2013-04-26T23:52:06-", 19, false);
+		failChooseInstant("2013-04-26T23:52:06-GMT+1", 19, false);
+		failChooseInstant("2013-04-26T23:52:06-1", 19, false);
+		failChooseInstant("2013-04-26T23:52:06-11", 19, false);
+		failChooseInstant("2013-04-26T23:52:06-11:", 19, false);
+		failChooseInstant("2013-04-26T23:52:06-111", 19, false);
+		failChooseInstant("2013-04-26T23:52:06-11:1", 19, false);
+		failChooseInstant("2013-04-26T23:52:06-8000", 19, false);
+		failChooseInstant("2013-04-26T23:52:06-0800-08:00", 24, false);
+		failChooseInstant("2013-04-26T23:52:06-08:00-0700", 25, false);
+		failChooseInstant("2013-04-26T23:52:06-07:00-0800", 25, false);
+	}
+	
+	private void failChooseInstant(final String timestamp, final String errsuffix)
+			throws Exception {
+		failChooseInstant(timestamp, null, iae(generrPrefix(timestamp) + ": " + errsuffix));
+	}
+	
+	private void failChooseInstant(final String timestamp, final int index, final boolean prior)
+			throws Exception {
+		failChooseInstant(timestamp, null, iae(generr(timestamp, index, prior)));
+	}
+	
+	private IllegalArgumentException iae(final String message) {
+		return new IllegalArgumentException(message);
+	}
+	
+	private String generrPrefix(final String timestamp) {
+		return String.format("Unparseable date: Text '%s' could not be parsed", timestamp);
+	}
+	
+	private String generr(final String timestamp, final int index, final boolean prior) {
+		final String template;
+		if (prior) {
+			template = generrPrefix(timestamp) + " at index %s";
+					
+		} else {
+			template = generrPrefix(timestamp) + ", unparsed text found at index %s";
+		}
+		return String.format(template, index);
+	}
+	
+	private void failChooseInstant(
+			final String timestamp,
+			final Long epochMillis,
+			final Exception expected)
+			throws Exception {
+		try {
+			chooseInstant(timestamp, epochMillis, "can't provide both error");
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+
+}

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
@@ -737,6 +737,7 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 					is("Cannot specify both time and epoch in provenance action"));
 		}
 
+		// test time conversion to a standard format
 		saveProvWithGoodTime("provenance",
 				new StringEpoch("2013-04-26T23:52:06-0800"),
 				new StringEpoch(1367049126000L, "2013-04-27T07:52:06+0000"));
@@ -759,23 +760,11 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 				new StringEpoch(1367049126140L),
 				new StringEpoch(1367049126140L, "2013-04-27T07:52:06+0000"));
 
+		// most tests for bad dates are in the arg utils tests, so we just do a single case here
 		saveProvWithBadTime("2013-04-26T25:52:06-0800",
-				"Unparseable date: Cannot parse \"2013-04-26T25:52:06-0800\": Value 25 for hourOfDay must be in the range [0,23]");
-		saveProvWithBadTime("2013-04-26T23:52:06-8000",
-				"Unparseable date: Invalid format: \"2013-04-26T23:52:06-8000\" is malformed at \"8000\"");
-		saveProvWithBadTime("2013-04-35T23:52:06-0800",
-				"Unparseable date: Cannot parse \"2013-04-35T23:52:06-0800\": Value 35 for dayOfMonth must be in the range [1,30]");
-		saveProvWithBadTime("2013-13-26T23:52:06-0800",
-				"Unparseable date: Cannot parse \"2013-13-26T23:52:06-0800\": Value 13 for monthOfYear must be in the range [1,12]");
-		saveProvWithBadTime("2013-13-26T23:52:06.1111-0800",
-				"Unparseable date: Invalid format: \"2013-13-26T23:52:06.1111-0800\" is malformed at \"1-0800\"");
-		saveProvWithBadTime("2013-13-26T23:52:06.-0800",
-				"Unparseable date: Invalid format: \"2013-13-26T23:52:06.-0800\" is malformed at \".-0800\"");
-		saveProvWithBadTime("2013-12-26T23:52:06.55",
-				"Unparseable date: Invalid format: \"2013-12-26T23:52:06.55\" is too short");
-		saveProvWithBadTime("2013-12-26T23:52-0800",
-				"Unparseable date: Invalid format: \"2013-12-26T23:52-0800\" is malformed at \"-0800\"");
-
+				"Unparseable date: Text '2013-04-26T25:52:06-0800' could not be parsed: " +
+				"Invalid value for HourOfDay (valid values 0 - 23): 25");
+		
 		CLIENT1.setPermissions(new SetPermissionsParams().withId(wsid)
 				.withNewPermission("w").withUsers(Arrays.asList(USER2)));
 		CLIENT2.saveObjects(new SaveObjectsParams().withWorkspace("provenance")
@@ -2367,7 +2356,7 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 				Arrays.asList(w2), true);
 
 		failListWorkspaceByDate("crappy date",
-				"Unparseable date: Invalid format: \"crappy date\"");
+				"Unparseable date: Text 'crappy date' could not be parsed at index 0");
 		try {
 			CLIENT1.listWorkspaceInfo(new ListWorkspaceInfoParams()
 				.withAfter(beforeall).withAfterEpoch(1L));
@@ -2730,7 +2719,7 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 		compareObjectInfo(CLIENT1.listObjects(lop), Arrays.asList(o2), false);
 
 		failListObjectsByDate(ws, "crappy obj date",
-				"Unparseable date: Invalid format: \"crappy obj date\"");
+				"Unparseable date: Text 'crappy obj date' could not be parsed at index 0");
 		try {
 			CLIENT1.listObjects(new ListObjectsParams()
 				.withWorkspaces(Arrays.asList(ws))


### PR DESCRIPTION
Jodatime has been deprecated since the release of Java 8, 8 years ago.
Use the built in classes instead.

Start moving mutable Dates to immutable Instants.