### PR TITLE
PTV-1786: Separate the admin commands from the admin framework

### DIFF
--- a/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
+++ b/src/us/kbase/workspace/kbase/InitWorkspaceServer.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -56,11 +57,14 @@ import us.kbase.workspace.database.mongo.S3ClientWithPresign;
 import us.kbase.workspace.database.mongo.exceptions.BlobStoreCommunicationException;
 import us.kbase.workspace.kbase.KBaseWorkspaceConfig.ListenerConfig;
 import us.kbase.workspace.kbase.BytestreamIdHandlerFactory.BytestreamClientCloner;
+import us.kbase.workspace.kbase.admin.AdministrationCommandSetBuilder;
 import us.kbase.workspace.kbase.admin.AdministratorHandler;
 import us.kbase.workspace.kbase.admin.AdministratorHandlerException;
 import us.kbase.workspace.kbase.admin.DefaultAdminHandler;
 import us.kbase.workspace.kbase.admin.KBaseAuth2AdminHandler;
 import us.kbase.workspace.kbase.admin.WorkspaceAdministration;
+import us.kbase.workspace.kbase.admin.WorkspaceAdministration.AdminCommandSpecification;
+import us.kbase.workspace.kbase.admin.WorkspaceAdministration.UserValidator;
 import us.kbase.workspace.listener.ListenerInitializationException;
 import us.kbase.workspace.listener.WorkspaceEventListener;
 import us.kbase.workspace.listener.WorkspaceEventListenerFactory;
