### PR TITLE
PTV-1786: Simplify type provider interface

### DIFF
--- a/src/us/kbase/typedobj/core/LocalTypeProvider.java
+++ b/src/us/kbase/typedobj/core/LocalTypeProvider.java
@@ -1,5 +1,7 @@
 package us.kbase.typedobj.core;
 
+import static java.util.Objects.requireNonNull;
+
 import us.kbase.typedobj.db.TypeDefinitionDB;
 import us.kbase.typedobj.exceptions.NoSuchModuleException;
 import us.kbase.typedobj.exceptions.NoSuchTypeException;
@@ -7,36 +9,24 @@ import us.kbase.typedobj.exceptions.TypeStorageException;
 
 /** A type provider for the typed object validator that takes a direct instance
  * of a type database.
- * @author gaprice@lbl.gov
  *
  */
 public class LocalTypeProvider implements TypeProvider {
 
-	//TODO TEST unit tests
-	
 	private final TypeDefinitionDB typeDB;
 	
 	/** Create a type provider that connects directly to a type database.
 	 * @param typeDB a type database.
 	 */
 	public LocalTypeProvider(final TypeDefinitionDB typeDB) {
-		if (typeDB == null) {
-			throw new NullPointerException("typeDB cannot be null");
-		}
-		this.typeDB = typeDB;
-	}
-	@Override
-	public AbsoluteTypeDefId resolveTypeDef(TypeDefId typeDefId)
-			throws NoSuchTypeException, NoSuchModuleException,
-			TypeStorageException {
-		return typeDB.resolveTypeDefId(typeDefId);
+		this.typeDB = requireNonNull(typeDB, "typeDB");
 	}
 
 	@Override
-	public String getTypeJsonSchema(AbsoluteTypeDefId typeDefId)
-			throws NoSuchTypeException, NoSuchModuleException,
-			TypeStorageException {
-		return typeDB.getJsonSchemaDocument(typeDefId);
+	public ResolvedType getTypeJsonSchema(final TypeDefId type)
+			throws NoSuchTypeException, NoSuchModuleException, TypeStorageException {
+		final AbsoluteTypeDefId rtype = typeDB.resolveTypeDefId(requireNonNull(type, "type"));
+		return new ResolvedType(rtype, typeDB.getJsonSchemaDocument(rtype));
 	}
 
 }

--- a/src/us/kbase/typedobj/core/TypeProvider.java
+++ b/src/us/kbase/typedobj/core/TypeProvider.java
@@ -1,39 +1,84 @@
 package us.kbase.typedobj.core;
 
+import static java.util.Objects.requireNonNull;
+
 import us.kbase.typedobj.exceptions.NoSuchModuleException;
 import us.kbase.typedobj.exceptions.NoSuchTypeException;
 import us.kbase.typedobj.exceptions.TypeStorageException;
 
-/** Provides type definitions to the TypedObjectValidator.
- * 
- * @author gaprice@lbl.gov
- *
- */
+/** Provides type definitions to the TypedObjectValidator. */
 public interface TypeProvider {
 
-	/** Translates a potentially unresolved type id (e.g. missing a minor
-	 * or major version) to an absolute type id.
-	 * @param typeDefId a type id that may not be completely specified.
-	 * @return a completely specified type id.
-	 * @throws TypeStorageException if an error occurs with the type storage
-	 * engine
-	 * @throws NoSuchModuleException if the module for the type does not exit
-	 * @throws NoSuchTypeException if the type does not exist
-	 */
-	public AbsoluteTypeDefId resolveTypeDef(final TypeDefId typeDefId)
-			throws NoSuchTypeException, NoSuchModuleException,
-			TypeStorageException;
+	/** A resolved type and its JSONSchema. */
+	public static class ResolvedType {
+		private final AbsoluteTypeDefId type;
+		private final String jsonSchema;
+
+		/** Construct the resolved type.
+		 * @param type the resolved type.
+		 * @param jsonSchema the JSONSchema.
+		 */
+		public ResolvedType(final AbsoluteTypeDefId type, final String jsonSchema) {
+			this.type = requireNonNull(type, "type");
+			this.jsonSchema = requireNonNull(jsonSchema, "jsonSchema");
+		}
+
+		/** Get the resolved type.
+		 * @return the type.
+		 */
+		public AbsoluteTypeDefId getType() {
+			return type;
+		}
+
+		/** Get the JSONSchema for the type.
+		 * @return the JSONSchema.
+		 */
+		public String getJsonSchema() {
+			return jsonSchema;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((jsonSchema == null) ? 0 : jsonSchema.hashCode());
+			result = prime * result + ((type == null) ? 0 : type.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			ResolvedType other = (ResolvedType) obj;
+			if (jsonSchema == null) {
+				if (other.jsonSchema != null)
+					return false;
+			} else if (!jsonSchema.equals(other.jsonSchema))
+				return false;
+			if (type == null) {
+				if (other.type != null)
+					return false;
+			} else if (!type.equals(other.type))
+				return false;
+			return true;
+		}
+	}
 	
-	/** Retrieves the JsonSchema type definition document, as a string, for the
+	/** Retrieves the resolved type and JsonSchema type definition document for the
 	 * specified type.
-	 * @param typeDefId a type id.
-	 * @return the JsonSchema document for the type.
+	 * @param type a type id.
+	 * @return the resolved type with JSONSchema.
 	 * @throws TypeStorageException if an error occurs with the type storage
-	 * engine
-	 * @throws NoSuchModuleException if the module for the type does not exit
-	 * @throws NoSuchTypeException if the type does not exist
+	 * engine.
+	 * @throws NoSuchModuleException if the module for the type does not exist.
+	 * @throws NoSuchTypeException if the type does not exist.
 	 */
-	public String getTypeJsonSchema(final AbsoluteTypeDefId typeDefId)
+	public ResolvedType getTypeJsonSchema(final TypeDefId type)
 			throws NoSuchTypeException, NoSuchModuleException,
 			TypeStorageException;
 }

--- a/src/us/kbase/typedobj/test/LocalTypeProviderTest.java
+++ b/src/us/kbase/typedobj/test/LocalTypeProviderTest.java
@@ -1,0 +1,61 @@
+package us.kbase.typedobj.test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import us.kbase.common.test.TestCommon;
+import us.kbase.typedobj.core.AbsoluteTypeDefId;
+import us.kbase.typedobj.core.LocalTypeProvider;
+import us.kbase.typedobj.core.TypeDefId;
+import us.kbase.typedobj.core.TypeDefName;
+import us.kbase.typedobj.db.TypeDefinitionDB;
+import us.kbase.typedobj.core.TypeProvider.ResolvedType;
+
+
+public class LocalTypeProviderTest {
+
+	@Test
+	public void getTypeJsonSchema() throws Exception {
+		final TypeDefinitionDB tdb = mock(TypeDefinitionDB.class);
+		
+		final LocalTypeProvider ltp = new LocalTypeProvider(tdb);
+		
+		when(tdb.resolveTypeDefId(TypeDefId.fromTypeString("Baz.Bat-6")))
+				.thenReturn(AbsoluteTypeDefId.fromAbsoluteTypeString("Baz.Bat-6.12"));
+		when(tdb.getJsonSchemaDocument(AbsoluteTypeDefId.fromAbsoluteTypeString("Baz.Bat-6.12")))
+				.thenReturn("{\"foo\":\"bar\"}");
+		
+		assertThat("incorrect result", ltp.getTypeJsonSchema(new TypeDefId("Baz.Bat", "6")),
+				is(new ResolvedType(
+						new AbsoluteTypeDefId(new TypeDefName("Baz.Bat"), 6, 12),
+						"{\"foo\":\"bar\"}")));
+	}
+	
+	@Test
+	public void constructFail() throws Exception {
+		try {
+			new LocalTypeProvider(null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("typeDB"));
+		}
+	}
+	
+	@Test
+	public void getTypeJsonSchemaFail() throws Exception {
+		final TypeDefinitionDB tdb = mock(TypeDefinitionDB.class);
+		final LocalTypeProvider ltp = new LocalTypeProvider(tdb);
+		try {
+			ltp.getTypeJsonSchema(null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("type"));
+		}
+	}
+	
+}

--- a/src/us/kbase/typedobj/test/TypeProviderTest.java
+++ b/src/us/kbase/typedobj/test/TypeProviderTest.java
@@ -1,0 +1,53 @@
+package us.kbase.typedobj.test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import us.kbase.common.test.TestCommon;
+import us.kbase.typedobj.core.AbsoluteTypeDefId;
+import us.kbase.typedobj.core.TypeDefName;
+import us.kbase.typedobj.core.TypeProvider.ResolvedType;
+
+public class TypeProviderTest {
+
+	@Test
+	public void equals() throws Exception {
+		EqualsVerifier.forClass(ResolvedType.class).usingGetClass().verify();
+	}
+	
+	@Test
+	public void construct() throws Exception {
+		final ResolvedType rt = new ResolvedType(
+				AbsoluteTypeDefId.fromAbsoluteTypeString("Foo.Bar-1.3"),
+				"{\"schema\": \"goes_here\"}");
+		
+		assertThat("incorrect type def", rt.getType(),
+				is(new AbsoluteTypeDefId(new TypeDefName("Foo.Bar"), 1, 3)));
+		assertThat("incorrect json schema", rt.getJsonSchema(), is("{\"schema\": \"goes_here\"}"));
+	}
+	
+	@Test
+	public void constructFail() throws Exception {
+		failConstruct(null, "{}", new NullPointerException("type"));
+		failConstruct(AbsoluteTypeDefId.fromAbsoluteTypeString("Foo.Bar-1.3"), null,
+				new NullPointerException("jsonSchema"));
+		
+	}
+	
+	private void failConstruct(
+			final AbsoluteTypeDefId type,
+			final String jsonSchema,
+			final Exception expected) {
+		try {
+			new ResolvedType(type, jsonSchema);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+	
+}


### PR DESCRIPTION
The absolute type def and the jsonschema can be fetched in one call to
the workspace, so make the provider a single call.