### PR TITLE
Add the MongoDB retryWrites param to the config

### DIFF
--- a/deploy.cfg.example
+++ b/deploy.cfg.example
@@ -10,6 +10,11 @@ mongodb-host = localhost
 # Name of the workspace mongo database
 mongodb-database = workspace
 
+# Setting for the MongoDB retryWrites connection parameter.
+# See https://www.mongodb.com/docs/manual/core/retryable-writes/
+# 'true' is true, anything else is false.
+#mongodb-retrywrites = false
+
 # The user name for an account with readWrite access to the database
 #mongodb-user = add username here
 

--- a/deployment/conf/.templates/deployment.cfg.templ
+++ b/deployment/conf/.templates/deployment.cfg.templ
@@ -1,6 +1,7 @@
 [Workspace]
 mongodb-database={{ default .Env.mongodb_database "workspace" }}
 mongodb-type-database={{ default .Env.mongodb_type_database "workspace_type_db" }}
+mongodb-retrywrites={{ default .Env.mongodb_retrywrites "false" }}
 mongodb-pwd={{ default .Env.mongodb_pwd "" }}
 ws-admin={{ default .Env.ws_admin "scanonadmin" }}
 # backend user is wstest globus user in ci

--- a/docsource/buildandconfigure.rst
+++ b/docsource/buildandconfigure.rst
@@ -165,6 +165,15 @@ the same as ``mongodb-database``.
 .. warning:: Once any data has been saved by the workspace, changing the type database will
    result in unspecified behavior, including data corruption.
 
+mongodb-retrywrites
+"""""""""""""""""""
+
+**Required**: No
+
+**Description**: Setting for the
+`MongoDB retryWrites <https://www.mongodb.com/docs/manual/core/retryable-writes/>`_
+connection parameter. ``true`` is true, anything else is false. Defaults to false.
+
 mongodb-user
 """"""""""""
 **Required**: If the MongoDB instance requires authorization

--- a/docsource/releasenotes.rst
+++ b/docsource/releasenotes.rst
@@ -31,6 +31,8 @@ UPDATES:
   would always be inaccessible unless the source workspace was public.
 * Error handling for saving objects has been improved for some cases and provides more
   information about the nature and source of the error.
+* Added the ``mongodb-retrywrites`` configuration setting in ``deploy.cfg``, defaulting to
+  ``false``.
 
 VERSION: 0.12.1 (Released 1/25/2022)
 ------------------------------------