@@ -197,8 +201,12 @@ public class InitWorkspaceServer {
 				.withFactory(wsdeps.sampleFac)
 				.build();
 		WorkspaceServerMethods wsmeth = new WorkspaceServerMethods(ws, types, builder, auth);
-		WorkspaceAdministration wsadmin = new WorkspaceAdministration(
-				wsmeth, types, ah, ADMIN_CACHE_MAX_SIZE, ADMIN_CACHE_EXP_TIME_MS);
+		final Map<String, AdminCommandSpecification> handlers = AdministrationCommandSetBuilder
+				.build(wsmeth, types);
+		final UserValidator userVal = (user, token) -> AdministrationCommandSetBuilder
+				.getUser(wsmeth, user, token);
+		final WorkspaceAdministration wsadmin = new WorkspaceAdministration(
+				ah, handlers, userVal, ADMIN_CACHE_MAX_SIZE, ADMIN_CACHE_EXP_TIME_MS);
 		final String mem = String.format(
 				"Started workspace server instance %s. Free mem: %s Total mem: %s, Max mem: %s",
 				++instanceCount, Runtime.getRuntime().freeMemory(),

--- a/src/us/kbase/workspace/kbase/admin/AdministrationCommandSetBuilder.java
+++ b/src/us/kbase/workspace/kbase/admin/AdministrationCommandSetBuilder.java
@@ -1,0 +1,486 @@
+package us.kbase.workspace.kbase.admin;
+
+import static us.kbase.workspace.kbase.ArgUtils.wsInfoToTuple;
+import static us.kbase.workspace.kbase.IdentifierUtils.processWorkspaceIdentifier;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.auth.AuthException;
+import us.kbase.auth.AuthToken;
+import us.kbase.common.service.JacksonTupleModule;
+import us.kbase.common.service.Tuple9;
+import us.kbase.common.service.UObject;
+import us.kbase.workspace.CreateWorkspaceParams;
+import us.kbase.workspace.GetObjectInfo3Params;
+import us.kbase.workspace.GetObjects2Params;
+import us.kbase.workspace.GetPermissionsMassParams;
+import us.kbase.workspace.GrantModuleOwnershipParams;
+import us.kbase.workspace.ListObjectsParams;
+import us.kbase.workspace.ListWorkspaceIDsParams;
+import us.kbase.workspace.ListWorkspaceInfoParams;
+import us.kbase.workspace.ObjectIdentity;
+import us.kbase.workspace.RemoveModuleOwnershipParams;
+import us.kbase.workspace.SaveObjectsParams;
+import us.kbase.workspace.SetGlobalPermissionsParams;
+import us.kbase.workspace.SetPermissionsParams;
+import us.kbase.workspace.SetWorkspaceDescriptionParams;
+import us.kbase.workspace.WorkspaceIdentity;
+import us.kbase.workspace.WorkspacePermissions;
+import us.kbase.workspace.database.Types;
+import us.kbase.workspace.database.WorkspaceIdentifier;
+import us.kbase.workspace.database.WorkspaceInformation;
+import us.kbase.workspace.database.WorkspaceUser;
+import us.kbase.workspace.database.DynamicConfig.DynamicConfigUpdate;
+import us.kbase.workspace.kbase.WorkspaceServerMethods;
+import us.kbase.workspace.kbase.admin.WorkspaceAdministration.AdminCommandSpecification;
+
+/** Builds the standard set of administration command handlers. */
+public class AdministrationCommandSetBuilder {
+	
+	private static final String GET_CONFIG = "getConfig";
+	private static final String SET_CONFIG = "setConfig";
+	
+	private static final String DENY_MOD_REQUEST = "denyModRequest";
+	private static final String APPROVE_MOD_REQUEST = "approveModRequest";
+	private static final String LIST_MOD_REQUESTS = "listModRequests";
+
+	private static final String SET_WORKSPACE_OWNER = "setWorkspaceOwner";
+	private static final String LIST_WORKSPACE_OWNERS = "listWorkspaceOwners";
+
+	private static final String REMOVE_MODULE_OWNERSHIP = "removeModuleOwnership";
+	private static final String GRANT_MODULE_OWNERSHIP = "grantModuleOwnership";
+	private static final String LIST_WORKSPACES = "listWorkspaces";
+	private static final String LIST_WORKSPACE_IDS = "listWorkspaceIDs";
+	private static final String GET_WORKSPACE_DESCRIPTION = "getWorkspaceDescription";
+	private static final String SET_WORKSPACE_DESCRIPTION = "setWorkspaceDescription";
+	private static final String LIST_OBJECTS = "listObjects";
+	private static final String SAVE_OBJECTS = "saveObjects";
+	private static final String GET_OBJECT_INFO = "getObjectInfo";
+	private static final String GET_OBJECT_HIST = "getObjectHistory";
+	private static final String GET_OBJECTS = "getObjects";
+	private static final String SET_GLOBAL_PERMISSION = "setGlobalPermission";
+	private static final String GET_WORKSPACE_INFO = "getWorkspaceInfo";
+	private static final String GET_PERMISSIONS = "getPermissions";
+	private static final String GET_PERMISSIONS_MASS = "getPermissionsMass";
+	private static final String SET_PERMISSIONS = "setPermissions";
+	private static final String CREATE_WORKSPACE = "createWorkspace";
+	private static final String DELETE_WS = "deleteWorkspace";
+	private static final String UNDELETE_WS = "undeleteWorkspace";
+
+	private final static ObjectMapper MAPPER = new ObjectMapper()
+			.registerModule(new JacksonTupleModule());
+	
+	private AdministrationCommandSetBuilder() {};
+	
+	/** Build the handlers.
+	 * @param wsmeth a workspace server methods instance.
+	 * @param types a types instance.
+	 * @return the handlers.
+	 */
+	public static Map<String, AdminCommandSpecification> build(
+			// TODO CODE some of the code here calls the underlying workspace instance.
+			// probably better to not do that and just call the service translation layer when
+			// possible.
+			final WorkspaceServerMethods wsmeth,
+			final Types types) {
+		
+		final Map<String, AdminCommandSpecification> handlers = new HashMap<>();
+		installTypeHandlers(types, wsmeth, handlers); // TODO CODE wsmeth should not be in there
+		installDynamicConfigHandlers(wsmeth, handlers);
+		installPermissionHandlers(wsmeth, handlers);
+		installWorkspaceHandlers(wsmeth, handlers);
+		installListWorkspaceHandlers(wsmeth, handlers);
+		installDeleteWorkspaceHandlers(wsmeth, handlers);
+		installObjectHandlers(wsmeth, handlers);
+		return handlers;
+	}
+	
+	private static void installTypeHandlers(
+			final Types types,
+			final WorkspaceServerMethods wsmeth,
+			final Map<String, AdminCommandSpecification> handlers) {
+		handlers.put(LIST_MOD_REQUESTS, new AdminCommandSpecification(
+			LIST_MOD_REQUESTS,
+			(cmd, token, toDelete) -> {
+				getLogger().info(LIST_MOD_REQUESTS);
+				return types.listModuleRegistrationRequests();
+			}));
+		handlers.put(APPROVE_MOD_REQUEST,new AdminCommandSpecification(
+			APPROVE_MOD_REQUEST,
+			(cmd, token, toDelete) -> {
+				final String mod = cmd.getModule();
+				getLogger().info(APPROVE_MOD_REQUEST + " " + mod);
+				types.resolveModuleRegistration(mod, true);
+				return null;
+			},
+			true));
+		handlers.put(DENY_MOD_REQUEST, new AdminCommandSpecification(
+			DENY_MOD_REQUEST,
+			(cmd, token, toDelete) -> {
+				final String mod = cmd.getModule();
+				getLogger().info(DENY_MOD_REQUEST + " " + mod);
+				types.resolveModuleRegistration(mod, false);
+				return null;
+			},
+			true));
+		handlers.put(GRANT_MODULE_OWNERSHIP, new AdminCommandSpecification(
+			GRANT_MODULE_OWNERSHIP,
+			(cmd, token, toDelete) -> {
+				final GrantModuleOwnershipParams params = getParams(cmd,
+						GrantModuleOwnershipParams.class);
+				getLogger().info(GRANT_MODULE_OWNERSHIP + " " + params.getMod() +
+						" " + params.getNewOwner());
+				wsmeth.grantModuleOwnership(params, null, true);
+				return null;
+			},
+			true));
+		handlers.put(REMOVE_MODULE_OWNERSHIP, new AdminCommandSpecification(
+			REMOVE_MODULE_OWNERSHIP,
+			(cmd, token, toDelete) -> {
+				final RemoveModuleOwnershipParams params = getParams(cmd,
+						RemoveModuleOwnershipParams.class);
+				getLogger().info(REMOVE_MODULE_OWNERSHIP + " " + params.getMod() +
+						" " + params.getOldOwner());
+				wsmeth.removeModuleOwnership(params, null, true);
+				return null;
+			},
+			true));
+	}
+	
+	private static void installDynamicConfigHandlers(
+			final WorkspaceServerMethods wsmeth,
+			final Map<String, AdminCommandSpecification> handlers) {
+		handlers.put(GET_CONFIG, new AdminCommandSpecification(
+			GET_CONFIG,
+			(cmd, token, toDelete) -> {
+				getLogger().info(GET_CONFIG);
+				return ImmutableMap.of("config", wsmeth.getWorkspace().getConfig().toMap());
+			}));
+		handlers.put(SET_CONFIG, new AdminCommandSpecification(
+			SET_CONFIG,
+			(cmd, token, toDelete) -> {
+				getLogger().info(SET_CONFIG); // add parameters?
+				final SetConfigParams params = getParams(cmd, SetConfigParams.class);
+				wsmeth.getWorkspace().setConfig(DynamicConfigUpdate.getBuilder()
+						.withMap(params.set).build());
+				return null;
+			},
+			true));
+	}
+
+	private static void installPermissionHandlers(
+			final WorkspaceServerMethods wsmeth,
+			final Map<String, AdminCommandSpecification> handlers) {
+		handlers.put(SET_PERMISSIONS, new AdminCommandSpecification(
+			SET_PERMISSIONS,
+			(cmd, token, toDelete) -> {
+				final SetPermissionsParams params = getParams(cmd, SetPermissionsParams.class);
+				final long id = wsmeth.setPermissionsAsAdmin(params, token);
+				getLogger().info(SET_PERMISSIONS + " " + id + " " + params.getNewPermission() +
+						" " + StringUtils.join(params.getUsers(), " "));
+				return null;
+			},
+			true));
+		handlers.put(SET_GLOBAL_PERMISSION, new AdminCommandSpecification(
+			SET_GLOBAL_PERMISSION,
+			(cmd, token, toDelete) -> {
+				final WorkspaceUser user = getUser(wsmeth, cmd, token);
+				final SetGlobalPermissionsParams params = getParams(cmd,
+						SetGlobalPermissionsParams.class);
+				final long id = wsmeth.setGlobalPermission(params, user);
+				getLogger().info(SET_GLOBAL_PERMISSION + " " + id + " " +
+						params.getNewPermission() + " " + user.getUser());
+				return null;
+			},
+			true));
+		handlers.put(GET_PERMISSIONS, new AdminCommandSpecification(
+			GET_PERMISSIONS,
+			(cmd, token, toDelete) -> {
+				final WorkspaceIdentity params = getParams(cmd, WorkspaceIdentity.class);
+				final WorkspaceUser user = getNullableUser(wsmeth, cmd, token);
+				final Map<String, String> perms;
+				if (user == null) {
+					perms = wsmeth.getPermissions(Arrays.asList(params), null, true)
+							.getPerms().get(0);
+				} else {
+					perms = wsmeth.getPermissions(params, user);
+				}
+				//TODO FEATURE would be better if could always provide ID vs. name
+				getLogger().info(GET_PERMISSIONS + " " + params.getId() + " " +
+						params.getWorkspace() + (user == null ? "" : " " + user.getUser()));
+				return perms;
+			}));
+		handlers.put(GET_PERMISSIONS_MASS, new AdminCommandSpecification(
+			GET_PERMISSIONS_MASS,
+			(cmd, token, toDelete) -> {
+				final GetPermissionsMassParams params = getParams(
+						cmd, GetPermissionsMassParams.class);
+				final WorkspacePermissions perms = wsmeth.getPermissions(
+						params.getWorkspaces(), null, true);
+				// not sure what to log here, could be 1K entries.
+				getLogger().info(GET_PERMISSIONS_MASS + " " + params.getWorkspaces().size() +
+						" workspaces in input");
+				return perms;
+			}));
+	}
+	
+	private static void installWorkspaceHandlers(
+			final WorkspaceServerMethods wsmeth,
+			final Map<String, AdminCommandSpecification> handlers) {
+		handlers.put(CREATE_WORKSPACE, new AdminCommandSpecification(
+			CREATE_WORKSPACE,
+			(cmd, token, toDelete) -> {
+				final WorkspaceUser user = getUser(wsmeth, cmd, token);
+				final CreateWorkspaceParams params = getParams(cmd, CreateWorkspaceParams.class);
+				final Tuple9<Long, String, String, String, Long, String, String, String,
+				Map<String, String>> ws =  wsmeth.createWorkspace(params, user);
+				getLogger().info(CREATE_WORKSPACE + " " + ws.getE1() + " " + ws.getE3());
+				return ws;
+			},
+			true));
+		handlers.put(SET_WORKSPACE_OWNER, new AdminCommandSpecification(
+			SET_WORKSPACE_OWNER,
+			(cmd, token, toDelete) -> {
+				final SetWorkspaceOwnerParams params = getParams(
+						cmd, SetWorkspaceOwnerParams.class);
+				final WorkspaceIdentifier wsi = processWorkspaceIdentifier(params.wsi);
+				final WorkspaceInformation info = wsmeth.getWorkspace().setWorkspaceOwner(
+						null,
+						wsi,
+						params.new_user == null ? null : getUser(wsmeth, params.new_user, token),
+						Optional.ofNullable(params.new_name), true);
+				getLogger().info(SET_WORKSPACE_OWNER + " " + info.getId() + " " +
+						info.getOwner().getUser());
+				return wsInfoToTuple(info);
+			}, 
+			true));
+		handlers.put(SET_WORKSPACE_DESCRIPTION, new AdminCommandSpecification(
+			SET_WORKSPACE_DESCRIPTION,
+			(cmd, token, toDelete) -> {
+				final SetWorkspaceDescriptionParams params = getParams(
+						cmd, SetWorkspaceDescriptionParams.class);
+				final WorkspaceIdentifier wsi = processWorkspaceIdentifier(
+						params.getWorkspace(), params.getId());
+				final long id = wsmeth.getWorkspace().setWorkspaceDescription(
+						null, wsi, params.getDescription(), true);
+				getLogger().info(SET_WORKSPACE_DESCRIPTION + " " + id);
+				return null;
+			},
+			true));
+		handlers.put(GET_WORKSPACE_DESCRIPTION, new AdminCommandSpecification(
+			GET_WORKSPACE_DESCRIPTION,
+			(cmd, token, toDelete) -> {
+				final WorkspaceIdentity wsi = getParams(cmd, WorkspaceIdentity.class);
+				final WorkspaceIdentifier wsid = processWorkspaceIdentifier(wsi);
+				final String desc = wsmeth.getWorkspace()
+						.getWorkspaceDescription(null, wsid, true);
+				// TODO FEATURE would be better if could always provide ID vs. name
+				getLogger().info(GET_WORKSPACE_DESCRIPTION + " " + wsi.getId() + " " +
+						wsi.getWorkspace());
+				return desc;
+			}));
+		handlers.put(GET_WORKSPACE_INFO, new AdminCommandSpecification(
+			GET_WORKSPACE_INFO,
+			(cmd, token, toDelete) -> {
+				final WorkspaceIdentity params = getParams(cmd, WorkspaceIdentity.class);
+				final WorkspaceIdentifier wsi = processWorkspaceIdentifier(
+								params.getWorkspace(), params.getId());
+				final WorkspaceInformation info = wsmeth.getWorkspace().
+						getWorkspaceInformationAsAdmin(wsi);
+				getLogger().info(GET_WORKSPACE_INFO + " " + info.getId());
+				return wsInfoToTuple(info);
+			}));
+	}
+
+	private static void installObjectHandlers(
+			final WorkspaceServerMethods wsmeth,
+			final Map<String, AdminCommandSpecification> handlers) {
+		handlers.put(SAVE_OBJECTS,new AdminCommandSpecification(
+			SAVE_OBJECTS,
+			(cmd, token, toDelete) -> {
+				final WorkspaceUser user = getUser(wsmeth, cmd, token);
+				final SaveObjectsParams params = getParams(cmd, SaveObjectsParams.class);
+				//method has its own logging
+				getLogger().info(SAVE_OBJECTS + " " + user.getUser());
+				return wsmeth.saveObjects(params, user, token);
+			},
+			true));
+		// TODO CODE for the next 3 methods, is passing the admin user really necessary?
+		// Check at some point, maybe remove
+		handlers.put(GET_OBJECT_INFO, new AdminCommandSpecification(
+			GET_OBJECT_INFO,
+			(cmd, token, toDelete) -> {
+				final GetObjectInfo3Params params = getParams(cmd, GetObjectInfo3Params.class);
+				getLogger().info(GET_OBJECT_INFO); // method has its own logging
+				return wsmeth.getObjectInformation(
+						params, new WorkspaceUser(token.getUserName()), true);
+			}));
+		handlers.put(GET_OBJECT_HIST, new AdminCommandSpecification(
+			GET_OBJECT_HIST,
+			(cmd, token, toDelete) -> {
+				final ObjectIdentity params = getParams(cmd, ObjectIdentity.class);
+				getLogger().info(GET_OBJECT_HIST); // method has its own logging
+				return wsmeth.getObjectHistory(
+						params, new WorkspaceUser(token.getUserName()), true);
+			}));
+		handlers.put(GET_OBJECTS, new AdminCommandSpecification(
+			GET_OBJECTS,
+			(cmd, token, resourcesToDelete) -> {
+				final GetObjects2Params params = getParams(cmd, GetObjects2Params.class);
+				getLogger().info(GET_OBJECTS); // method has its own logging
+				return wsmeth.getObjects(params, new WorkspaceUser(token.getUserName()), true,
+						resourcesToDelete);
+			}));
+		handlers.put(LIST_OBJECTS, new AdminCommandSpecification(
+			LIST_OBJECTS,
+			(cmd, token, resourcesToDelete) -> {
+				final ListObjectsParams params = getParams(cmd, ListObjectsParams.class);
+				final WorkspaceUser user = getNullableUser(wsmeth, cmd, token);
+				final String ustr = user == null ? "adminuser" : "user: " + user.getUser();
+				getLogger().info(LIST_OBJECTS + " " + ustr);
+				return wsmeth.listObjects(params, user, user == null);
+			}));
+	}
+	
+	private static void installListWorkspaceHandlers(
+			final WorkspaceServerMethods wsmeth,
+			final Map<String, AdminCommandSpecification> handlers) {
+		handlers.put(LIST_WORKSPACES, new AdminCommandSpecification(
+			LIST_WORKSPACES,
+			(cmd, token, resourcesToDelete) -> {
+				final WorkspaceUser user = getUser(wsmeth, cmd, token);
+				final ListWorkspaceInfoParams params = getParams(
+						cmd, ListWorkspaceInfoParams.class);
+				getLogger().info(LIST_WORKSPACES + " " + user.getUser());
+				return wsmeth.listWorkspaceInfo(params, user);
+			}));
+		handlers.put(LIST_WORKSPACE_IDS, new AdminCommandSpecification(
+			LIST_WORKSPACE_IDS,
+			(cmd, token, resourcesToDelete) -> {
+				final WorkspaceUser user = getUser(wsmeth, cmd, token);
+				final ListWorkspaceIDsParams params = getParams(cmd, ListWorkspaceIDsParams.class);
+				getLogger().info(LIST_WORKSPACE_IDS + " " + user.getUser());
+				return wsmeth.listWorkspaceIDs(params, user);
+			}));
+		handlers.put(LIST_WORKSPACE_OWNERS, new AdminCommandSpecification(
+			LIST_WORKSPACE_OWNERS,
+			(cmd, token, resourcesToDelete) -> {
+				getLogger().info(LIST_WORKSPACE_OWNERS);
+				return wsmeth.getWorkspace().getAllWorkspaceOwners().stream().map(u -> u.getUser())
+						.collect(Collectors.toList());
+			}));
+	}
+
+	private static void installDeleteWorkspaceHandlers(
+			final WorkspaceServerMethods wsmeth,
+			final Map<String, AdminCommandSpecification> handlers) {
+		handlers.put(DELETE_WS, new AdminCommandSpecification(
+			DELETE_WS,
+			(cmd, token, toDelete) -> {
+				final WorkspaceIdentity params = getParams(cmd, WorkspaceIdentity.class);
+				final WorkspaceIdentifier wksp = processWorkspaceIdentifier(params);
+				final long id = wsmeth.getWorkspace().setWorkspaceDeleted(null, wksp, true, true);
+				getLogger().info(DELETE_WS + " " + id);
+				return null;
+			},
+			true));
+		handlers.put(UNDELETE_WS, new AdminCommandSpecification(
+			UNDELETE_WS,
+			(cmd, token, toDelete) -> {
+				final WorkspaceIdentity params = getParams(cmd, WorkspaceIdentity.class);
+				final WorkspaceIdentifier wksp = processWorkspaceIdentifier(params);
+				final long id = wsmeth.getWorkspace().setWorkspaceDeleted(null, wksp, false, true);
+				getLogger().info(UNDELETE_WS + " " + id);
+				return null;
+			},
+			true));
+	}
+	
+	private static class SetConfigParams {
+		public Map<String, Object> set;
+		
+		@SuppressWarnings("unused")
+		public SetConfigParams() {}; // for jackson
+	}
+	
+	private static class SetWorkspaceOwnerParams {
+		public WorkspaceIdentity wsi;
+		public String new_user;
+		public String new_name;
+		
+		@SuppressWarnings("unused")
+		public SetWorkspaceOwnerParams() {}; //for jackson
+	}
+	
+	private static <T> T getParams(final AdminCommand input, final Class<T> clazz)
+			throws IOException {
+		final UObject p = input.getParams();
+		if (p == null) {
+			throw new NullPointerException("Method parameters " +
+					clazz.getSimpleName() + " may not be null");
+		}
+		try {
+			return MAPPER.readValue(p.getPlacedStream(), clazz);
+		} catch (JsonMappingException e) { // parse exception can't happen here
+			throw new IllegalArgumentException("Unable to deserialize "
+					+ clazz.getSimpleName() + " out of params field: " + e.getMessage(), e);
+		}
+	}
+	
+	private static Logger getLogger() {
+		return LoggerFactory.getLogger(AdministrationCommandSetBuilder.class);
+	}
+	
+	private static WorkspaceUser getUser(
+			final WorkspaceServerMethods wsmeth,
+			final AdminCommand cmd,
+			final AuthToken token)
+			throws IOException, AuthException {
+		return getUser(wsmeth, cmd.getUser(), token);
+	}
+
+	/** Validate and get a user.
+	 * @param wsmeth a workspace server methods instance.
+	 * @param user the KBase user name.
+	 * @param token a valid KBase token, which need not be for the user to be validated.
+	 * @return the user name.
+	 * @throws IOException if an IOException occurs.
+	 * @throws AuthException if an error occurs validating the user.
+	 */
+	public static WorkspaceUser getUser(
+			final WorkspaceServerMethods wsmeth,
+			final String user,
+			final AuthToken token)
+			throws IOException, AuthException {
+		if (user == null) {
+			throw new NullPointerException("User may not be null");
+		}
+		// TODO NOW what happens if we don't do the null check? Can we move it into validateUsers?
+		return wsmeth.validateUsers(Arrays.asList(user), token).get(0);
+	}
+	
+	private static WorkspaceUser getNullableUser(
+			final WorkspaceServerMethods wsmeth,
+			final AdminCommand cmd,
+			final AuthToken token)
+			throws IOException, AuthException {
+		if (cmd.getUser() == null) {
+			return null;
+		}
+		return wsmeth.validateUsers(Arrays.asList(cmd.getUser()), token).get(0);
+	}
+	
+}

--- a/src/us/kbase/workspace/kbase/admin/WorkspaceAdministration.java
+++ b/src/us/kbase/workspace/kbase/admin/WorkspaceAdministration.java
@@ -1,59 +1,30 @@
 package us.kbase.workspace.kbase.admin;
 
-import static us.kbase.workspace.kbase.ArgUtils.wsInfoToTuple;
-import static us.kbase.workspace.kbase.IdentifierUtils.processWorkspaceIdentifier;
+import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Ticker;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.ImmutableMap;
 
 import us.kbase.auth.AuthException;
 import us.kbase.auth.AuthToken;
-import us.kbase.common.service.JacksonTupleModule;
-import us.kbase.common.service.Tuple9;
 import us.kbase.common.service.UObject;
-import us.kbase.workspace.CreateWorkspaceParams;
-import us.kbase.workspace.GetObjectInfo3Params;
-import us.kbase.workspace.GetObjects2Params;
-import us.kbase.workspace.GetPermissionsMassParams;
-import us.kbase.workspace.GrantModuleOwnershipParams;
-import us.kbase.workspace.ListObjectsParams;
-import us.kbase.workspace.ListWorkspaceIDsParams;
-import us.kbase.workspace.ListWorkspaceInfoParams;
-import us.kbase.workspace.ObjectIdentity;
-import us.kbase.workspace.RemoveModuleOwnershipParams;
-import us.kbase.workspace.SaveObjectsParams;
-import us.kbase.workspace.SetGlobalPermissionsParams;
-import us.kbase.workspace.SetPermissionsParams;
-import us.kbase.workspace.SetWorkspaceDescriptionParams;
-import us.kbase.workspace.WorkspaceIdentity;
-import us.kbase.workspace.WorkspacePermissions;
-import us.kbase.workspace.database.DynamicConfig.DynamicConfigUpdate;
-import us.kbase.workspace.database.Types;
-import us.kbase.workspace.database.WorkspaceIdentifier;
-import us.kbase.workspace.database.WorkspaceInformation;
 import us.kbase.workspace.database.WorkspaceObjectData;
 import us.kbase.workspace.database.WorkspaceUser;
-import us.kbase.workspace.kbase.WorkspaceServerMethods;
 
 /** A workspace administration mediator. Administration calls should be routed to this class,
  * which checks that the user is authorized, transforms the input parameters, and calls
@@ -66,92 +37,190 @@ import us.kbase.workspace.kbase.WorkspaceServerMethods;
  */
 public class WorkspaceAdministration {
 	
-	private static final String GET_CONFIG = "getConfig";
-	private static final String SET_CONFIG = "setConfig";
-	
-	private static final String DENY_MOD_REQUEST = "denyModRequest";
-	private static final String APPROVE_MOD_REQUEST = "approveModRequest";
-	private static final String LIST_MOD_REQUESTS = "listModRequests";
-
 	private static final String REMOVE_ADMIN = "removeAdmin";
 	private static final String ADD_ADMIN = "addAdmin";
 	private static final String LIST_ADMINS = "listAdmins";
-
-	private static final String SET_WORKSPACE_OWNER = "setWorkspaceOwner";
-	private static final String LIST_WORKSPACE_OWNERS = "listWorkspaceOwners";
-
-	private static final String REMOVE_MODULE_OWNERSHIP = "removeModuleOwnership";
-	private static final String GRANT_MODULE_OWNERSHIP = "grantModuleOwnership";
-	private static final String LIST_WORKSPACES = "listWorkspaces";
-	private static final String LIST_WORKSPACE_IDS = "listWorkspaceIDs";
-	private static final String GET_WORKSPACE_DESCRIPTION = "getWorkspaceDescription";
-	private static final String SET_WORKSPACE_DESCRIPTION = "setWorkspaceDescription";
-	private static final String LIST_OBJECTS = "listObjects";
-	private static final String SAVE_OBJECTS = "saveObjects";
-	private static final String GET_OBJECT_INFO = "getObjectInfo";
-	private static final String GET_OBJECT_HIST = "getObjectHistory";
-	private static final String GET_OBJECTS = "getObjects";
-	private static final String SET_GLOBAL_PERMISSION = "setGlobalPermission";
-	private static final String GET_WORKSPACE_INFO = "getWorkspaceInfo";
-	private static final String GET_PERMISSIONS = "getPermissions";
-	private static final String GET_PERMISSIONS_MASS = "getPermissionsMass";
-	private static final String SET_PERMISSIONS = "setPermissions";
-	private static final String CREATE_WORKSPACE = "createWorkspace";
-	private static final String DELETE_WS = "deleteWorkspace";
-	private static final String UNDELETE_WS = "undeleteWorkspace";
-
-	private final static ObjectMapper MAPPER = new ObjectMapper()
-			.registerModule(new JacksonTupleModule());
 	
-	private final WorkspaceServerMethods wsmeth;
-	private final Types types;
+	/** An interface for handling an administration command. */
+	@FunctionalInterface
+	public static interface AdminCommandHandler {
+		
+		/** Run the command.
+		 * @param cmd the command.
+		 * @param token the user's token.
+		 * @param resourcesToDelete a threadlocal in which resources that must be deleted when
+		 * the command is completed can be stored.
+		 * @return the result of the command.
+		 * @throws Exception if an error occurs.
+		 */
+		Object runCommand(
+				AdminCommand command,
+				AuthToken token,
+				// there's got to be a better way to deal with this...
+				ThreadLocal<List<WorkspaceObjectData>> resourcesToDelete)
+			throws Exception;
+	}
+	
+	/** A specification for an administration command. */
+	public static class AdminCommandSpecification {
+		private final String commandName;
+		private final AdminCommandHandler commandHandler;
+		private final boolean requireWrite;
+		
+		/** Create the specification.
+		 * @param the name of the command to respond to.
+		 * @param commandHandler the handler for the command.
+		 */
+		public AdminCommandSpecification(
+				final String commandName,
+				final AdminCommandHandler commandHandler) {
+			this(commandName, commandHandler, false);
+		}
+		
+		/** Create the specification.
+		 * @param the name of the command to respond to.
+		 * @param commandHandler the handler for the command.
+		 * @param requireWrite true if this command requires write privileges.
+		 */
+		public AdminCommandSpecification(
+				final String commandName,
+				final AdminCommandHandler commandHandler,
+				final boolean requireWrite) {
+			this.commandName = requireNonNull(commandName, "commandName");
+			this.commandHandler = requireNonNull(commandHandler, "commandHandler");
+			this.requireWrite = requireWrite;
+		}
+		
+		/** Get the name of the command.
+		 * @return the name.
+		 */
+		public String getName() {
+			return this.commandName;
+		}
+
+		/** Run the command.
+		 * @param cmd the command.
+		 * @param token the user's token.
+		 * @param resourcesToDelete a threadlocal in which resources that must be deleted when
+		 * the command is completed can be stored.
+		 * @return the result of the command.
+		 * @throws Exception if an error occurs.
+		 */
+		public Object runCommand(
+				final AdminCommand cmd,
+				final AuthToken token,
+				final ThreadLocal<List<WorkspaceObjectData>> resourcesToDelete)
+				throws Exception {
+			return commandHandler.runCommand(cmd, token, resourcesToDelete);
+		}
+
+		/** Whether write privileges are required to run this command.
+		 * @return true if write privileges are required.
+		 */
+		public boolean isRequireWrite() {
+			return requireWrite;
+		}
+	}
+	
+	/** A validator for KBase users. */
+	@FunctionalInterface
+	public static interface UserValidator {
+		
+		/** Validate and get a user.
+		 * @param user the KBase user name.
+		 * @param token a valid KBase token, which need not be for the user to be validated.
+		 * @return the user name.
+		 * @throws IOException if an IOException occurs.
+		 * @throws AuthException if an error occurs validating the user.
+		 */
+		WorkspaceUser validateUser(String user, AuthToken token) throws IOException, AuthException;
+	}
+	
 	private final AdministratorHandler admin;
 	private final Cache<String, AdminRole> adminCache;
+	private final Map<String, AdminCommandSpecification> commandHandlers;
+	private final UserValidator userValidator;
 	
 	/** Create the workspace administration instance.
-	 * @param ws a workspace instance.
-	 * @param wsmeth a workspace methods instance.
-	 * @param types a workspace types instance.
 	 * @param admin an administrator handler.
 	 * @param maxCacheSize the maximum number of {@link AdminRole}s to cache.
 	 * @param cacheTimeInMS the maximum time an {@link AdminRole} will be cached in milliseconds.
 	 */
 	public WorkspaceAdministration(
-			final WorkspaceServerMethods wsmeth,
-			final Types types,
 			final AdministratorHandler admin,
+			// TODO NOW this is temporary to reduce PR size. Change to a builder & add unit tests
+			// Also redo javadoc after that
+			final Map<String, AdminCommandSpecification> commandHandlers,
+			final UserValidator userValidator,
 			final int maxCacheSize,
 			final int cacheTimeInMS) {
-		this(wsmeth, types, admin, maxCacheSize, cacheTimeInMS, Ticker.systemTicker());
+		this(admin, commandHandlers, userValidator, maxCacheSize,
+				cacheTimeInMS, Ticker.systemTicker());
 	}
 	
 	/** This constructor should only be used for tests. */
 	public WorkspaceAdministration(
-			final WorkspaceServerMethods wsmeth,
-			final Types types,
 			final AdministratorHandler admin,
+			final Map<String, AdminCommandSpecification> commandHandlers,
+			final UserValidator userValidator,
 			final int maxCacheSize,
 			final int cacheTimeInMS,
 			final Ticker ticker) {
-		this.types = types;
-		// TODO CODE some of the code here calls the underlying workspace instance.
-		// probably better to not do that and just call the service translation layer when
-		// possible.
-		this.wsmeth = wsmeth;
 		this.admin = admin;
 		adminCache = CacheBuilder.newBuilder()
 				.maximumSize(maxCacheSize)
 				.expireAfterWrite(cacheTimeInMS, TimeUnit.MILLISECONDS)
 				.ticker(ticker)
 				.build();
+		this.commandHandlers = commandHandlers;
+		this.userValidator = userValidator;
+		installAdminCommandSpecs();
+	}
+	
+	private void installAdminCommandSpecs() {
+		final List<AdminCommandSpecification> specs = Arrays.asList(
+			new AdminCommandSpecification(
+				LIST_ADMINS,
+				(cmd, tok, toDelete) -> {
+					getLogger().info(LIST_ADMINS);
+					return admin.getAdmins().stream().map(u -> u.getUser())
+							.collect(Collectors.toList());
+				}),
+			new AdminCommandSpecification(
+				ADD_ADMIN,
+				(cmd, tok, toDelete) -> {
+					final WorkspaceUser user = userValidator.validateUser(cmd.getUser(), tok);
+					getLogger().info(ADD_ADMIN + " " + user.getUser());
+					admin.addAdmin(user);
+					adminCache.invalidate(user.getUser());
+					return null;
+				},
+				true),
+			new AdminCommandSpecification(
+				REMOVE_ADMIN,
+				(cmd, tok, toDelete) -> {
+					final WorkspaceUser user = userValidator.validateUser(cmd.getUser(), tok);
+					getLogger().info(REMOVE_ADMIN + " " + user.getUser());
+					admin.removeAdmin(user);
+					adminCache.invalidate(user.getUser());
+					return null;
+				},
+				true)
+			);
+		
+		for (final AdminCommandSpecification spec: specs) {
+			commandHandlers.put(spec.getName(), spec);
+		}
 	}
 	
 	private static Logger getLogger() {
 		return LoggerFactory.getLogger(WorkspaceAdministration.class);
 	}
 	
-	private void requireWrite(final AdminRole role) {
-		if (!AdminRole.ADMIN.equals(role)) {
+	private void checkRequireWrite(
+			final AdminCommandSpecification cmdspec,
+			final AdminRole role) {
+		if (cmdspec.isRequireWrite() && !AdminRole.ADMIN.equals(role)) {
 			throw new IllegalArgumentException(
 					"Full administration rights required for this command");
 		}
@@ -185,9 +254,8 @@ public class WorkspaceAdministration {
 			final ThreadLocal<List<WorkspaceObjectData>> resourcesToDelete)
 			throws Exception {
 		final AdminRole role = getAdminRole(token);
-		final String putativeAdmin = token.getUserName();
 		if (AdminRole.NONE.equals(role)) {
-			throw new IllegalArgumentException("User " + putativeAdmin + " is not an admin");
+			throw new IllegalArgumentException("User " + token.getUserName() + " is not an admin");
 		}
 		final AdminCommand cmd;
 		try {
@@ -200,304 +268,12 @@ public class WorkspaceAdministration {
 			}
 			throw ioe;
 		}
-		// should look into some sort of interface w/ registration instead of a massive if else
 		final String fn = cmd.getCommand();
-		if (GET_CONFIG.contentEquals(fn)) {
-			getLogger().info(GET_CONFIG);
-			return ImmutableMap.of("config", wsmeth.getWorkspace().getConfig().toMap());
+		if (!commandHandlers.containsKey(fn)) {
+			throw new IllegalArgumentException(
+					"I don't know how to process the command: " + fn);
 		}
-		if (SET_CONFIG.equals(fn)) {
-			requireWrite(role);
-			getLogger().info(SET_CONFIG); // add parameters?
-			final SetConfigParams params = getParams(cmd, SetConfigParams.class);
-			wsmeth.getWorkspace().setConfig(DynamicConfigUpdate.getBuilder().withMap(params.set)
-					.build());
-			return null;
-		}
-		if (LIST_MOD_REQUESTS.equals(fn)) {
-			getLogger().info(LIST_MOD_REQUESTS);
-			return types.listModuleRegistrationRequests();
-		}
-		if (APPROVE_MOD_REQUEST.equals(fn)) {
-			requireWrite(role);
-			final String mod = cmd.getModule();
-			getLogger().info(APPROVE_MOD_REQUEST + " " + mod);
-			types.resolveModuleRegistration(mod, true);
-			return null;
-		}
-		if (DENY_MOD_REQUEST.equals(fn)) {
-			requireWrite(role);
-			final String mod = cmd.getModule();
-			getLogger().info(DENY_MOD_REQUEST + " " + mod);
-			types.resolveModuleRegistration(mod, false);
-			return null;
-		}
-		if (LIST_ADMINS.equals(fn)) {
-			getLogger().info(LIST_ADMINS);
-			return usersToStrings(admin.getAdmins());
-		}
-		if (ADD_ADMIN.equals(fn)) {
-			requireWrite(role);
-			final WorkspaceUser user = getUser(cmd, token);
-			getLogger().info(ADD_ADMIN + " " + user.getUser());
-			admin.addAdmin(user);
-			adminCache.invalidate(user.getUser());
-			return null;
-		}
-		if (REMOVE_ADMIN.equals(fn)) {
-			requireWrite(role);
-			final WorkspaceUser user = getUser(cmd, token);
-			getLogger().info(REMOVE_ADMIN + " " + user.getUser());
-			admin.removeAdmin(user);
-			adminCache.invalidate(user.getUser());
-			return null;
-		}
-		if (SET_WORKSPACE_OWNER.equals(fn)) {
-			requireWrite(role);
-			final SetWorkspaceOwnerParams params = getParams(cmd, SetWorkspaceOwnerParams.class);
-			
-			final WorkspaceIdentifier wsi = processWorkspaceIdentifier(params.wsi);
-			final WorkspaceInformation info = wsmeth.getWorkspace().setWorkspaceOwner(
-					null,
-					wsi,
-					params.new_user == null ? null : getUser(params.new_user, token),
-					Optional.ofNullable(params.new_name), true);
-			getLogger().info(SET_WORKSPACE_OWNER + " " + info.getId() + " " +
-					info.getOwner().getUser());
-			return wsInfoToTuple(info);
-		}
-		if (CREATE_WORKSPACE.equals(fn)) {
-			requireWrite(role);
-			final WorkspaceUser user = getUser(cmd, token);
-			final CreateWorkspaceParams params = getParams(cmd, CreateWorkspaceParams.class);
-			final Tuple9<Long, String, String, String, Long, String, String, String,
-					Map<String, String>> ws =  wsmeth.createWorkspace(params, user);
-			getLogger().info(CREATE_WORKSPACE + " " + ws.getE1() + " " + ws.getE3());
-			return ws;
-		}
-		if (SET_PERMISSIONS.equals(fn)) {
-			requireWrite(role);
-			final SetPermissionsParams params = getParams(cmd, SetPermissionsParams.class);
-			final long id = wsmeth.setPermissionsAsAdmin(params, token);
-			getLogger().info(SET_PERMISSIONS + " " + id + " " + params.getNewPermission() + " " +
-					StringUtils.join(params.getUsers(), " "));
-			return null;
-		}
-		if (SET_WORKSPACE_DESCRIPTION.equals(fn)) {
-			requireWrite(role);
-			final SetWorkspaceDescriptionParams params = getParams(
-					cmd, SetWorkspaceDescriptionParams.class);
-			final WorkspaceIdentifier wsi = processWorkspaceIdentifier(
-					params.getWorkspace(), params.getId());
-			final long id = wsmeth.getWorkspace().setWorkspaceDescription(
-					null, wsi, params.getDescription(), true);
-			getLogger().info(SET_WORKSPACE_DESCRIPTION + " " + id);
-			return null;
-		}
-		if (GET_WORKSPACE_DESCRIPTION.equals(fn)) {
-			final WorkspaceIdentity wsi = getParams(cmd, WorkspaceIdentity.class);
-			final WorkspaceIdentifier wsid = processWorkspaceIdentifier(wsi);
-			final String desc = wsmeth.getWorkspace().getWorkspaceDescription(null, wsid, true);
-			// TODO FEATURE would be better if could always provide ID vs. name
-			getLogger().info(GET_WORKSPACE_DESCRIPTION + " " + wsi.getId() + " " +
-					wsi.getWorkspace());
-			return desc;
-		}
-		if (GET_PERMISSIONS.equals(fn)) {
-			final WorkspaceIdentity params = getParams(cmd, WorkspaceIdentity.class);
-			final WorkspaceUser user = getNullableUser(cmd, token);
-			final Map<String, String> perms;
-			if (user == null) {
-				perms = wsmeth.getPermissions(Arrays.asList(params), null, true).getPerms().get(0);
-			} else {
-				perms = wsmeth.getPermissions(params, user);
-			}
-			//TODO FEATURE would be better if could always provide ID vs. name
-			getLogger().info(GET_PERMISSIONS + " " + params.getId() + " " +
-					params.getWorkspace() + (user == null ? "" : " " + user.getUser()));
-			return perms;
-		}
-		if (GET_PERMISSIONS_MASS.equals(fn)) {
-			final GetPermissionsMassParams params = getParams(cmd, GetPermissionsMassParams.class);
-			// not sure what to log here, could be 1K entries.
-			final WorkspacePermissions perms = wsmeth.getPermissions(
-					params.getWorkspaces(), null, true);
-			getLogger().info(GET_PERMISSIONS_MASS + " " + params.getWorkspaces().size() +
-					" workspaces in input");
-			return perms;
-		}
-		if (GET_WORKSPACE_INFO.equals(fn)) {
-			final WorkspaceIdentity params = getParams(cmd, WorkspaceIdentity.class);
-			final WorkspaceIdentifier wsi = processWorkspaceIdentifier(
-							params.getWorkspace(), params.getId());
-			final WorkspaceInformation info = wsmeth.getWorkspace().
-					getWorkspaceInformationAsAdmin(wsi);
-			getLogger().info(GET_WORKSPACE_INFO + " " + info.getId());
-			return wsInfoToTuple(info);
-		}
-		if (SET_GLOBAL_PERMISSION.equals(fn)) {
-			requireWrite(role);
-			final WorkspaceUser user = getUser(cmd, token);
-			final SetGlobalPermissionsParams params = getParams(cmd,
-					SetGlobalPermissionsParams.class);
-			final long id = wsmeth.setGlobalPermission(params, user);
-			getLogger().info(SET_GLOBAL_PERMISSION + " " + id + " " +
-					params.getNewPermission() + " " + user.getUser());
-			return null;
-		}
-		if (SAVE_OBJECTS.equals(fn)) {
-			requireWrite(role);
-			final WorkspaceUser user = getUser(cmd, token);
-			final SaveObjectsParams params = getParams(cmd, SaveObjectsParams.class);
-			//method has its own logging
-			getLogger().info(SAVE_OBJECTS + " " + user.getUser());
-			return wsmeth.saveObjects(params, user, token);
-		}
-		if (GET_OBJECT_INFO.equals(fn)) {
-			final GetObjectInfo3Params params = getParams(cmd, GetObjectInfo3Params.class);
-			// method has its own logging
-			getLogger().info(GET_OBJECT_INFO);
-			// is passing the admin user really necessary? Check at some point, maybe remove
-			return wsmeth.getObjectInformation(params, new WorkspaceUser(putativeAdmin), true);
-		}
-		if (GET_OBJECT_HIST.equals(fn)) {
-			final ObjectIdentity params = getParams(cmd, ObjectIdentity.class);
-			// method has its own logging
-			getLogger().info(GET_OBJECT_HIST);
-			return wsmeth.getObjectHistory(params, new WorkspaceUser(putativeAdmin), true);
-		}
-		if (GET_OBJECTS.equals(fn)) {
-			final GetObjects2Params params = getParams(cmd, GetObjects2Params.class);
-			// method has its own logging
-			getLogger().info(GET_OBJECTS);
-			return wsmeth.getObjects(params, new WorkspaceUser(putativeAdmin), true,
-					resourcesToDelete);
-		}
-		if (LIST_WORKSPACES.equals(fn)) {
-			final WorkspaceUser user = getUser(cmd, token);
-			final ListWorkspaceInfoParams params = getParams(cmd, ListWorkspaceInfoParams.class);
-			getLogger().info(LIST_WORKSPACES + " " + user.getUser());
-			return wsmeth.listWorkspaceInfo(params, user);
-		}
-		if (LIST_WORKSPACE_IDS.equals(fn)) {
-			final WorkspaceUser user = getUser(cmd, token);
-			final ListWorkspaceIDsParams params = getParams(cmd, ListWorkspaceIDsParams.class);
-			getLogger().info(LIST_WORKSPACE_IDS + " " + user.getUser());
-			return wsmeth.listWorkspaceIDs(params, user);
-		}
-		if (LIST_OBJECTS.equals(fn)) {
-			final ListObjectsParams params = getParams(cmd, ListObjectsParams.class);
-			final WorkspaceUser user = getNullableUser(cmd, token);
-			final String ustr = user == null ? "adminuser" : "user: " + user.getUser();
-			getLogger().info(LIST_OBJECTS + " " + ustr);
-			return wsmeth.listObjects(params, user, user == null);
-		}
-		if (DELETE_WS.equals(fn)) {
-			requireWrite(role);
-			final WorkspaceIdentity params = getParams(cmd, WorkspaceIdentity.class);
-			final WorkspaceIdentifier wksp = processWorkspaceIdentifier(params);
-			final long id = wsmeth.getWorkspace().setWorkspaceDeleted(null, wksp, true, true);
-			getLogger().info(DELETE_WS + " " + id);
-			return null;
-		}
-		if (UNDELETE_WS.equals(fn)) {
-			requireWrite(role);
-			final WorkspaceIdentity params = getParams(cmd, WorkspaceIdentity.class);
-			final WorkspaceIdentifier wksp = processWorkspaceIdentifier(params);
-			final long id = wsmeth.getWorkspace().setWorkspaceDeleted(null, wksp, false, true);
-			getLogger().info(UNDELETE_WS + " " + id);
-			return null;
-		}
-		if (LIST_WORKSPACE_OWNERS.equals(fn)) {
-			getLogger().info(LIST_WORKSPACE_OWNERS);
-			return usersToStrings(wsmeth.getWorkspace().getAllWorkspaceOwners());
-		}
-		if (GRANT_MODULE_OWNERSHIP.equals(fn)) {
-			requireWrite(role);
-			final GrantModuleOwnershipParams params = getParams(cmd,
-					GrantModuleOwnershipParams.class);
-			getLogger().info(GRANT_MODULE_OWNERSHIP + " " + params.getMod() +
-					" " + params.getNewOwner());
-			wsmeth.grantModuleOwnership(params, null, true);
-			return null;
-		}
-		if (REMOVE_MODULE_OWNERSHIP.equals(fn)) {
-			requireWrite(role);
-			final RemoveModuleOwnershipParams params = getParams(cmd,
-					RemoveModuleOwnershipParams.class);
-			getLogger().info(REMOVE_MODULE_OWNERSHIP + " " + params.getMod() +
-					" " + params.getOldOwner());
-			wsmeth.removeModuleOwnership(params, null, true);
-			return null;
-		}
-		throw new IllegalArgumentException(
-				"I don't know how to process the command: " + fn);
+		checkRequireWrite(commandHandlers.get(fn), role);
+		return commandHandlers.get(fn).runCommand(cmd, token, resourcesToDelete);
 	}
-
-	private List<String> usersToStrings(final Set<WorkspaceUser> users) {
-		final List<String> ret = new ArrayList<String>();
-		for (final WorkspaceUser u: users) {
-			ret.add(u.getUser());
-		}
-		return ret;
-	}
-
-	private WorkspaceUser getUser(final AdminCommand cmd, final AuthToken token)
-			throws IOException, AuthException {
-		return getUser(cmd.getUser(), token);
-	}
-
-	private WorkspaceUser getUser(final String user, final AuthToken token)
-			throws IOException, AuthException {
-		if (user == null) {
-			throw new NullPointerException("User may not be null");
-		}
-		return wsmeth.validateUsers(Arrays.asList(user), token).get(0);
-	}
-	
-	private WorkspaceUser getNullableUser(final AdminCommand cmd, final AuthToken token)
-			throws IOException, AuthException {
-		if (cmd.getUser() == null) {
-			return null;
-		}
-		return wsmeth.validateUsers(Arrays.asList(cmd.getUser()), token).get(0);
-	}
-	
-	private static class SetConfigParams {
-		public Map<String, Object> set;
-		
-		@SuppressWarnings("unused")
-		public SetConfigParams() {}; // for jackson
-	}
-	
-	private static class SetWorkspaceOwnerParams {
-		public WorkspaceIdentity wsi;
-		public String new_user;
-		public String new_name;
-		
-		@SuppressWarnings("unused")
-		public SetWorkspaceOwnerParams() {}; //for jackson
-	}
-	
-	private <T> T getParams(final AdminCommand input, final Class<T> clazz)
-			throws IOException {
-		final UObject p = input.getParams();
-		if (p == null) {
-			throw new NullPointerException("Method parameters " +
-					clazz.getSimpleName() + " may not be null");
-		}
-		try {
-			return MAPPER.readValue(p.getPlacedStream(), clazz);
-		} catch (JsonMappingException e) { // parse exception can't happen here
-			throw new IllegalArgumentException("Unable to deserialize "
-					+ clazz.getSimpleName() + " out of params field: " + e.getMessage(), e);
-		}
-	}
-
-//	//why doesn't this work?
-//	@SuppressWarnings("unused")
-//	private <T> T getParams(final Map<String, Object> input) {
-//		return UObject.transformObjectToObject(input.get("params"),
-//				new TypeReference<T>() {});
-//	}
 }

--- a/src/us/kbase/workspace/test/kbase/admin/WorkspaceAdministrationWithHandlersTest.java
+++ b/src/us/kbase/workspace/test/kbase/admin/WorkspaceAdministrationWithHandlersTest.java
@@ -81,11 +81,17 @@ import us.kbase.workspace.database.WorkspaceObjectData;
 import us.kbase.workspace.database.WorkspaceUser;
 import us.kbase.workspace.kbase.WorkspaceServerMethods;
 import us.kbase.workspace.kbase.admin.AdminRole;
+import us.kbase.workspace.kbase.admin.AdministrationCommandSetBuilder;
 import us.kbase.workspace.kbase.admin.AdministratorHandler;
 import us.kbase.workspace.kbase.admin.AdministratorHandlerException;
 import us.kbase.workspace.kbase.admin.WorkspaceAdministration;
+import us.kbase.workspace.kbase.admin.WorkspaceAdministration.AdminCommandSpecification;
+import us.kbase.workspace.kbase.admin.WorkspaceAdministration.UserValidator;
 
-public class WorkspaceAdministrationTest {
+public class WorkspaceAdministrationWithHandlersTest {
+	
+	// Tests the workspace admin class with the standard set of handlers installed via the
+	// handler set builder
 	
 	// these tests are waaaay more complicated than then need to be because the SDK
 	// doesn't create equals & hashCode methods for its generated classes.
@@ -158,12 +164,17 @@ public class WorkspaceAdministrationTest {
 		final WorkspaceServerMethods wsmeth = mock(WorkspaceServerMethods.class);
 		when(wsmeth.getWorkspace()).thenReturn(ws);
 		final Types types = mock(Types.class);
+		final Map<String, AdminCommandSpecification> handlers = AdministrationCommandSetBuilder
+				.build(wsmeth, types);
+		final UserValidator userVal = (user, token) -> AdministrationCommandSetBuilder
+				.getUser(wsmeth, user, token);
 		final AdministratorHandler ah = mock(AdministratorHandler.class);
 		final WorkspaceAdministration admin;
 		if (ticker == null) {
-			admin = new WorkspaceAdministration(wsmeth, types, ah, cacheSize, cacheTimeMS);
+			admin = new WorkspaceAdministration(ah, handlers, userVal, cacheSize, cacheTimeMS);
 		} else {
-			admin = new WorkspaceAdministration(wsmeth, types, ah, cacheSize, cacheTimeMS, ticker);
+			admin = new WorkspaceAdministration(
+					ah, handlers, userVal, cacheSize, cacheTimeMS, ticker);
 		}
 		return new TestMocks(ws, wsmeth, types, ah, ticker, admin);
 	}
@@ -446,7 +457,7 @@ public class WorkspaceAdministrationTest {
 				"backend-file-retrieval-scaling", 4))));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"getConfig", WorkspaceAdministration.class));
+				"getConfig", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -460,7 +471,7 @@ public class WorkspaceAdministrationTest {
 		mocks.admin.runCommand(new AuthToken("tok", "fake"), command, null);
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"setConfig", WorkspaceAdministration.class));
+				"setConfig", AdministrationCommandSetBuilder.class));
 		
 		verify(mocks.ws).setConfig(DynamicConfigUpdate.getBuilder()
 				.withBackendScaling(89).build());
