### PR TITLE
PTV-1733: Consolidate* reference parsing code

### DIFF
--- a/src/us/kbase/typedobj/core/TypedObjectValidator.java
+++ b/src/us/kbase/typedobj/core/TypedObjectValidator.java
@@ -72,7 +72,7 @@ public class TypedObjectValidator {
 	 * This object is used to fetch the typed object Json Schema documents and
 	 * JsonSchema objects which are used for validation
 	 */
-	protected TypeProvider typeProvider;
+	private TypeProvider typeProvider;
 	
 	
 	/**
@@ -91,7 +91,8 @@ public class TypedObjectValidator {
 		this.typeProvider = typeProvider;
 	}
 	
-	
+	// TODO MEMORY delete these methods that work on strings / JSON nodes. They'll kill memory
+	// use for any large objects and are only used in tests.
 	/**
 	 * Validate a Json String instance against the specified TypeDefId.  Returns a TypedObjectValidationReport
 	 * containing the results of the validation and any other KBase typed object specific information such

--- a/src/us/kbase/workspace/database/ObjectIdentifier.java
+++ b/src/us/kbase/workspace/database/ObjectIdentifier.java
@@ -5,7 +5,9 @@ import static us.kbase.workspace.database.Util.xorNameId;
 import static us.kbase.workspace.database.Util.noNulls;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,6 +30,8 @@ public class ObjectIdentifier {
 	//this cannot be a legal object/workspace char
 	/** The separator between parts of a workspace reference to an object. */
 	public final static String REFERENCE_SEP = "/";
+	/** The separator between references in a reference path. */
+	public static final String REFERENCE_PATH_SEP = ";";
 	
 	private final WorkspaceIdentifier wsi;
 	private final String name;
@@ -401,13 +405,23 @@ public class ObjectIdentifier {
 		return new Builder(oi);
 	}
 	
-	/** Get a builder given an object reference.
+	/** Get a builder given an object reference. Notably, reference paths will cause an error.
+	 * If a reference path is permissible input, use {@link #getBuilderFromRefPath(String)}.
 	 * @param reference the object reference.
 	 * @return a new builder.
 	 */
 	public static Builder getBuilder(final String reference) {
-		// TODO CODE add a builder for a reference path like X/Y/Z;X/Y;X/Y/Z and replace parsers
 		return new Builder(reference);
+	}
+
+	/** Get a builder given an object reference or reference path.
+	 * Example: "my_ws/my_obj/5;6/7;ws1/obj2;6/7/8"
+	 *
+	 * @param reference the object reference or path.
+	 * @return a new builder.
+	 */
+	public static Builder getBuilderFromRefPath(final String refpath) {
+		return new Builder(refpath, true);
 	}
 	
 	/** Create a copy of the input builder.
@@ -421,7 +435,7 @@ public class ObjectIdentifier {
 	/** A builder for an {@link ObjectIdentifier}. */
 	public static class Builder {
 		
-		private final WorkspaceIdentifier wsi;
+		private WorkspaceIdentifier wsi;
 		private String name = null;
 		private long id = -1;
 		private int version = -1;
@@ -453,13 +467,46 @@ public class ObjectIdentifier {
 			this.lookup = b.lookup;
 			this.subset = b.subset;
 		}
-
-		public Builder(final String reference) {
+		
+		private Builder(final String reference) {
 			checkString(reference, "reference");
-			final String[] r = reference.split(REFERENCE_SEP);
+			processReference(reference, true);
+		}
+
+		private Builder(final String refpath, boolean ignored) {
+			checkString(refpath, "refpath");
+			String[] parts = refpath.split(REFERENCE_PATH_SEP);
+			// remove trailing whitespace after last REFERENCE_PATH_SEP
+			// also will ignore stuff like '1/1/1;   ;' since the parsing alg doesn't make a
+			// distinction. Fine for now
+			if (parts.length > 1 && parts[parts.length - 1].trim().isEmpty()) {
+				parts = Arrays.copyOf(parts, parts.length - 1);
+			}
+			final LinkedList<ObjectIdentifier> path = new LinkedList<>();
+			for (int i = 0; i < parts.length; i++) {
+				try {
+					if (i == 0) {
+						processReference(parts[i], true);
+					} else {
+						path.add(processReference(parts[i], false));
+					}
+				} catch (IllegalArgumentException e) {
+					final String errprefix = parts.length == 1 ?
+							"" : String.format("Reference path position %s: ", i + 1);
+					throw new IllegalArgumentException(errprefix + e.getLocalizedMessage(), e);
+				}
+			}
+			if (!path.isEmpty()) {
+				this.refpath = Collections.unmodifiableList(path); // needs to be immutable
+			}
+		}
+		
+		private ObjectIdentifier processReference(final String reference, final boolean set) {
+			 // treat spaces in individual ref as errors
+			final String[] r = reference.trim().split(REFERENCE_SEP);
 			if (r.length != 2 && r.length != 3) {
 				throw new IllegalArgumentException(String.format(
-						"Illegal number of separators %s in object reference %s",
+						"Illegal number of separators '%s' in object reference '%s'",
 						REFERENCE_SEP, reference));
 			}
 			WorkspaceIdentifier wsi;
@@ -468,12 +515,24 @@ public class ObjectIdentifier {
 			} catch (NumberFormatException nfe) {
 				wsi = new WorkspaceIdentifier(r[0]);
 			}
-			this.wsi = wsi;  // java complains if we assign directly
-			this.version = r.length == 3 ? checkVersion(parseInt(r[2], reference, "version")) : -1;
+			long id = -1;
+			String name = null;
 			try {
-				this.id = checkID(Long.parseLong(r[1]));
+				id = checkID(Long.parseLong(r[1]));
 			} catch (NumberFormatException nfe) {
-				this.name = checkObjectName(r[1]);
+				name = checkObjectName(r[1]);
+			}
+			final int version = r.length == 3 ?
+					checkVersion(parseInt(r[2], reference, "version")) : -1;
+			if (set) {
+				this.wsi = wsi;
+				this.id = id;
+				this.name = name;
+				this.version = version;
+				return null;
+			}
+			else {
+				return new ObjectIdentifier(wsi, id, name, version);
 			}
 		}
 

--- a/src/us/kbase/workspace/database/ObjectIdentifier.java
+++ b/src/us/kbase/workspace/database/ObjectIdentifier.java
@@ -173,12 +173,12 @@ public class ObjectIdentifier {
 		}
 	}
 	
-	private static Integer parseInt(String s, String reference, String portion) {
+	private static Integer parseInt(final String s, final String reference, final String portion) {
 		try {
 			return Integer.parseInt(s);
 		} catch (NumberFormatException e) {
 			throw new IllegalArgumentException(String.format(
-					"Unable to parse %s portion of object reference %s to an integer",
+					"Unable to parse %s portion of object reference '%s' to an integer",
 					portion, reference));
 		}
 	}

--- a/src/us/kbase/workspace/database/Workspace.java
+++ b/src/us/kbase/workspace/database/Workspace.java
@@ -1803,34 +1803,14 @@ public class Workspace {
 				final T associatedObject)
 				throws IdParseException {
 			// cannot be null or empty at this point
-			final String[] refs = id.trim().split(";");
-			final List<ObjectIdentifier> ois = new LinkedList<>();
-			for (int i = 0; i < refs.length; i++) {
-				try {
-					ois.add(ObjectIdentifier.getBuilder(refs[i].trim()).build());
-					//Illegal arg is probably not the right exception
-				} catch (IllegalArgumentException iae) {
-					final List<String> attribs = getAnyAttributeSet(associatedObject, id);
-					final String messagePrefix;
-					if (refs.length == 1) {
-						messagePrefix = "";
-					} else {
-						messagePrefix = String.format(
-								"ID parse error in reference string %s at position %s: ",
-								id, i + 1);
-					}
-					throw new IdParseException(messagePrefix + iae.getMessage(),
-							getIdType(), associatedObject, id, attribs, iae);
-				}
+			try {
+				return ObjectIdentifier.getBuilderFromRefPath(id).build();
+				//Illegal arg is probably not the right exception
+			} catch (IllegalArgumentException e) {
+				final List<String> attribs = getAnyAttributeSet(associatedObject, id);
+				throw new IdParseException(
+						e.getMessage(), getIdType(), associatedObject, id, attribs, e);
 			}
-			if (ois.size() == 1) {
-				return ois.get(0);
-			}
-			// probably not worth making a builder starting from a reference to avoid an
-			// extra OI instantiation
-			return ObjectIdentifier.getBuilder(ois.get(0))
-					.withReferencePath(ois.subList(1, ois.size()))
-					.build();
 		}
 
 		//use this method when an ID is bad regardless of the attribute set

--- a/src/us/kbase/workspace/database/provenance/Common.java
+++ b/src/us/kbase/workspace/database/provenance/Common.java
@@ -10,6 +10,8 @@ import java.net.URL;
  * Tests are all via testing the public provenance class APIs.
  */
 class Common {
+	
+	private Common() {};
 
 	static String processString(final String input) {
 		return isNullOrEmpty(input) ? null : input.trim();

--- a/src/us/kbase/workspace/kbase/IdentifierUtils.java
+++ b/src/us/kbase/workspace/kbase/IdentifierUtils.java
@@ -19,7 +19,8 @@ import us.kbase.workspace.database.WorkspaceIdentifier;
 
 public class IdentifierUtils {
 	
-	//TODO JAVADOC
+	// TODO JAVADOC
+	// TODO CODE check the ref parse code in ObjectIdentifer and see if this code can be simplified
 	
 	public static WorkspaceIdentifier processWorkspaceIdentifier(
 			final WorkspaceIdentity wsi) {
@@ -171,8 +172,7 @@ public class IdentifierUtils {
 			throw new IllegalArgumentException(
 					"No object specifications provided");
 		}
-		final List<ObjectIdentifier> objs =
-				new LinkedList<ObjectIdentifier>();
+		final List<ObjectIdentifier> objs = new LinkedList<>();
 		int objcount = 1;
 		for (final ObjectSpecification o: objects) {
 			if (o == null) {
@@ -244,8 +244,7 @@ public class IdentifierUtils {
 				.build();
 	}
 
-	private static void mutateObjSpecByRefString(
-			final ObjectSpecification o) {
+	private static void mutateObjSpecByRefString(final ObjectSpecification o) {
 		if (o.getRef() == null) {
 			return;
 		}

--- a/src/us/kbase/workspace/kbase/WorkspaceServerMethods.java
+++ b/src/us/kbase/workspace/kbase/WorkspaceServerMethods.java
@@ -442,8 +442,6 @@ public class WorkspaceServerMethods {
 					InaccessibleObjectException, NoSuchReferenceException, NoSuchObjectException,
 					TypedObjectExtractionException, ReferenceSearchMaximumSizeExceededException,
 					InterruptedException {
-		// ugh, tried to see if we could code out the jpe and ioe but it's too much of a mess
-		// once you get into the byte array cache and JTS
 		checkAddlArgs(params.getAdditionalProperties(), GetObjects2Params.class);
 		final List<ObjectIdentifier> loi =
 				processObjectSpecifications(params.getObjects());

--- a/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
+++ b/src/us/kbase/workspace/test/kbase/IdentifierUtilsTest.java
@@ -311,14 +311,14 @@ public class IdentifierUtilsTest {
 	public void failObjectIdentityWithKBRef() throws Exception {
 		final ObjectIdentity refoi = new ObjectIdentity().withRef("kb|ws.4.obj.3");
 		expectFailProcessObjectIdentifier(refoi, new IllegalArgumentException(
-				"Illegal number of separators / in object reference kb|ws.4.obj.3"));
+				"Illegal number of separators '/' in object reference 'kb|ws.4.obj.3'"));
 	}
 	
 	@Test
 	public void failObjectIdentityWithKBRefAndVer() throws Exception {
 		final ObjectIdentity refoi = new ObjectIdentity().withRef("kb|ws.4.obj.3.ver.2");
 		expectFailProcessObjectIdentifier(refoi, new IllegalArgumentException(
-				"Illegal number of separators / in object reference kb|ws.4.obj.3.ver.2"));
+				"Illegal number of separators '/' in object reference 'kb|ws.4.obj.3.ver.2'"));
 	}
 	
 	@Test
@@ -565,7 +565,7 @@ public class IdentifierUtilsTest {
 				new IllegalArgumentException(
 						"Error on ObjectSpecification #2: Invalid object " +
 						"reference (baz) at position #3: Illegal number of " +
-						"separators / in object reference baz"));
+						"separators '/' in object reference 'baz'"));
 	}
 	
 	@Test

--- a/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/workspace/test/kbase/JSONRPCLayerTest.java
@@ -956,11 +956,13 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 		loi.clear();
 		loi.add(new ObjectIdentity().withRef("saveget/2"));
 		loi.add(new ObjectIdentity().withRef("kb|wss." + wsid + ".obj.2"));
-		failGetObjects(loi, "Error on ObjectIdentity #2: Illegal number of separators / in object reference kb|wss." + wsid + ".obj.2");
+		failGetObjects(loi, "Error on ObjectIdentity #2: Illegal number of separators '/' in "
+				+ "object reference 'kb|wss." + wsid + ".obj.2'");
 
 		loi.set(1, new ObjectIdentity().withRef("saveget/1"));
 		loi.add(new ObjectIdentity().withRef("kb|ws." + wsid));
-		failGetObjects(loi, "Error on ObjectIdentity #3: Illegal number of separators / in object reference kb|ws." + wsid);
+		failGetObjects(loi, "Error on ObjectIdentity #3: Illegal number of separators '/' in "
+				+ "object reference 'kb|ws." + wsid + "'");
 
 		//there are 32 different ways to get this type of error. Just try a few.
 		loi.set(2, new ObjectIdentity().withRef("kb|ws." + wsid).withName("2"));
@@ -2662,8 +2664,9 @@ public class JSONRPCLayerTest extends JSONRPCLayerTester {
 		try {
 			CLIENT1.getObjectHistory(new ObjectIdentity().withRef("listObjs1/hidden/1/3"));
 		} catch (ServerException se) {
-			assertThat("correct excep message", se.getLocalizedMessage(),
-					is("Illegal number of separators / in object reference listObjs1/hidden/1/3"));
+			assertThat("correct excep message", se.getLocalizedMessage(), is(
+					"Illegal number of separators '/' in object reference 'listObjs1/hidden/1/3'")
+					);
 		}
 	}
 

--- a/src/us/kbase/workspace/test/workspace/ObjectIdentifierTest.java
+++ b/src/us/kbase/workspace/test/workspace/ObjectIdentifierTest.java
@@ -31,6 +31,10 @@ public class ObjectIdentifierTest {
 	
 	private static final WorkspaceIdentifier WSI = new WorkspaceIdentifier(100000000);
 	
+	private static ObjectIdentifier.Builder builder(final WorkspaceIdentifier wsi) {
+		return ObjectIdentifier.getBuilder(wsi);
+	}
+	
 	@Test
 	public void equals() throws Exception {
 		EqualsVerifier.forClass(ObjectIdentifier.class).usingGetClass().verify();
@@ -415,8 +419,17 @@ public class ObjectIdentifierTest {
 		assertThat("incorrect refpath", oi.getRefPath(), is(Arrays.asList(oi1)));
 		
 		// test modifying the returned path
+		failModifyRefPath(oi, oi2);
+		
+		// test from ref path string
+		final ObjectIdentifier roi = ObjectIdentifier.getBuilderFromRefPath("1/1/1;2/2/2").build();
+		failModifyRefPath(roi, oi2);
+		
+	}
+
+	public void failModifyRefPath(final ObjectIdentifier target, final ObjectIdentifier toAdd) {
 		try {
-			oi.getRefPath().add(oi2);
+			target.getRefPath().add(toAdd);
 			fail("expected exception");
 		} catch (UnsupportedOperationException e) {
 			// test passed
@@ -429,6 +442,7 @@ public class ObjectIdentifierTest {
 		final Optional<String> name;
 		final Optional<Long> id;
 		final Optional<Integer> version;
+		final List<ObjectIdentifier> refpath;
 
 		public RefTestCase(
 				final String ref,
@@ -441,6 +455,22 @@ public class ObjectIdentifierTest {
 			this.name = name;
 			this.id = id;
 			this.version = version;
+			this.refpath = null;
+		}
+		
+		public RefTestCase(
+				final String ref,
+				final WorkspaceIdentifier wsi,
+				final Optional<String> name,
+				final Optional<Long> id,
+				final Optional<Integer> version,
+				final List<ObjectIdentifier> refpath) {
+			this.ref = ref;
+			this.wsi = wsi;
+			this.name = name;
+			this.id = id;
+			this.version = version;
+			this.refpath = refpath;
 		}
 	}
 	
@@ -466,7 +496,7 @@ public class ObjectIdentifierTest {
 				new RefTestCase("1/1/60", w1, ES, opt(1L), opt(60)),
 				new RefTestCase("whoo/23/91", wwhoo, ES, opt(23L), opt(91)),
 				new RefTestCase("89/what", w89, opt("what"), EL, EI),
-				new RefTestCase("89/what/32", w89, opt("what"), EL, opt(32)),
+				new RefTestCase("   \t  89/what/32  \t  ", w89, opt("what"), EL, opt(32)),
 				new RefTestCase("whoo/6", wwhoo, ES, opt(6L), EI),
 				new RefTestCase("whoo/89/", wwhoo, ES, opt(89L), EI)  // trailing slash ok
 				);
@@ -474,11 +504,89 @@ public class ObjectIdentifierTest {
 		for (final RefTestCase t: tests) {
 			final ObjectIdentifier oi = ObjectIdentifier.getBuilder(t.ref).build();
 			
+			checkRefTestCase(oi, t);
+			
+			// test that the ref path builder processes refs identically
+			final ObjectIdentifier roi = ObjectIdentifier.getBuilderFromRefPath(t.ref).build();
+			
+			checkRefTestCase(roi, t);
+		}
+	}
+
+	public void checkRefTestCase(final ObjectIdentifier oi, final RefTestCase t) {
+		assertThat("incorrect wsi for ref " + t.ref, oi.getWorkspaceIdentifier(), is(t.wsi));
+		assertThat("incorrect name for ref " + t.ref, oi.getName(), is(t.name));
+		assertThat("incorrect id for ref " + t.ref, oi.getID(), is(t.id));
+		assertThat("incorrect version for ref" + t.ref, oi.getVersion(), is(t.version));
+		assertNoNonAddressState(oi);
+	}
+	
+	@Test
+	public void buildFromRefPath() throws Exception {
+		final WorkspaceIdentifier wfoo = new WorkspaceIdentifier("foo");
+		final WorkspaceIdentifier wufoo = new WorkspaceIdentifier("user1:foo");
+		final WorkspaceIdentifier wfoA = new WorkspaceIdentifier("fo.A-1_2");
+		final WorkspaceIdentifier wwhoo = new WorkspaceIdentifier("whoo");
+		final WorkspaceIdentifier w1 = new WorkspaceIdentifier(1);
+		final WorkspaceIdentifier w2 = new WorkspaceIdentifier(2);
+		final WorkspaceIdentifier w89 = new WorkspaceIdentifier(89);
+		final List<ObjectIdentifier> oi1 = list(
+				builder(w1).withID(2L).withVersion(3).build(),
+				builder(wfoo).withName("bar").build());
+		final List<ObjectIdentifier> oi2 = list(
+				builder(wfoA).withName("f|o.A-1_2").withVersion(1).build());
+		final List<ObjectIdentifier> oi3 = list(
+				builder(wwhoo).withID(89L).build(),
+				builder(w2).withID(3L).build(),
+				builder(wufoo).withName("baz").withVersion(1).build(),
+				builder(w1).withName(TEXT255).build());
+		final List<ObjectIdentifier> oi4 = list(builder(w1).withID(1L).withVersion(1).build());
+		final List<ObjectIdentifier> oi5 = list(builder(wufoo).withName("bat").build());
+		final List<ObjectIdentifier> oi6 = list(
+				builder(wwhoo).withName("whee").withVersion(3).build());
+		final List<ObjectIdentifier> oi7 = list(builder(w2).withID(101L).build());
+		final List<ObjectIdentifier> oi8 = list(builder(w1).withID(1L).withVersion(34).build());
+		final List<ObjectIdentifier> oi9 = list(
+				builder(wwhoo).withID(65L).withVersion(78).build());
+		final List<ObjectIdentifier> oi10 = list(builder(w89).withName("what").build());
+		final List<ObjectIdentifier> oi11 = list(
+				builder(w89).withName("what").withVersion(32).build());
+		final List<ObjectIdentifier> oi12 = list(builder(wwhoo).withID(6L).build());
+
+		// we use WorkspaceIdentifier under the hood to check the workspace ID and so don't 
+		// exhaustively test valid workspace IDs / Names here
+		final List<RefTestCase> tests = list(
+				// test trailing whitespace after ; separator ok
+				new RefTestCase("   fo.A-1_2/f|o.A-1_2/1   \t  ;  \t   1/2/3 ; foo/bar   ;    ",
+						wfoA, opt("f|o.A-1_2"), EL, opt(1), oi1),
+				new RefTestCase("1/" + TEXT255 + "  ;  fo.A-1_2/f|o.A-1_2/1",
+						w1, opt(TEXT255), EL, EI, oi2),
+				// check trailing slash ok
+				new RefTestCase("1/1/1;whoo/89/;2/3/  \t  ;user1:foo/baz/1;1/" + TEXT255,
+						w1, ES, opt(1L), opt(1), oi3),
+				new RefTestCase("user1:foo/bar  ;   1/1/1 \t \n", wufoo, opt("bar"), EL, EI, oi4),
+				new RefTestCase("foo/bar/1;user1:foo/bat", wfoo, opt("bar"), EL, opt(1), oi5),
+				new RefTestCase("2/49; whoo/whee/3", w2, ES, opt(49L), EI, oi6),
+				new RefTestCase("1/1/60;  2/101", w1, ES, opt(1L), opt(60), oi7),
+				new RefTestCase("whoo/23/91;1/1/34", wwhoo, ES, opt(23L), opt(91), oi8),
+				new RefTestCase("89/what;whoo/65/78", w89, opt("what"), EL, EI, oi9),
+				new RefTestCase("   \t  89/what/32  \t  ; 89/what",
+						w89, opt("what"), EL, opt(32), oi10),
+				new RefTestCase("whoo/6; 89/what/32", wwhoo, ES, opt(6L), EI, oi11),
+				new RefTestCase("whoo/89/;whoo/6", wwhoo, ES, opt(89L), EI, oi12)
+				);
+		
+		for (final RefTestCase t: tests) {
+			final ObjectIdentifier oi = ObjectIdentifier.getBuilderFromRefPath(t.ref).build();
+			
 			assertThat("incorrect wsi for ref " + t.ref, oi.getWorkspaceIdentifier(), is(t.wsi));
 			assertThat("incorrect name for ref " + t.ref, oi.getName(), is(t.name));
 			assertThat("incorrect id for ref " + t.ref, oi.getID(), is(t.id));
-			assertThat("incorrect version for ref f" + t.ref, oi.getVersion(), is(t.version));
-			assertNoNonAddressState(oi);
+			assertThat("incorrect version for ref " + t.ref, oi.getVersion(), is(t.version));
+			assertThat("incorrect refpath for ref " + t.ref, oi.getRefPath(), is(t.refpath));
+			assertThat("incorrect hasrefpath", oi.hasRefPath(), is(true));
+			assertThat("incorrect lookup", oi.isLookupRequired(), is(false));
+			assertThat("incorrect subset", oi.getSubSet(), is(SubsetSelection.EMPTY));
 		}
 	}
 	
@@ -508,17 +616,19 @@ public class ObjectIdentifierTest {
 	public void getBuilderRefFail() throws Exception {
 		// we use WorkspaceIdentifier under the hood to store the workspace ID and so don't 
 		// exhaustively test invalid workspace IDs / Names here
+		failGetBuilderRef(null, new IllegalArgumentException(
+				"reference cannot be null or the empty string"));
+		failGetBuilderRef("1/1/1;2/2/2", new IllegalArgumentException(
+				"Illegal number of separators '/' in object reference '1/1/1;2/2/2'"));
 		final Map<String, Exception> testCases = MapBuilder.<String, Exception>newHashMap()
-				.with(null, new IllegalArgumentException(
-						"reference cannot be null or the empty string"))
 				.with("  \t   ", new IllegalArgumentException(
-						"Illegal number of separators / in object reference   \t   "))
+						"Illegal number of separators '/' in object reference '  \t   '"))
 				.with("1", new IllegalArgumentException(
-						"Illegal number of separators / in object reference 1"))
+						"Illegal number of separators '/' in object reference '1'"))
 				.with("foo", new IllegalArgumentException(
-						"Illegal number of separators / in object reference foo"))
+						"Illegal number of separators '/' in object reference 'foo'"))
 				.with("foo/1/3/4", new IllegalArgumentException(
-						"Illegal number of separators / in object reference foo/1/3/4"))
+						"Illegal number of separators '/' in object reference 'foo/1/3/4'"))
 				.with("user1|foo/1/3", new IllegalArgumentException(
 						"Illegal character in workspace name user1|foo: |"))
 				.with("foo/b*ar/3", new IllegalArgumentException(
@@ -540,12 +650,86 @@ public class ObjectIdentifierTest {
 				.build();
 		
 		for (final String ref: testCases.keySet()) {
-			try {
-				ObjectIdentifier.getBuilder(ref);
-				fail("expected exception");
-			} catch (Exception got) {
-				TestCommon.assertExceptionCorrect(got, testCases.get(ref));
-			}
+			failGetBuilderRef(ref, testCases.get(ref));
+			failGetBuilderFromRefPath(ref, testCases.get(ref));
+		}
+	}
+	
+	private static final String f(final String formatString, final Object... args) {
+		return String.format(formatString, args);
+	}
+	
+	@Test
+	public void getBuilderFromRefPathFail() throws Exception {
+		failGetBuilderFromRefPath(null, new IllegalArgumentException(
+				"refpath cannot be null or the empty string"));
+		final String one = "1/1/1;";
+		final Map<String, Exception> testCases = MapBuilder.<String, Exception>newHashMap()
+				.with(f("%s  \t   ;   ", one), new IllegalArgumentException(
+						"Reference path position 2: "
+						+ "Illegal number of separators '/' in object reference '  \t   '"))
+				.with(f("%s%s1", one, one), new IllegalArgumentException(
+						"Reference path position 3: "
+						+ "Illegal number of separators '/' in object reference '1'"))
+				.with(f("foo;%s", one), new IllegalArgumentException(
+						"Reference path position 1: "
+						+ "Illegal number of separators '/' in object reference 'foo'"))
+				.with(f("%s%s%s%sfoo/1/3/4", one, one, one, one), new IllegalArgumentException(
+						"Reference path position 5: "
+						+ "Illegal number of separators '/' in object reference 'foo/1/3/4'"))
+				.with(f("%suser1|foo/1/3", one), new IllegalArgumentException(
+						"Reference path position 2: "
+						+ "Illegal character in workspace name user1|foo: |"))
+				.with(f("%s%sfoo/b*ar/3", one, one), new IllegalArgumentException(
+						"Reference path position 3: "
+						+ "Illegal character in object name b*ar: *"))
+				.with(f("foo/%s;%s", TEXT256, one), new IllegalArgumentException(
+						"Reference path position 1: "
+						+ "Object name exceeds the maximum length of 255"))
+				.with(f("%s0/bar/3", one), new IllegalArgumentException(
+						"Reference path position 2: Workspace id must be > 0"))
+				.with(f("%s%s-10000/bar/3", one, one), new IllegalArgumentException(
+						"Reference path position 3: Workspace id must be > 0"))
+				.with(f("%s/1/3", one), new IllegalArgumentException(
+						"Reference path position 2: "
+						+ "Workspace name cannot be null or the empty string"))
+				.with(f("%s%s%s1//3", one, one, one), new IllegalArgumentException(
+						"Reference path position 4: "
+						+ "Object name cannot be null or the empty string"))
+				.with(f("%sf/0/3", one), new IllegalArgumentException(
+						"Reference path position 2: Object id must be > 0"))
+				.with(f("f/-1/3;%s", one), new IllegalArgumentException(
+						"Reference path position 1: Object id must be > 0"))
+				.with(f("%s%s%s%s%sf/1/0", one, one, one, one, one), new IllegalArgumentException(
+						"Reference path position 6: Object version must be > 0"))
+				.with(f("%sf/1/-10", one), new IllegalArgumentException(
+						"Reference path position 2: Object version must be > 0"))
+				.with(f("%s%sf/1/n", one, one), new IllegalArgumentException(
+						"Reference path position 3: "
+						+ "Unable to parse version portion of object reference f/1/n to an integer"
+						))
+				.build();
+		
+		for (final String ref: testCases.keySet()) {
+			failGetBuilderFromRefPath(ref, testCases.get(ref));
+		}
+	}
+
+	private void failGetBuilderRef(final String ref, final Exception expected) {
+		try {
+			ObjectIdentifier.getBuilder(ref);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+	
+	private void failGetBuilderFromRefPath(final String ref, final Exception expected) {
+		try {
+			ObjectIdentifier.getBuilderFromRefPath(ref);
+			fail("expected exception for ref " + ref);
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
 		}
 	}
 	

--- a/src/us/kbase/workspace/test/workspace/ObjectIdentifierTest.java
+++ b/src/us/kbase/workspace/test/workspace/ObjectIdentifierTest.java
@@ -646,7 +646,8 @@ public class ObjectIdentifierTest {
 				.with("f/1/0", new IllegalArgumentException("Object version must be > 0"))
 				.with("f/1/-10", new IllegalArgumentException("Object version must be > 0"))
 				.with("f/1/n", new IllegalArgumentException(
-						"Unable to parse version portion of object reference f/1/n to an integer"))
+						"Unable to parse version portion of object reference 'f/1/n' to an integer"
+						))
 				.build();
 		
 		for (final String ref: testCases.keySet()) {
@@ -706,7 +707,8 @@ public class ObjectIdentifierTest {
 						"Reference path position 2: Object version must be > 0"))
 				.with(f("%s%sf/1/n", one, one), new IllegalArgumentException(
 						"Reference path position 3: "
-						+ "Unable to parse version portion of object reference f/1/n to an integer"
+						+ "Unable to parse version portion of object reference 'f/1/n' to an "
+						+ "integer"
 						))
 				.build();
 		

--- a/src/us/kbase/workspace/test/workspace/ReferenceTest.java
+++ b/src/us/kbase/workspace/test/workspace/ReferenceTest.java
@@ -32,13 +32,14 @@ public class ReferenceTest {
 	public void failRefStringConst() throws Exception {
 		failMakeRef(null, "reference cannot be null or the empty string");
 		failMakeRef("", "reference cannot be null or the empty string");
-		failMakeRef("1", "Illegal number of separators / in object reference 1");
+		failMakeRef("1", "Illegal number of separators '/' in object reference '1'");
 		failMakeRef("1/2", "ref 1/2 is not an absolute reference");
 		failMakeRef("1/foo", "ref 1/foo is not an absolute reference");
 		failMakeRef("foo/1/2", "ref foo/1/2 is not an absolute reference");
 		failMakeRef("1/foo/2", "ref 1/foo/2 is not an absolute reference");
-		failMakeRef("1/1/foo", "Unable to parse version portion of object reference 1/1/foo to an integer");
-		failMakeRef("1/2/3/4", "Illegal number of separators / in object reference 1/2/3/4");
+		failMakeRef("1/1/foo",
+				"Unable to parse version portion of object reference 1/1/foo to an integer");
+		failMakeRef("1/2/3/4", "Illegal number of separators '/' in object reference '1/2/3/4'");
 	}
 	
 	@Test

--- a/src/us/kbase/workspace/test/workspace/ReferenceTest.java
+++ b/src/us/kbase/workspace/test/workspace/ReferenceTest.java
@@ -38,7 +38,7 @@ public class ReferenceTest {
 		failMakeRef("foo/1/2", "ref foo/1/2 is not an absolute reference");
 		failMakeRef("1/foo/2", "ref 1/foo/2 is not an absolute reference");
 		failMakeRef("1/1/foo",
-				"Unable to parse version portion of object reference 1/1/foo to an integer");
+				"Unable to parse version portion of object reference '1/1/foo' to an integer");
 		failMakeRef("1/2/3/4", "Illegal number of separators '/' in object reference '1/2/3/4'");
 	}
 	

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -3207,7 +3207,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		innertuple.set(0, Arrays.asList("foo", "YourMotherWasAHamster"));
 		failSave(user, wsi, objs, new TypedObjectValidationException(
 				"Object #1, foo has unparseable reference YourMotherWasAHamster: Illegal number " +
-				"of separators / in object reference YourMotherWasAHamster at /ws_2/0/1"));
+				"of separators '/' in object reference 'YourMotherWasAHamster' at /ws_2/0/1"));
 		
 		innertuple.set(0, Arrays.asList("foo", ref2));
 		data.remove("ws_any");
@@ -3802,19 +3802,16 @@ public class WorkspaceTest extends WorkspaceTester {
 		// also tests failing on objects with id attributes
 		failSave(u1, testws, fail, makeRefData("readws/4;;2/refref1/1"), type1, p1,
 				new TypedObjectValidationException("Object #1, fail has unparseable reference " +
-						"readws/4;;2/refref1/1: ID parse error in reference string " +
-						"readws/4;;2/refref1/1 at position 2: reference cannot be null or the " +
-						"empty string at /refs/0"));
+						"readws/4;;2/refref1/1: Reference path position 2: Illegal number of " +
+						"separators '/' in object reference '' at /refs/0"));
 		failSave(u1, testws, fail, makeRefData(" ; ; "), type2Ref, p1,
 				new TypedObjectValidationException("Object #1, fail has unparseable reference " +
-						" ; ; : ID parse error in reference string " +
-						" ; ;  at position 1: reference cannot be null or the " +
-						"empty string at /refs/0"));
+						" ; ; : Reference path position 1: Illegal number of " +
+						"separators '/' in object reference ' ' at /refs/0"));
 		failSave(u1, testws, fail, makeRefData("readws/4;1;2/refref1/1"), type12Ref, p1,
 				new TypedObjectValidationException("Object #1, fail has unparseable reference " +
-						"readws/4;1;2/refref1/1: ID parse error in reference string " +
-						"readws/4;1;2/refref1/1 at position 2: Illegal number of separators / " +
-						"in object reference 1 at /refs/0"));
+						"readws/4;1;2/refref1/1: Reference path position 2: Illegal number of " +
+						"separators '/' in object reference '1' at /refs/0"));
 		
 		// test fail save on bad reference type
 		failSave(u1, testws, fail,
@@ -3867,9 +3864,8 @@ public class WorkspaceTest extends WorkspaceTester {
 				.withWorkspaceObjects(Arrays.asList("readws/4;;2/refref1/1")));
 		failSave(u1, testws, fail, mt, type1, pfail,
 				new TypedObjectValidationException("Object #1, fail has unparseable provenance " +
-						"reference readws/4;;2/refref1/1: ID parse error in reference string " +
-						"readws/4;;2/refref1/1 at position 2: reference cannot be null or the " +
-						"empty string"));
+						"reference readws/4;;2/refref1/1: Reference path position 2: " +
+						"Illegal number of separators '/' in object reference ''"));
 		
 		// inaccessible head
 		pfail = new Provenance(u1).addAction(new ProvenanceAction()

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTest.java
@@ -2584,7 +2584,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		data.set(1, new WorkspaceSaveObject(obj3, data4, abstype0, null, emptyprov, false));
 		failSave(userfoo, wspace, data, new TypedObjectValidationException(
 				"Object #2, obj3 has unparseable reference foo/bar/baz: Unable to parse version " +
-				"portion of object reference foo/bar/baz to an integer at /ref"));
+				"portion of object reference 'foo/bar/baz' to an integer at /ref"));
 		
 		Map<String, Object> data5 = new HashMap<String, Object>(data1);
 		data5.put("ref", null);
@@ -2612,7 +2612,7 @@ public class WorkspaceTest extends WorkspaceTester {
 		data.set(1, new WorkspaceSaveObject(obj4, data3, abstype0, null, badids, false));
 		failSave(userfoo, wspace, data, new TypedObjectValidationException(
 				"Object #2, obj4 has unparseable provenance reference foo/bar/baz: Unable to " +
-				"parse version portion of object reference foo/bar/baz to an integer"));
+				"parse version portion of object reference 'foo/bar/baz' to an integer"));
 		
 		badids = new Provenance(userfoo);
 		badids.addAction(new Provenance.ProvenanceAction().withWorkspaceObjects(Arrays.asList((String) null)));


### PR DESCRIPTION
Turns out I'll need a reference path validator for the provenance work.
The first step is to make a single parser rather than having it split
into two chunks. Improves code cohesion as well.

\* mostly, there's still some stuff in IdentifierUtils but it does weird
things around rearranging the ref order that I don't want to touch for
now