--- a/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
+++ b/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
@@ -346,15 +346,16 @@ public class InitWorkspaceServer {
 	public static MongoClient buildMongo(final KBaseWorkspaceConfig c, final String dbName)
 			throws WorkspaceInitException {
 		//TODO ZLATER MONGO handle shards & replica sets
+		final MongoClientOptions opts = MongoClientOptions.builder()
+				.retryWrites(c.getMongoRetryWrites()).build();
 		try {
 			if (c.getMongoUser() != null) {
 				final MongoCredential creds = MongoCredential.createCredential(
 						c.getMongoUser(), dbName, c.getMongoPassword().toCharArray());
 				// unclear if and when it's safe to clear the password
-				return new MongoClient(new ServerAddress(c.getHost()), creds,
-						MongoClientOptions.builder().retryWrites(c.getMongoRetryWrites()).build());
+				return new MongoClient(new ServerAddress(c.getHost()), creds, opts);
 			} else {
-				return new MongoClient(new ServerAddress(c.getHost()));
+				return new MongoClient(new ServerAddress(c.getHost()), opts);
 			}
 		} catch (MongoException e) {
 			LoggerFactory.getLogger(InitWorkspaceServer.class).error(

--- a/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
+++ b/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
@@ -352,7 +352,7 @@ public class InitWorkspaceServer {
 						c.getMongoUser(), dbName, c.getMongoPassword().toCharArray());
 				// unclear if and when it's safe to clear the password
 				return new MongoClient(new ServerAddress(c.getHost()), creds,
-						MongoClientOptions.builder().build());
+						MongoClientOptions.builder().retryWrites(c.getMongoRetryWrites()).build());
 			} else {
 				return new MongoClient(new ServerAddress(c.getHost()));
 			}

--- a/src/us/kbase/workspace/kbase/KBaseWorkspaceConfig.java
+++ b/src/us/kbase/workspace/kbase/KBaseWorkspaceConfig.java
@@ -43,12 +43,17 @@ public class KBaseWorkspaceConfig {
 	//TODO CODE use optionals instead of nulls.
 	//TODO CODE consider returning classes containing related parameters rather than individual parameters.
 	
-	//required deploy parameters
+	// mongodb parameters
 	private static final String HOST = "mongodb-host";
 	private static final String DB = "mongodb-database";
 	private static final String TYPE_DB = "mongodb-type-database";
-	//startup workspace admin user
+	private static final String MONGO_USER = "mongodb-user";
+	private static final String MONGO_PWD = "mongodb-pwd";
+	private static final String MONGO_RETRY_WRITES = "mongodb-retrywrites";
+	
+	// startup workspace admin user
 	private static final String WSADMIN = "ws-admin";
+
 	// backend params
 	private static final String BACKEND_TYPE = "backend-type";
 	private static final String BACKEND_USER = "backend-user";
@@ -57,9 +62,6 @@ public class KBaseWorkspaceConfig {
 	private static final String BACKEND_REGION = "backend-region";
 	private static final String BACKEND_CONTAINER = "backend-container";
 	private static final String BACKEND_SSC_SSL = "backend-trust-all-ssl-certificates";
-	//mongo db auth params:
-	private static final String MONGO_USER = "mongodb-user";
-	private static final String MONGO_PWD = "mongodb-pwd";
 	
 	//auth servers
 	private static final String KBASE_AUTH_URL = "auth-service-url";
@@ -110,6 +112,7 @@ public class KBaseWorkspaceConfig {
 	private final String host;
 	private final String db;
 	private final String typedb;
+	private final boolean mongoRetryWrites;
 	private final BackendType backendType;
 	private final Region backendRegion;
 	private final String backendContainer;
@@ -269,6 +272,7 @@ public class KBaseWorkspaceConfig {
 		host = nullIfEmpty(config.get(HOST));
 		db = nullIfEmpty(config.get(DB));
 		typedb = nullIfEmpty(config.get(TYPE_DB));
+		mongoRetryWrites = TRUE_STR.equals(nullIfEmpty(config.get(MONGO_RETRY_WRITES)));
 		if (db != null && db.equals(typedb)) {
 			paramErrors.add(String.format("The parameters %s and %s have the same value, %s",
 					DB, TYPE_DB, db));
@@ -457,7 +461,8 @@ public class KBaseWorkspaceConfig {
 		String params = "";
 		// TODO CODE move this up top where it's easier to see & alter, document
 		final List<String> paramSet = new LinkedList<String>(
-				Arrays.asList(HOST, DB, TYPE_DB, MONGO_USER, KBASE_AUTH_URL, KBASE_AUTH2_URL,
+				Arrays.asList(HOST, DB, TYPE_DB, MONGO_RETRY_WRITES, MONGO_USER,
+						KBASE_AUTH_URL, KBASE_AUTH2_URL,
 						KBASE_AUTH_ADMIN_READ_ONLY_ROLES, KBASE_AUTH_ADMIN_FULL_ROLES,
 						BACKEND_TYPE, BACKEND_URL, BACKEND_USER, BACKEND_REGION,
 						BACKEND_CONTAINER, BACKEND_SSC_SSL));
@@ -530,6 +535,10 @@ public class KBaseWorkspaceConfig {
 	
 	public String getTypeDBName() {
 		return typedb;
+	}
+	
+	public boolean getMongoRetryWrites() {
+		return mongoRetryWrites;
 	}
 
 	public URL getAuthURL() {
@@ -672,6 +681,7 @@ public class KBaseWorkspaceConfig {
 		result = prime * result + ((infoMessages == null) ? 0 : infoMessages.hashCode());
 		result = prime * result + ((listenerConfigs == null) ? 0 : listenerConfigs.hashCode());
 		result = prime * result + ((mongoPassword == null) ? 0 : mongoPassword.hashCode());
+		result = prime * result + (mongoRetryWrites ? 1231 : 1237);
 		result = prime * result + ((mongoUser == null) ? 0 : mongoUser.hashCode());
 		result = prime * result + ((paramReport == null) ? 0 : paramReport.hashCode());
 		result = prime * result + ((sampleServiceToken == null) ? 0 : sampleServiceToken.hashCode());
@@ -798,6 +808,8 @@ public class KBaseWorkspaceConfig {
 			if (other.mongoPassword != null)
 				return false;
 		} else if (!mongoPassword.equals(other.mongoPassword))
+			return false;
+		if (mongoRetryWrites != other.mongoRetryWrites)
 			return false;
 		if (mongoUser == null) {
 			if (other.mongoUser != null)

--- a/src/us/kbase/workspace/test/kbase/KBaseWorkspaceConfigTest.java
+++ b/src/us/kbase/workspace/test/kbase/KBaseWorkspaceConfigTest.java
@@ -177,6 +177,7 @@ public class KBaseWorkspaceConfigTest {
 		public String typeDBname = null;
 		public String mongoPwd = null;
 		public String mongoUser = null;
+		public boolean mongoRetryWrites = false;
 		public List<ListenerConfig> listenerConfigs = Collections.emptyList();
 		public BackendType backendType = null;
 		public URL backendURL = null;
@@ -298,6 +299,11 @@ public class KBaseWorkspaceConfigTest {
 			this.mongoUser = mongoUser;
 			return this;
 		}
+		
+		public ExpectedConfig withMongoRetryWrites(final boolean retrywrites) {
+			this.mongoRetryWrites = retrywrites;
+			return this;
+		}
 
 		public ExpectedConfig withParamReport(final String paramReport) {
 			this.paramReport = paramReport;
@@ -387,6 +393,8 @@ public class KBaseWorkspaceConfigTest {
 			assertThat("incorrect listeners", kwc.getListenerConfigs(), is(exp.listenerConfigs));
 			assertThat("incorrect mongo pwd", kwc.getMongoPassword(), is(exp.mongoPwd));
 			assertThat("incorrect mongo user", kwc.getMongoUser(), is(exp.mongoUser));
+			assertThat("incorrect mongo retrywrites",
+					kwc.getMongoRetryWrites(), is(exp.mongoRetryWrites));
 			assertThat("incorrect param report", kwc.getParamReport(), is(exp.paramReport));
 			assertThat("incorrect bytestream token",
 					kwc.getBytestreamToken(), is(exp.bytestreamToken));
@@ -465,6 +473,7 @@ public class KBaseWorkspaceConfigTest {
 				.with("mongodb-host", "    somehost    ")
 				.with("mongodb-database", "    somedb   ")
 				.with("mongodb-type-database", "     typedb     ")
+				.with("mongodb-retrywrites", "     true     ")
 				.with("temp-dir", "   temp   ")
 				.with("auth-service-url", "    " + AUTH_LEGACY_URL + "    ")
 				.with("auth2-service-url", "   " + CI_SERV + "auth     ")
@@ -501,6 +510,7 @@ public class KBaseWorkspaceConfigTest {
 				"mongodb-host=somehost\n" +
 				"mongodb-database=somedb\n" +
 				"mongodb-type-database=typedb\n" +
+				"mongodb-retrywrites=true\n" +
 				"mongodb-user=muser\n" +
 				"auth-service-url=" + AUTH_LEGACY_URL + "\n" +
 				"auth2-service-url=" + CI_SERV + "auth\n" +
@@ -530,6 +540,7 @@ public class KBaseWorkspaceConfigTest {
 						.withMongohost("somehost")
 						.withMongoDBname("somedb")
 						.withTypeDBname("typedb")
+						.withMongoRetryWrites(true)
 						.withMongoUser("muser")
 						.withMongoPwd("mpwd")
 						.withListenerConfigs(Arrays.asList(
@@ -562,6 +573,7 @@ public class KBaseWorkspaceConfigTest {
 				.with("mongodb-host", "somehost")
 				.with("mongodb-database", "somedb")
 				.with("mongodb-type-database", "     typedb     ")
+				.with("mongodb-retrywrites", "     \t     ")
 				.with("temp-dir", "temp")
 				.with("auth-service-url", AUTH_LEGACY_URL)
 				.with("auth2-service-url", CI_SERV + "auth")


### PR DESCRIPTION
The update of the MongoDB driver from v3.8 to v3.12 has a change where
the retryWrites parameter default is now true. This causes the workspace
service to fail to start in KBase CI. Locally and in Travis CI
everything is fine, so to truly test the fix we'll need to start the
service in KBase CI.