@@ -482,7 +493,7 @@ public class WorkspaceAdministrationTest {
 						"backend-file-retrieval-scaling must be an integer > 0"));
 
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"setConfig", WorkspaceAdministration.class));
+				"setConfig", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -502,7 +513,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("incorrect return", o.get(0).getModuleName(), is("mod"));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"listModRequests", WorkspaceAdministration.class));
+				"listModRequests", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -517,7 +528,7 @@ public class WorkspaceAdministrationTest {
 		mocks.admin.runCommand(new AuthToken("tok", "fake"), command, null);
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"approveModRequest somemod", WorkspaceAdministration.class));
+				"approveModRequest somemod", AdministrationCommandSetBuilder.class));
 		
 		verify(mocks.types).resolveModuleRegistration("somemod", true);
 	}
@@ -534,7 +545,7 @@ public class WorkspaceAdministrationTest {
 		mocks.admin.runCommand(new AuthToken("tok", "fake"), command, null);
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"denyModRequest somemod", WorkspaceAdministration.class));
+				"denyModRequest somemod", AdministrationCommandSetBuilder.class));
 		
 		verify(mocks.types).resolveModuleRegistration("somemod", false);
 	}
@@ -634,7 +645,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("meta correct", gross.getE9(), is(Collections.emptyMap()));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"setWorkspaceOwner 3 owner", WorkspaceAdministration.class));
+				"setWorkspaceOwner 3 owner", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -680,7 +691,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("meta correct", gross.getE9(), is(Collections.emptyMap()));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"setWorkspaceOwner 10 usern", WorkspaceAdministration.class));
+				"setWorkspaceOwner 10 usern", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -726,7 +737,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("incorrect return", gross, is(grossret)); // rely on identity
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"createWorkspace 7 user1", WorkspaceAdministration.class));
+				"createWorkspace 7 user1", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -756,7 +767,7 @@ public class WorkspaceAdministrationTest {
 		mocks.admin.runCommand(new AuthToken("tok", "fake"), command, null);
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"setPermissions 24 a u1 u2", WorkspaceAdministration.class));
+				"setPermissions 24 a u1 u2", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -775,7 +786,7 @@ public class WorkspaceAdministrationTest {
 		mocks.admin.runCommand(new AuthToken("tok", "fake"), command, null);
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"setWorkspaceDescription 8", WorkspaceAdministration.class));
+				"setWorkspaceDescription 8", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -796,7 +807,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("incorrect description", desc, is("desc1"));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"getWorkspaceDescription null ws1", WorkspaceAdministration.class));
+				"getWorkspaceDescription null ws1", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -830,7 +841,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("incorrect perms", perms, is(ImmutableMap.of("user", "a", "user2", "r")));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"getPermissions 3 null", WorkspaceAdministration.class));
+				"getPermissions 3 null", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -861,7 +872,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("incorrect perms", perms, is(ImmutableMap.of("user3", "w", "user10", "r")));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"getPermissions null foo auser", WorkspaceAdministration.class));
+				"getPermissions null foo auser", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -902,7 +913,8 @@ public class WorkspaceAdministrationTest {
 				ImmutableMap.of("user3", "w", "user10", "r"))));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"getPermissionsMass 2 workspaces in input", WorkspaceAdministration.class));
