### PR TITLE
PTV-1786: Add Delegating Type Provider

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -103,5 +103,6 @@
 	<classpathentry kind="lib" path="/jars/lib/jars/picocli/picocli-4.6.1.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/kbase/sample/SampleServiceClient-0.1.1.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/mongo/mongo-java-driver-3.12.10.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/caffeinecache/caffeine-2.9.3.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/build.xml
+++ b/build.xml
@@ -67,6 +67,7 @@
     <include name="logback/logback-core-1.1.2.jar"/>
     <include name="logback/logback-classic-1.1.2.jar"/>
     <include name="google/guava-14.0.1.jar"/>
+    <include name="caffeinecache/caffeine-2.9.3.jar"/>
     <include name="kafka/kafka-clients-2.1.0.jar"/>
     <include name="kbase/handle/AbstractHandleClient-1.0.0.jar"/>
     <include name="kbase/sample/SampleServiceClient-0.1.1.jar"/>

--- a/src/us/kbase/typedobj/core/TypeDefName.java
+++ b/src/us/kbase/typedobj/core/TypeDefName.java
@@ -8,8 +8,8 @@ import java.util.regex.Pattern;
 
 public class TypeDefName {
 	
-	private final static Pattern INVALID_TYPE_NAMES = 
-			Pattern.compile("[^\\w]");
+	// In java, unlike, say, python 3, this is a-zA-Z0-9_ only, no unicode chars
+	private final static Pattern INVALID_TYPE_NAMES = Pattern.compile("[^\\w]");
 	private final static int MAX_NAME_SIZE_BYTES = 255;
 	
 	private final String module;
@@ -27,7 +27,7 @@ public class TypeDefName {
 	 */
 	public TypeDefName(String fullname) {
 		String [] tokens = fullname.split("\\.");
-		if(tokens.length != 2) {
+		if (tokens.length != 2) {
 			throw new IllegalArgumentException(String.format(
 					"Illegal fullname of a typed object: %s", fullname));
 		}

--- a/src/us/kbase/workspace/kbase/DelegatingTypeProvider.java
+++ b/src/us/kbase/workspace/kbase/DelegatingTypeProvider.java
@@ -1,0 +1,357 @@
+package us.kbase.workspace.kbase;
+
+import static java.util.Objects.requireNonNull;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_16;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Ticker;
+
+import us.kbase.common.service.JsonClientException;
+import us.kbase.common.service.ServerException;
+import us.kbase.typedobj.core.AbsoluteTypeDefId;
+import us.kbase.typedobj.core.TypeDefId;
+import us.kbase.typedobj.core.TypeProvider;
+import us.kbase.typedobj.exceptions.NoSuchModuleException;
+import us.kbase.typedobj.exceptions.NoSuchTypeException;
+import us.kbase.workspace.TypeInfo;
+import us.kbase.workspace.WorkspaceClient;
+
+/** A type provider that delegates to another workspace service.
+ * 
+ * There are two internal caches - one that maps absolute type IDs to their jsonschema document,
+ * and one that maps non-absolute type IDs to their respective absolute IDs. The size of
+ * each cache can be configured as well as the residence time of the latter cache.
+ */
+public class DelegatingTypeProvider implements TypeProvider {
+	
+	/** The default amount of time a non-absolute to absolute type mapping should remain in the
+	 * cache in milliseconds.
+	 */
+	public static final int DEFAULT_TYPE_CACHE_TIME_MS = 5 * 60 * 1000; // 5m between checks
+
+	/** The maximum size of the non-absolute to absolute type mapping cache in bytes. Mapping sizes
+	 * are calculated as sum of the Java UTF-16 encoding size of the non-absolute type string and
+	 * absolute type string. References, etc. are not accounted for.
+	 */
+	public static final int DEFAULT_TYPE_CACHE_MAX_SIZE = 128 * 1024;
+	
+	
+	/** The maximum size of the absolute type to JSONschema mapping cache in bytes. Mapping sizes
+	 * are calculated as sum of the Java UTF-16 encoding size of the absolute type string and the
+	 * size of the UTF-8 encoded JSON schema. References, etc. are not accounted for.
+	 * 
+	 * This value is the minimum size allowed for the maximum size of the cache as the caching
+	 * logic depends on the jsonschema cache being populated.
+	 */
+	public static final int DEFAULT_JSONSCHEMA_CACHE_MAX_SIZE = 1024 * 1024;
+	
+	private final WorkspaceClient client;
+	private final Cache<String, String> typeCache;
+	private final Cache<String, byte[]> jsonSchemaCache;
+
+	private DelegatingTypeProvider(
+			final WorkspaceClient client,
+			final int typeCacheTimeMS,
+			final int typeCacheMaxSize,
+			final int jsonschemaCacheMaxSize,
+			final Ticker cacheTicker,
+			final boolean evictionsOnCurrentThread) {
+		this.client = requireNonNull(client);
+		// TODO JAVA11 upgrade Caffeine to v3.x after dumping java 8
+		final Caffeine<String, String> tb = Caffeine.newBuilder()
+				.expireAfterWrite(typeCacheTimeMS, TimeUnit.MILLISECONDS)
+				.maximumWeight(typeCacheMaxSize)
+				.weigher((String k, String v) ->  utf16Bytes(k) + utf16Bytes(v))
+				.ticker(cacheTicker);
+		// converting to byte saves 2x memory costs over char[]/string for ascii if we use utf8
+		// encoding, since java uses utf16.
+		final Caffeine<String, byte[]> jb = Caffeine.newBuilder()
+				.maximumWeight(jsonschemaCacheMaxSize)
+				.weigher((String k, byte[] v) -> utf16Bytes(k) + v.length);
+		if (evictionsOnCurrentThread) {
+			tb.executor(runnable -> runnable.run());
+			jb.executor(runnable -> runnable.run());
+		}
+		typeCache = tb.build();
+		jsonSchemaCache = jb.build();
+	}
+	
+	private int utf16Bytes(final String s) {
+		// memory inefficient but only expected to be used on tiny strings. Use a counting stream
+		// if needed
+		return s.getBytes(UTF_16).length;
+	}
+
+	@Override
+	public ResolvedType getTypeJsonSchema(final TypeDefId typeDefId)
+			throws NoSuchTypeException, NoSuchModuleException, TypeFetchException {
+		final String abstype;
+		if (requireNonNull(typeDefId, "typeDefId").isAbsolute()) {
+			abstype = typeDefId.getTypeString();
+		} else {
+			// populates the jsonschema cache as well as the type cache
+			abstype = resolveType(typeDefId);
+		}
+		return getJsonSchema(abstype);
+	}
+	
+	private static class GodDammitWrapper extends RuntimeException {
+		private static final long serialVersionUID = 1L;
+
+		public GodDammitWrapper(final Throwable cause) {
+			super(cause);
+		}
+	}
+	
+	private String resolveType(final TypeDefId type)
+			throws NoSuchModuleException, NoSuchTypeException, TypeFetchException {
+		try {
+			return typeCache.get(
+					type.getTypeString(),
+					typestr -> {
+						final TypeInfo ti = getTypeInfo(typestr);
+						final byte[] jsonschema = ti.getJsonSchema().getBytes(UTF_8);
+						getJsonSchema(ti.getTypeDef(), jsonschema); // populate jsonschema cache
+						return ti.getTypeDef();
+					});
+		} catch (GodDammitWrapper e) {
+			handleException(e);
+			return null; // impossible to get here but codecov will whine just the same
+		}
+	}
+
+	private ResolvedType getJsonSchema(final String absoluteType)
+			throws TypeFetchException, NoSuchTypeException, NoSuchModuleException {
+		final byte[] jsonSchema;
+		try {
+			jsonSchema = getJsonSchema(absoluteType, null);
+		} catch (GodDammitWrapper e) {
+			handleException(e);
+			return null; // impossible to get here but codecov will whine just the same
+		}
+		return new ResolvedType(
+				AbsoluteTypeDefId.fromAbsoluteTypeString(absoluteType),
+				new String(jsonSchema, UTF_8));
+	}
+	
+	private byte[] getJsonSchema(
+			final String absoluteType,
+			final byte[] incomingJSONSchema)
+			throws GodDammitWrapper {
+		return jsonSchemaCache.get(
+				absoluteType,
+				abstype -> {
+					if (incomingJSONSchema != null) {
+						return incomingJSONSchema;
+					}
+					final TypeInfo ti = getTypeInfo(abstype);
+					// TODO NOW update type cache if prefix types are present and < current type
+					return ti.getJsonSchema().getBytes(UTF_8);
+				});
+	}
+
+	private void handleException(final GodDammitWrapper e)
+			throws NoSuchModuleException, NoSuchTypeException, TypeFetchException {
+		if (e.getCause() instanceof NoSuchModuleException) {
+			throw (NoSuchModuleException) e.getCause();
+		}
+		if (e.getCause() instanceof NoSuchTypeException) {
+			throw (NoSuchTypeException) e.getCause();
+		}
+		throw (TypeFetchException) e.getCause();
+	}
+
+	private TypeInfo getTypeInfo(final String type) throws GodDammitWrapper {
+		try {
+			return client.getTypeInfo(type);
+		} catch (ServerException e) {
+			if ( // error codes would be nice
+					e.getMessage().contains("Module doesn't exist: ") ||
+					e.getMessage().contains("was not initialized. For") ||
+					e.getMessage().contains("Module wasn't uploaded: ")
+					) {
+				throw new GodDammitWrapper(new NoSuchModuleException(e.getMessage(), e));
+			}
+			if (
+					e.getMessage().contains("This type wasn't released yet") ||
+					e.getMessage().contains("Unable to locate type: ")
+					) {
+				throw new GodDammitWrapper(new NoSuchTypeException(e.getMessage(), e));
+			}
+			// ew. Don't want the SE data (e.g. server side stack trace) in the message, but
+			// don't want to lose it either.
+			// This is the best I could come up with, maybe there's a better way
+			throw new GodDammitWrapper(new TypeFetchException(
+					"Failed retrieving type info from remote type database: " + e.getMessage(),
+					new TypeFetchException(e.getData(), e)));
+		} catch (IOException | JsonClientException e) {
+			throw new GodDammitWrapper(new TypeFetchException(
+					"Failed retrieving type info from remote type database: " +
+					e.getMessage(), e));
+		}
+	}
+
+	/** Create a builder for a {@link DelegatingTypeProvider}.
+	 * @param client a client pointing at the workspace to which type queries should be delegated.
+	 * @return the builder.
+	 */
+	public static Builder getBuilder(final WorkspaceClient client) {
+		return new Builder(client);
+	}
+	
+	/** A builder for a {@link DelegatingTypeProvider}. */
+	public static class Builder {
+		
+		private final WorkspaceClient client;
+		private int typeCacheTimeMS = DEFAULT_TYPE_CACHE_TIME_MS;
+		private int typeCacheMaxSize = DEFAULT_TYPE_CACHE_MAX_SIZE;
+		private int jsonschemaCacheMaxSize = DEFAULT_JSONSCHEMA_CACHE_MAX_SIZE;
+		private Ticker cacheTicker = Ticker.systemTicker();
+		private boolean evictionsOnCurrentThread = false;
+
+		private Builder(final WorkspaceClient client) {
+			this.client = requireNonNull(client, "client");
+		}
+		
+		/** Set the amount of time an entry in the non-absolute to absolute type cache should
+		 * remain in milliseconds. Typically is this a small amount of time to that type updates
+		 * are reflected reasonably quickly.
+		 * @param typeCacheTimeMS the cache expiration time in milliseconds defaulting to
+		 * {@link DelegatingTypeProvider#DEFAULT_TYPE_CACHE_TIME_MS}.
+		 * @return this builder.
+		 */
+		public Builder withTypeCacheTimeMS(final int typeCacheTimeMS) {
+			this.typeCacheTimeMS = gt(typeCacheTimeMS, 0, "typeCacheTimeMS");
+			return this;
+		}
+		
+		/** Set the maximum size of the non-absolute to absolute type mapping cache in bytes.
+		 * Mapping sizes are calculated as sum of the Java UTF-16 encoding size of the
+		 * non-absolute type string and absolute type string. References, etc. are not
+		 * accounted for.
+		 * @param typeCacheMaxSize the maximum cache size, defaulting to
+		 * {@link DelegatingTypeProvider#DEFAULT_TYPE_CACHE_MAX_SIZE}
+		 * @return this builder.
+		 */
+		public Builder withTypeCacheMaxSize(final int typeCacheMaxSize) {
+			this.typeCacheMaxSize = gt(typeCacheMaxSize, 0, "typeCacheMaxSize");
+			return this;
+		}
+
+		/** Set the maximum size of the absolute type to JSONschema mapping cache in bytes.
+		 * Mapping sizes are calculated as sum of the Java UTF-16 encoding size of the absolute
+		 * type string and the size of the UTF-8 encoded JSON schema. References, etc. are not
+		 * accounted for.
+		 * 
+		 * The size must be at least
+		 * {@link DelegatingTypeProvider#DEFAULT_JSONSCHEMA_CACHE_MAX_SIZE} as the caching
+		 * logic depends on the jsonschema cache being populated.
+		 * @param jsonschemaCacheMaxSize the maximum cache size, defaulting to
+		 * {@link DelegatingTypeProvider#DEFAULT_JSONSCHEMA_CACHE_MAX_SIZE}.
+		 * @return this builder.
+		 */
+		public Builder withJsonSchemaCacheMaxSize(final int jsonschemaCacheMaxSize) {
+			this.jsonschemaCacheMaxSize = gt(jsonschemaCacheMaxSize,
+					DEFAULT_JSONSCHEMA_CACHE_MAX_SIZE, "jsonschemaCacheMaxSize");
+			return this;
+		}
+		
+		/** Set the ticker for the non-absolute to absolute type cache; generally only useful
+		 * for testing purposes.
+		 * @param ticker the ticker. Null input is silently ignored.
+		 * @return this builder.
+		 */
+		public Builder withCacheTicker(final Ticker ticker) {
+			if (ticker != null) {
+				this.cacheTicker = ticker;
+			}
+			return this;
+		}
+
+		/** If true, cache evictions will be performed on the current thread rather than
+		 * asynchronously. Only use this setting for testing.
+		 * @param sync true to run cache evictions on the current thread. 
+		 * @return this builder.
+		 */
+		public Builder withRunCacheEvictionsOnCurrentThread(final boolean sync) {
+			this.evictionsOnCurrentThread = sync;
+			return this;
+		}
+		
+		private int gt(final int num, final int min, final String name) {
+			if (num < min) {
+				throw new IllegalArgumentException(name + " must be >= " + min);
+			}
+			return num;
+		}
+		
+		/** Build the {@link DelegatingTypeProvider}.
+		 * @return the type provider.
+		 */
+		public DelegatingTypeProvider build() {
+			return new DelegatingTypeProvider(client, typeCacheTimeMS, typeCacheMaxSize,
+					jsonschemaCacheMaxSize, cacheTicker, evictionsOnCurrentThread);
+		}
+	}
+	
+/* APPENDIX: Production info on JSONSchema sizes for cache sizing
+ * Retrieved from KBase production on 2022/4/23
+ * 
+$ ipython
+In [1]: from biokbase.workspace.client import Workspace
+In [2]: wsurl = 'https://kbase.us/services/ws'
+In [3]: ws = Workspace(wsurl)
+In [4]: sizes = {}
+In [5]: for mod in ws.list_all_types({}).keys():
+   ...:     types = ws.get_all_type_info(mod)
+   ...:     for typ in types:
+   ...:         for typever in typ['type_vers']:
+   ...:             print(typever)
+   ...:             sizes[typever] = len(ws.get_jsonschema(typever))
+   ...:
+BAMBI.BambiRunResult-1.0
+
+*snip*
+
+ProbabilisticAnnotation.RxnProbs-1.0
+
+In [6]: len(sizes)
+Out[6]: 581
+
+In [7]: sum(sizes.values())
+Out[7]: 4198723
+
+In [10]: import statistics as stats
+
+In [11]: stats.mean(sizes.values())
+Out[11]: 7226.717728055078
+
+In [12]: stats.median(sizes.values())
+Out[12]: 3764
+
+In [13]: stats.pstdev(sizes.values())
+Out[13]: 8793.704647534383
+
+In [19]: max(sizes.items(), key=lambda i: i[1])
+Out[19]: ('KBaseFBA.FBAModel-13.0', 58560)
+
+In [20]: min(sizes.items(), key=lambda i: i[1])
+Out[20]: ('KBaseNarrative.Metadata-1.0', 112)
+
+In [23]: sum([len(k) for k in sizes.keys()])
+Out[23]: 16744
+
+In [24]: max([len(k) for k in sizes.keys()])
+Out[24]: 51
+
+In [25]: min([len(k) for k in sizes.keys()])
+Out[25]: 14
+
+ */
+
+}

--- a/src/us/kbase/workspace/test/kbase/DelegatingTypeProviderTest.java
+++ b/src/us/kbase/workspace/test/kbase/DelegatingTypeProviderTest.java
@@ -1,0 +1,487 @@
+package us.kbase.workspace.test.kbase;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static us.kbase.common.test.TestCommon.list;
+import static us.kbase.common.test.TestCommon.LONG1001;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.github.benmanes.caffeine.cache.Ticker;
+
+import org.junit.Test;
+
+import us.kbase.common.service.JsonClientException;
+import us.kbase.common.service.ServerException;
+import us.kbase.common.test.TestCommon;
+import us.kbase.typedobj.core.AbsoluteTypeDefId;
+import us.kbase.typedobj.core.TypeDefId;
+import us.kbase.typedobj.core.TypeProvider.ResolvedType;
+import us.kbase.typedobj.core.TypeProvider.TypeFetchException;
+import us.kbase.typedobj.exceptions.NoSuchModuleException;
+import us.kbase.typedobj.exceptions.NoSuchTypeException;
+import us.kbase.workspace.TypeInfo;
+import us.kbase.workspace.WorkspaceClient;
+import us.kbase.workspace.kbase.DelegatingTypeProvider;
+
+public class DelegatingTypeProviderTest {
+
+	@Test
+	public void constants() throws Exception {
+		assertThat("incorrect type cache time",
+				DelegatingTypeProvider.DEFAULT_TYPE_CACHE_TIME_MS, is(300000));
+		assertThat("incorrect type cache size",
+				DelegatingTypeProvider.DEFAULT_TYPE_CACHE_MAX_SIZE, is(131072));
+		assertThat("incorrect jsonschema cache size",
+				DelegatingTypeProvider.DEFAULT_JSONSCHEMA_CACHE_MAX_SIZE, is(1048576));
+	}
+	
+	private class FakeTicker implements Ticker {
+
+		private final AtomicLong nanos = new AtomicLong();
+
+		public FakeTicker advance(long nanoseconds) {
+			nanos.addAndGet(nanoseconds);
+			return this;
+		}
+
+		@Override
+		public long read() {
+			return nanos.get();
+		}
+	}
+	
+	// #### Cacheless tests ####
+	
+	private static class TestMocks {
+		private final WorkspaceClient ws;
+		private final DelegatingTypeProvider p;
+		private final FakeTicker t;
+
+		public TestMocks(
+				final WorkspaceClient ws,
+				final DelegatingTypeProvider p,
+				final FakeTicker t) {
+			this.ws = ws;
+			this.p = p;
+			this.t = t;
+		}
+	}
+	
+	private Exception failGetJsonSchema(
+			final DelegatingTypeProvider p,
+			final TypeDefId type,
+			final Exception expected) {
+		try {
+			p.getTypeJsonSchema(type);
+			fail("expected exception");
+			return null;
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+			return got;
+		}
+	}
+	
+	private TestMocks initMocks() {
+		return initMocks(0, 0, 1024 * 1024);
+	}
+	
+	private TestMocks initMocks(
+			final int typeCacheTimeMS,
+			final int typeCacheSize,
+			final int jsonSchemaCacheSize) {
+		return initMocks(typeCacheTimeMS, typeCacheSize, jsonSchemaCacheSize, false);
+	}
+	
+	private TestMocks initMocks(
+			final int typeCacheTimeMS,
+			final int typeCacheSize,
+			final int jsonSchemaCacheSize,
+			final boolean evictSynchronously) {
+		return _initMocks(typeCacheTimeMS, typeCacheSize, jsonSchemaCacheSize, new FakeTicker(),
+				evictSynchronously);
+	}
+	
+	private TestMocks _initMocks(
+			final int typeCacheTimeMS,
+			final int typeCacheSize,
+			final int jsonSchemaCacheSize,
+			final FakeTicker ticker,
+			final boolean evictSynchronously) {
+		final WorkspaceClient cli = mock(WorkspaceClient.class);
+		
+		final DelegatingTypeProvider dtp = DelegatingTypeProvider.getBuilder(cli)
+				.withJsonSchemaCacheMaxSize(jsonSchemaCacheSize)
+				.withTypeCacheMaxSize(typeCacheSize)
+				.withTypeCacheTimeMS(typeCacheTimeMS)
+				.withCacheTicker(ticker)
+				.withRunCacheEvictionsOnCurrentThread(evictSynchronously)
+				.build();
+		return new TestMocks(cli, dtp, ticker);
+	}
+	
+	private TypeDefId type(final String type) {
+		return TypeDefId.fromTypeString(type);
+	}
+	
+	private AbsoluteTypeDefId atype(final String type) {
+		return AbsoluteTypeDefId.fromAbsoluteTypeString(type);
+	}
+	
+	@Test
+	public void getJsonSchemaForNonAbsoluteType() throws Exception {
+		final TestMocks m = initMocks();
+		
+		when(m.ws.getTypeInfo("Foo.Bar-6")).thenReturn(
+				new TypeInfo()
+					.withJsonSchema("jsonschema here")
+					.withTypeDef("Foo.Bar-6.3"),
+				(TypeInfo) null); // ensure only called once
+		assertThat(m.p.getTypeJsonSchema(type("Foo.Bar-6")),
+				is(new ResolvedType(atype("Foo.Bar-6.3"), "jsonschema here")));
+	}
+	
+	@Test
+	public void getJsonSchemaForAbsoluteType() throws Exception {
+		final TestMocks m = initMocks();
+		
+		when(m.ws.getTypeInfo("Foo.Bar-6.2")).thenReturn(
+				new TypeInfo()
+					.withJsonSchema("jsonschema here")
+					.withTypeDef("Foo.Bar-6.2"),
+				(TypeInfo) null); // ensure only called once
+		
+		assertThat(m.p.getTypeJsonSchema(type("Foo.Bar-6.2")),
+				is(new ResolvedType(atype("Foo.Bar-6.2"), "jsonschema here")));
+	}
+	
+	// #### Build error tests ####
+	
+	@Test
+	public void getBuilderFail() throws Exception {
+		try {
+			DelegatingTypeProvider.getBuilder(null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("client"));
+		}
+	}
+	
+	@Test
+	public void withTypeCacheTimeMSFail() throws Exception {
+		final WorkspaceClient c = mock(WorkspaceClient.class);
+		for (final int time: list(-1, -100, -1000000000)) {
+			try {
+				DelegatingTypeProvider.getBuilder(c).withTypeCacheTimeMS(time);
+				fail("expected exception");
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+						"typeCacheTimeMS must be >= 0"));
+			}
+		}
+	}
+	
+	@Test
+	public void withTypeCacheMaxSizeFail() throws Exception {
+		final WorkspaceClient c = mock(WorkspaceClient.class);
+		for (final int size: list(-1, -100, -1000000000)) {
+			try {
+				DelegatingTypeProvider.getBuilder(c).withTypeCacheMaxSize(size);
+				fail("expected exception");
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+						"typeCacheMaxSize must be >= 0"));
+			}
+		}
+	}
+	
+	@Test
+	public void withJsonSchemaCacheMaxSizeFail() throws Exception {
+		final WorkspaceClient c = mock(WorkspaceClient.class);
+		for (final int size: list(1024 * 1024 - 1, 1000000, 100, 0, -1, -100, -1000000000)) {
+			try {
+				DelegatingTypeProvider.getBuilder(c).withJsonSchemaCacheMaxSize(size);
+				fail("expected exception");
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+						"jsonschemaCacheMaxSize must be >= 1048576"));
+			}
+		}
+	}
+	
+	// #### Type fetch error tests ####
+	
+	@Test
+	public void getJsonSchemaFailNoSuchModule() throws Exception {
+		// test with absolute & non-absolute types
+		for (final String type: list("Foo.Baz-32", "Foo.Baz-32.19")) {
+			final List<String> errors = list(
+					"Module doesn't exist: Foo",
+					"Module Foo was not initialized. For that you must request ownership of the "
+							+ "module, and your request must be approved.",
+					"Module wasn't uploaded: Foo"
+					);
+			for (final String err: errors) {
+				final TestMocks m = initMocks();
+				when(m.ws.getTypeInfo(type)).thenThrow(
+						new ServerException(err, 1, "somename", "stack\ntrace\nlline 1: i++"));
+				final Exception got = failGetJsonSchema(
+						m.p, TypeDefId.fromTypeString(type),
+						new NoSuchModuleException(err));
+				TestCommon.assertExceptionCorrect(
+						got.getCause(), new ServerException(err, 1, "somename"));
+			}
+		}
+	}
+	
+	@Test
+	public void getJsonSchemaForNonAbsoluteTypeFailNoSuchType() throws Exception {
+		// test with absolute & non-absolute types
+		for (final String type: list("Foo.Baz-32", "Foo.Baz-32.19")) {
+			final List<String> errors = list(
+					"This type wasn't released yet and you should be an owner to access "
+							+ "unreleased version information",
+					"Unable to locate type: Foo.Baz"
+					);
+			for (final String err: errors) {
+				final TestMocks m = initMocks();
+				when(m.ws.getTypeInfo(type)).thenThrow(
+						new ServerException(err, 1, "somename", "stack\ntrace\nlline 1: i++"));
+				final Exception got = failGetJsonSchema(m.p, TypeDefId.fromTypeString(type),
+						new NoSuchTypeException(err));
+				TestCommon.assertExceptionCorrect(
+						got.getCause(), new ServerException(err, 1, "somename"));
+			}
+		}
+	}
+	
+	@Test
+	public void getJsonSchemaForNonAbsoluteTypeFailServerException() throws Exception {
+		// test with absolute & non-absolute types
+		for (final String type: list("Foo.Baz-32", "Foo.Baz-32.19")) {
+			final TestMocks m = initMocks();
+			when(m.ws.getTypeInfo(type)).thenThrow(
+					new ServerException("aw crap", 1, "somename", "stack\ntrace\nlline 1: i++"));
+			final Exception got = failGetJsonSchema(m.p, TypeDefId.fromTypeString(type),
+					new TypeFetchException("Failed retrieving type info from remote type "
+							+ "database: aw crap"));
+			TestCommon.assertExceptionCorrect(
+					got.getCause(), new TypeFetchException("stack\ntrace\nlline 1: i++"));
+			TestCommon.assertExceptionCorrect(
+						got.getCause().getCause(), new ServerException("aw crap", 1, "somename"));
+		}
+	}
+	
+	@Test
+	public void getJsonSchemaForNonAbsoluteTypeFailIOException() throws Exception {
+		// test with absolute & non-absolute types
+		for (final String type: list("Foo.Baz-32", "Foo.Baz-32.19")) {
+			final TestMocks m = initMocks();
+			when(m.ws.getTypeInfo(type)).thenThrow(new IOException("poop"));
+			final Exception got = failGetJsonSchema(m.p, TypeDefId.fromTypeString(type),
+					new TypeFetchException("Failed retrieving type info from remote type "
+							+ "database: poop"));
+			TestCommon.assertExceptionCorrect(got.getCause(), new IOException("poop"));
+		}
+	}
+	
+	@Test
+	public void getJsonSchemaForNonAbsoluteTypeFailJsonClientException() throws Exception {
+		// test with absolute & non-absolute types
+		for (final String type: list("Foo.Baz-32", "Foo.Baz-32.19")) {
+			final TestMocks m = initMocks();
+			when(m.ws.getTypeInfo(type)).thenThrow(new JsonClientException("dang bruh"));
+			final Exception got = failGetJsonSchema(m.p, TypeDefId.fromTypeString(type),
+					new TypeFetchException("Failed retrieving type info from remote type "
+							+ "database: dang bruh"));
+			TestCommon.assertExceptionCorrect(
+					got.getCause(), new JsonClientException("dang bruh"));
+		}
+	}
+	
+	// #### Cache invalidation tests ####
+	
+	@Test
+	public void typeCacheEvictOnTime() throws Exception {
+		final TestMocks m = initMocks(5, 1000000, 1024*1024);
+		
+		when(m.ws.getTypeInfo("Foo.Bar-6")).thenReturn(
+				new TypeInfo()
+					.withTypeDef("Foo.Bar-6.3")
+					.withJsonSchema("jsonschema here"),
+				new TypeInfo()
+					.withTypeDef("Foo.Bar-6.4")
+					.withJsonSchema("jsonschema v2 here")
+					);
+		when(m.ws.getTypeInfo("Foo.Baz-2")).thenReturn(
+				new TypeInfo()
+					.withTypeDef("Foo.Baz-2.1")
+					.withJsonSchema("other jsonschema here"),
+				(TypeInfo) null // ensure only called once
+				);
+		
+		assertThat(m.p.getTypeJsonSchema(type("Foo.Bar-6")),
+				is(new ResolvedType(atype("Foo.Bar-6.3"), "jsonschema here")));
+		m.t.advance(1); // anything called after this won't expire in this test
+		assertThat(m.p.getTypeJsonSchema(type("Foo.Baz-2")),
+				is(new ResolvedType(atype("Foo.Baz-2.1"), "other jsonschema here")));
+		m.t.advance(4999998);
+		assertThat(m.p.getTypeJsonSchema(type("Foo.Bar-6")),
+				is(new ResolvedType(atype("Foo.Bar-6.3"), "jsonschema here")));
+		assertThat(m.p.getTypeJsonSchema(type("Foo.Baz-2")),
+				is(new ResolvedType(atype("Foo.Baz-2.1"), "other jsonschema here")));
+		m.t.advance(1);
+		assertThat(m.p.getTypeJsonSchema(type("Foo.Bar-6")),
+				is(new ResolvedType(atype("Foo.Bar-6.4"), "jsonschema v2 here")));
+		assertThat(m.p.getTypeJsonSchema(type("Foo.Baz-2")),
+				is(new ResolvedType(atype("Foo.Baz-2.1"), "other jsonschema here")));
+		
+		verify(m.ws, times(2)).getTypeInfo("Foo.Bar-6");
+	}
+	
+	@Test
+	public void typeCacheEvictOnWeight() throws Exception {
+		// The cache uses the Window TinyFLU eviction algorithm which makes it pretty
+		// hard to test, see https://9vx.org/post/on-window-tinylfu/
+
+		// Type names cannot have non-ASCII chars, so no 4 byte UTF-16 characters are possible
+		final TestMocks m = initMocks(1000000, 80, 1024*1024, true);
+		// Note that the weight is the length of the keys in chars * 2 since in memory strings
+		// are stored in UTF-16
+		
+		when(m.ws.getTypeInfo("Fo.Bar-6")).thenReturn(
+				new TypeInfo()
+					.withTypeDef("Fo.Bar-6.3")
+					.withJsonSchema("jsonschema 1 here"),
+				new TypeInfo()
+					.withTypeDef("Fo.Bar-6.4")
+					.withJsonSchema("jsonschema 1.1 here")
+					);
+		when(m.ws.getTypeInfo("Fo.Bas-2")).thenReturn(
+				new TypeInfo()
+					.withTypeDef("Fo.Bas-2.1")
+					.withJsonSchema("jsonschema 2 here"),
+				(TypeInfo) null); // only called once
+		final TypeInfo ti = new TypeInfo()
+				.withTypeDef("Fo.Bat-1.7")
+				.withJsonSchema("jsonschema 3 here");
+		final TypeInfo ti2 = new TypeInfo()
+				.withTypeDef("Fo.Bat-1.9")
+				.withJsonSchema("jsonschema 3.1 here");
+		when(m.ws.getTypeInfo("Fo.Bat-1")).thenReturn(ti, ti, ti2);
+		
+		// the cache eviction policy is not strict LRU, it also takes frequency into account,
+		// so we have to do a bit of wrangling to get the evictions we want
+		assertThat(m.p.getTypeJsonSchema(type("Fo.Bar-6")),
+				is(new ResolvedType(atype("Fo.Bar-6.3"), "jsonschema 1 here")));
+		assertThat(m.p.getTypeJsonSchema(type("Fo.Bas-2")),
+				is(new ResolvedType(atype("Fo.Bas-2.1"), "jsonschema 2 here")));
+		// cache should now be full
+		assertThat(m.p.getTypeJsonSchema(type("Fo.Bar-6")),
+				is(new ResolvedType(atype("Fo.Bar-6.3"), "jsonschema 1 here")));
+		assertThat(m.p.getTypeJsonSchema(type("Fo.Bas-2")),
+				is(new ResolvedType(atype("Fo.Bas-2.1"), "jsonschema 2 here")));
+		
+		assertThat(m.p.getTypeJsonSchema(type("Fo.Bat-1")),
+				is(new ResolvedType(atype("Fo.Bat-1.7"), "jsonschema 3 here")));
+		// call multiple times to handle immediate frequency based eviction and evict 1st entry
+		assertThat(m.p.getTypeJsonSchema(type("Fo.Bat-1")),
+				is(new ResolvedType(atype("Fo.Bat-1.7"), "jsonschema 3 here")));
+		assertThat(m.p.getTypeJsonSchema(type("Fo.Bar-6")),
+				is(new ResolvedType(atype("Fo.Bar-6.4"), "jsonschema 1.1 here")));
+		// call multiple times to evict 3rd entry
+		// that 2nd entry is really stuck in there
+		assertThat(m.p.getTypeJsonSchema(type("Fo.Bar-6")),
+				is(new ResolvedType(atype("Fo.Bar-6.4"), "jsonschema 1.1 here")));
+		assertThat(m.p.getTypeJsonSchema(type("Fo.Bar-6")),
+				is(new ResolvedType(atype("Fo.Bar-6.4"), "jsonschema 1.1 here")));
+		
+		assertThat(m.p.getTypeJsonSchema(type("Fo.Bat-1")),
+				is(new ResolvedType(atype("Fo.Bat-1.9"), "jsonschema 3.1 here")));
+		
+		// I'm not really sure I understand what's going on here but it does show the cache
+		// is being updated and entries are getting evicted which is the main
+		// thing
+	}
+	
+	@Test
+	public void jsonSchemaCacheEvictOnWeight() throws Exception {
+		// See the notes for the type cash test above. Testing cache eviction here is
+		// difficult to do without a really clear understanding of the cache eviction algorithm
+		// which is pretty complex and is not worth the time to get my head around right now
+		
+		// the relative -> absolute type cache never evicts for this test
+		final TestMocks m = initMocks(1000000, 10000000, 1200000, true);
+		
+		final String s1000 = LONG1001.substring(0, LONG1001.length() - 1);
+		final String s100000 = lngstr(s1000, 100);
+		final String s399980 = lngstr(s100000, 4).substring(0, 399980);
+		final String s399980mod = s399980.substring(0, 399979) + "1";
+		final String s599980 = lngstr(s100000, 6).substring(0, 599980);
+		final String s599980mod = s599980.substring(0, 599979) + "1";
+		final String s199981 = lngstr(s100000, 2).substring(0, 199981);
+		
+		when(m.ws.getTypeInfo("Wo.We-7")).thenReturn(
+				new TypeInfo()
+					.withTypeDef("Wo.We-7.1")
+					.withJsonSchema(s399980)
+					);
+		when(m.ws.getTypeInfo("Wo.We-7.1")).thenReturn(
+				new TypeInfo()
+					.withTypeDef("Wo.We-7.1")
+					// this should never happen in practice but we change the jsonschmea for
+					// testing purposes
+					.withJsonSchema(s399980mod)
+					);
+		when(m.ws.getTypeInfo("Wo.Wx-2")).thenReturn(
+				new TypeInfo()
+					.withTypeDef("Wo.Wx-2.7")
+					.withJsonSchema(s599980)
+					);
+		when(m.ws.getTypeInfo("Wo.Wx-2.7")).thenReturn(
+				new TypeInfo()
+					.withTypeDef("Wo.Wx-2.7")
+					.withJsonSchema(s599980mod)
+					);
+		when(m.ws.getTypeInfo("Wo.Wz-9")).thenReturn(
+				new TypeInfo()
+					.withTypeDef("Wo.Wz-9.3")
+					.withJsonSchema(s199981)
+					);
+		
+		assertThat(m.p.getTypeJsonSchema(type("Wo.We-7")),
+				is(new ResolvedType(atype("Wo.We-7.1"), s399980)));
+		assertThat(m.p.getTypeJsonSchema(type("Wo.Wx-2")),
+				is(new ResolvedType(atype("Wo.Wx-2.7"), s599980)));
+		// adding any more items will cause an eviction
+		assertThat(m.p.getTypeJsonSchema(type("Wo.We-7")),
+				is(new ResolvedType(atype("Wo.We-7.1"), s399980)));
+		assertThat(m.p.getTypeJsonSchema(type("Wo.Wx-2")),
+				is(new ResolvedType(atype("Wo.Wx-2.7"), s599980)));
+		
+		assertThat(m.p.getTypeJsonSchema(type("Wo.Wz-9")),
+				is(new ResolvedType(atype("Wo.Wz-9.3"), s199981)));
+		// first entry is evicted at this point
+		assertThat(m.p.getTypeJsonSchema(type("Wo.We-7")),
+				is(new ResolvedType(atype("Wo.We-7.1"), s399980mod)));
+		// 2nd entry is evicted at this point
+		assertThat(m.p.getTypeJsonSchema(type("Wo.Wx-2")),
+				is(new ResolvedType(atype("Wo.Wx-2.7"), s599980mod)));
+	}
+	
+	private String lngstr(final String s, final int reps) {
+		final StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < reps; i++) {
+			sb.append(s);
+		}
+		return sb.toString();
+	}
+	
+}

--- a/src/us/kbase/workspace/version/WorkspaceVersion.java
+++ b/src/us/kbase/workspace/version/WorkspaceVersion.java
@@ -3,6 +3,8 @@ package us.kbase.workspace.version;
 /** The version of the workspace code. */
 public class WorkspaceVersion {
 	
+	private WorkspaceVersion() {};
+	
 	/** The version. */
 	public static final String VERSION = "0.13.2-dev1";
 


### PR DESCRIPTION
for the type validator.

There's a bug in the caching strategy wherein providing an absolute type id could return a newer type than providing a non-absolute type id for the same type, which shouldn't happen. The next PR will fix that bug as this PR is really large already and it'll require more code and more tests.