### PR TITLE
Print a stacktrace when the server can't start

### DIFF
--- a/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
+++ b/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
@@ -183,6 +183,7 @@ public class InitWorkspaceServer {
 					wsdeps.listeners);
 			ah = getAdminHandler(cfg, ws);
 		} catch (WorkspaceInitException | WorkspaceCommunicationException e) {
+			e.printStackTrace(System.err);
 			rep.reportFail(e.getLocalizedMessage());
 			rep.reportFail("Server startup failed - all calls will error out.");
 			return null;


### PR DESCRIPTION
Slightly hacky but fine in the startup code