+				"getPermissionsMass 2 workspaces in input",
+				AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -940,7 +952,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("meta correct", gross.getE9(), is(Collections.emptyMap()));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"getWorkspaceInfo 10", WorkspaceAdministration.class));
+				"getWorkspaceInfo 10", AdministrationCommandSetBuilder.class));
 	}
 
 	@Test
@@ -970,7 +982,7 @@ public class WorkspaceAdministrationTest {
 		mocks.admin.runCommand(new AuthToken("tok", "fake"), command, null);
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"setGlobalPermission 65 r auser", WorkspaceAdministration.class));
+				"setGlobalPermission 65 r auser", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -1044,7 +1056,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("incorrect tuple", l.get(0), is(supergross)); // rely on identity
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"saveObjects auser", WorkspaceAdministration.class));
+				"saveObjects auser", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -1161,7 +1173,7 @@ public class WorkspaceAdministrationTest {
 								Arrays.asList("25/3/22"))));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"getObjectInfo", WorkspaceAdministration.class));
+				"getObjectInfo", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -1227,7 +1239,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("incorrect return", res, is(Arrays.asList(sg1, sg2)));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"getObjectHistory", WorkspaceAdministration.class));
+				"getObjectHistory", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -1357,7 +1369,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("incorrect dat", res.getData(), is(Arrays.asList(od1, od2)));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"getObjects", WorkspaceAdministration.class));
+				"getObjects", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -1432,7 +1444,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("incorrect return", res, is(Arrays.asList(g1, g2)));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"listWorkspaces user1", WorkspaceAdministration.class));
+				"listWorkspaces user1", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -1468,7 +1480,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("incorrect ws", res.getWorkspaces(), is(Arrays.asList(3L, 4L)));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"listWorkspaceIDs user1", WorkspaceAdministration.class));
+				"listWorkspaceIDs user1", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -1561,7 +1573,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("incorrect res", res, is(Arrays.asList(sg1, sg2)));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"listObjects user: user1", WorkspaceAdministration.class));
+				"listObjects user: user1", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -1651,7 +1663,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("incorrect res", res, is(Arrays.asList(sg1, sg2)));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"listObjects adminuser", WorkspaceAdministration.class));
+				"listObjects adminuser", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -1668,7 +1680,7 @@ public class WorkspaceAdministrationTest {
 		mocks.admin.runCommand(new AuthToken("tok", "fake"), command, null);
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"deleteWorkspace 7", WorkspaceAdministration.class));
+				"deleteWorkspace 7", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -1685,7 +1697,7 @@ public class WorkspaceAdministrationTest {
 		mocks.admin.runCommand(new AuthToken("tok", "fake"), command, null);
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"undeleteWorkspace 8", WorkspaceAdministration.class));
+				"undeleteWorkspace 8", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -1705,7 +1717,7 @@ public class WorkspaceAdministrationTest {
 		assertThat("incorrect users", ret, is(Arrays.asList("u1", "u2")));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"listWorkspaceOwners", WorkspaceAdministration.class));
+				"listWorkspaceOwners", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -1737,7 +1749,7 @@ public class WorkspaceAdministrationTest {
 				eq(true));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"grantModuleOwnership ModName owner", WorkspaceAdministration.class));
+				"grantModuleOwnership ModName owner", AdministrationCommandSetBuilder.class));
 	}
 	
 	@Test
@@ -1767,7 +1779,7 @@ public class WorkspaceAdministrationTest {
 				eq(true));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
-				"removeModuleOwnership ModName owner", WorkspaceAdministration.class));
+				"removeModuleOwnership ModName owner", AdministrationCommandSetBuilder.class));
 	}
 	
 	/* *****************************************


### PR DESCRIPTION
Makes it easier to run with different sets of admin commands or different implementations of the same set

Step two of this process is making a WorkspaceAdministrator builder and using that instead of just taking a map of admin commands in the constructor. At that point I'll also add new WA unit tests.