### PR TITLE
PTV-1786: Simplify type operation delegation part 1/2

### DIFF
--- a/src/us/kbase/workspace/kbase/DelegatingTypeServerMethods.java
+++ b/src/us/kbase/workspace/kbase/DelegatingTypeServerMethods.java
@@ -18,7 +18,6 @@ import us.kbase.workspace.RegisterTypespecCopyParams;
 import us.kbase.workspace.RegisterTypespecParams;
 import us.kbase.workspace.RemoveModuleOwnershipParams;
 import us.kbase.workspace.TypeInfo;
-import us.kbase.workspace.kbase.WorkspaceDelegator.WorkspaceDelegationException;
 
 /** An implementation of the type service methods that delegate to another workspace service.
  * Note that any asAdmin param toggles are ignored - administration methods should be delegated
@@ -40,7 +39,7 @@ public class DelegatingTypeServerMethods implements TypeServerMethods {
 			final GrantModuleOwnershipParams params,
 			final AuthToken token,
 			final boolean asAdmin) // admin methods should not call this when delegating
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		delegator.delegate(token, c -> {c.grantModuleOwnership(params); return null;});
 	}
 
@@ -49,13 +48,13 @@ public class DelegatingTypeServerMethods implements TypeServerMethods {
 			final RemoveModuleOwnershipParams params,
 			final AuthToken token,
 			final boolean asAdmin) // admin methods should not call this when delegating
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		delegator.delegate(token, c -> {c.removeModuleOwnership(params); return null;});
 	}
 
 	@Override
 	public void requestModuleOwnership(final String mod, final AuthToken token)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		delegator.delegate(token, c -> {c.requestModuleOwnership(mod); return null;});
 	}
 
@@ -63,7 +62,7 @@ public class DelegatingTypeServerMethods implements TypeServerMethods {
 	public Map<String, String> registerTypespec(
 			final RegisterTypespecParams params,
 			final AuthToken token)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		return delegator.delegate(token, c -> c.registerTypespec(params));
 	}
 
@@ -71,19 +70,19 @@ public class DelegatingTypeServerMethods implements TypeServerMethods {
 	public Long registerTypespecCopy(
 			final RegisterTypespecCopyParams params,
 			final AuthToken token)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		return delegator.delegate(token, c -> c.registerTypespecCopy(params));
 	}
 
 	@Override
 	public List<String> releaseModule(final String mod, final AuthToken token)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		return delegator.delegate(token, c -> c.releaseModule(mod));
 	}
 
 	@Override
 	public List<String> listModules(final ListModulesParams params)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		return delegator.delegate(null, c -> c.listModules(params));
 	}
 
@@ -91,7 +90,7 @@ public class DelegatingTypeServerMethods implements TypeServerMethods {
 	public ModuleVersions listModuleVersions(
 			final ListModuleVersionsParams params,
 			final AuthToken token)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		return delegator.delegate(token, c -> c.listModuleVersions(params));
 	}
 
@@ -99,19 +98,19 @@ public class DelegatingTypeServerMethods implements TypeServerMethods {
 	public ModuleInfo getModuleInfo(
 			final GetModuleInfoParams params,
 			final AuthToken token)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		return delegator.delegate(token, c -> c.getModuleInfo(params));
 	}
 
 	@Override
 	public String getJsonschema(final String type, final AuthToken token)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		return delegator.delegate(token, c -> c.getJsonschema(type));
 	}
 
 	@Override
 	public Map<String, List<String>> translateFromMD5Types(final List<String> md5Types)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		return delegator.delegate(null, c -> c.translateFromMD5Types(md5Types));
 	}
 
@@ -119,31 +118,31 @@ public class DelegatingTypeServerMethods implements TypeServerMethods {
 	public Map<String, String> translateToMD5Types(
 			final List<String> semTypes,
 			final AuthToken token)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		return delegator.delegate(token, c -> c.translateToMD5Types(semTypes));
 	}
 
 	@Override
 	public TypeInfo getTypeInfo(final String type, final AuthToken token)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		return delegator.delegate(token, c -> c.getTypeInfo(type));
 	}
 
 	@Override
 	public List<TypeInfo> getAllTypeInfo(final String mod, final AuthToken token)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		return delegator.delegate(token, c -> c.getAllTypeInfo(mod));
 	}
 
 	@Override
 	public FuncInfo getFuncInfo(final String func, final AuthToken token)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		return delegator.delegate(token, c -> c.getFuncInfo(func));
 	}
 
 	@Override
 	public List<FuncInfo> getAllFuncInfo(final String mod, final AuthToken token)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		return delegator.delegate(token, c -> c.getAllFuncInfo(mod));
 	}
 
@@ -151,7 +150,7 @@ public class DelegatingTypeServerMethods implements TypeServerMethods {
 	public Map<String, Map<String, String>> listAllTypes(
 			final ListAllTypesParams params,
 			final AuthToken token)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		return delegator.delegate(token, c -> c.listAllTypes(params));
 	}
 

--- a/src/us/kbase/workspace/kbase/TypeClient.java
+++ b/src/us/kbase/workspace/kbase/TypeClient.java
@@ -1,0 +1,254 @@
+package us.kbase.workspace.kbase;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import us.kbase.auth.AuthToken;
+import us.kbase.common.service.JsonClientException;
+import us.kbase.common.service.ServerException;
+import us.kbase.common.service.UObject;
+import us.kbase.common.service.UnauthorizedException;
+import us.kbase.workspace.FuncInfo;
+import us.kbase.workspace.GetModuleInfoParams;
+import us.kbase.workspace.GrantModuleOwnershipParams;
+import us.kbase.workspace.ListAllTypesParams;
+import us.kbase.workspace.ListModuleVersionsParams;
+import us.kbase.workspace.ListModulesParams;
+import us.kbase.workspace.ModuleInfo;
+import us.kbase.workspace.ModuleVersions;
+import us.kbase.workspace.RegisterTypespecCopyParams;
+import us.kbase.workspace.RegisterTypespecParams;
+import us.kbase.workspace.RemoveModuleOwnershipParams;
+import us.kbase.workspace.TypeInfo;
+import us.kbase.workspace.WorkspaceClient;
+
+/** An type client that delegates type operations to another service.
+ * Note that any asAdmin param toggles are ignored - administration methods should be delegated
+ * to {@link #administer(UObject, AuthToken)} rather than the standard methods.
+ */
+public class TypeClient implements TypeServerMethods {
+	
+	/* Once the type server is completely split from the workspace, add another constructor
+	 * that takes a type service URL and a TypeServiceClient provider and add if blocks in
+	 * the methods to use the right client.
+	 * 
+	 * An alternate approach would be to make a wrapper than can wrap and hide the differences
+	 * between a workspace client and a type client but that seems like more work for the same
+	 * result.
+	 */
+	
+	/** Provides a workspace client. */
+	public interface WorkspaceClientProvider {
+		
+		/** Get a client.
+		 * @param workspaceURL the workspace URL.
+		 * @return the client.
+		 * @throws UnauthorizedException if an authorization error occurs.
+		 * @throws IOException if an IOError occurs.
+		 */
+		WorkspaceClient getClient(final URL workspaceURL)
+				throws UnauthorizedException, IOException;
+		
+		/** Get a client.
+		 * @param workspaceURL the workspace URL.
+		 * @param token the user's token.
+		 * @return the client.
+		 * @throws UnauthorizedException if an authorization error occurs.
+		 * @throws IOException if an IOError occurs.
+		 */
+		WorkspaceClient getClient(final URL workspaceURL, final AuthToken token)
+				 throws UnauthorizedException, IOException;
+	}
+	
+	private final WorkspaceClientProvider wsprovider;
+	private final URL targetURL;
+
+	/** Create the type client.
+	 * @param targetURL the URL of a workspace to which type methods will be delegated.
+	 * @param wsprovider a workspace client provider.
+	 */
+	public TypeClient(final URL targetURL, final WorkspaceClientProvider wsprovider) {
+		this.targetURL = requireNonNull(targetURL, "targetURL");
+		this.wsprovider = requireNonNull(wsprovider, "wsprovider");
+	}
+	
+	/** Get the URL of the service to which type operations will be delegated.
+	 * @return the URL
+	 */
+	public URL getTargetURL() {
+		return targetURL;
+	}
+
+	@Override
+	public void grantModuleOwnership(
+			final GrantModuleOwnershipParams params,
+			final AuthToken token,
+			final boolean asAdmin) // admin methods should not call this when delegating
+			throws TypeDelegationException {
+		delegate(token, c -> {c.grantModuleOwnership(params); return null;});
+	}
+
+	@Override
+	public void removeModuleOwnership(
+			final RemoveModuleOwnershipParams params,
+			final AuthToken token,
+			final boolean asAdmin) // admin methods should not call this when delegating
+			throws TypeDelegationException {
+		delegate(token, c -> {c.removeModuleOwnership(params); return null;});
+	}
+
+	@Override
+	public void requestModuleOwnership(final String mod, final AuthToken token)
+			throws TypeDelegationException {
+		delegate(token, c -> {c.requestModuleOwnership(mod); return null;});
+	}
+
+	@Override
+	public Map<String, String> registerTypespec(
+			final RegisterTypespecParams params,
+			final AuthToken token)
+			throws TypeDelegationException {
+		return delegate(token, c -> c.registerTypespec(params));
+	}
+
+	@Override
+	public Long registerTypespecCopy(
+			final RegisterTypespecCopyParams params,
+			final AuthToken token)
+			throws TypeDelegationException {
+		return delegate(token, c -> c.registerTypespecCopy(params));
+	}
+
+	@Override
+	public List<String> releaseModule(
+			final String mod,
+			final AuthToken token)
+			throws TypeDelegationException {
+		return delegate(token, c -> c.releaseModule(mod));
+	}
+
+	@Override
+	public List<String> listModules(final ListModulesParams params)
+			throws TypeDelegationException {
+		return delegate(null, c -> c.listModules(params));
+	}
+
+	@Override
+	public ModuleVersions listModuleVersions(
+			final ListModuleVersionsParams params,
+			final AuthToken token)
+			throws TypeDelegationException {
+		return delegate(token, c -> c.listModuleVersions(params));
+	}
+
+	@Override
+	public ModuleInfo getModuleInfo(final GetModuleInfoParams params, final AuthToken token)
+			throws TypeDelegationException {
+		return delegate(token, c -> c.getModuleInfo(params));
+	}
+
+	@Override
+	public String getJsonschema(final String type, final AuthToken token)
+			throws TypeDelegationException {
+		return delegate(token, c -> c.getJsonschema(type));
+	}
+
+	@Override
+	public Map<String, List<String>> translateFromMD5Types(final List<String> md5Types)
+			throws TypeDelegationException {
+		return delegate(null, c -> c.translateFromMD5Types(md5Types));
+	}
+
+	@Override
+	public Map<String, String> translateToMD5Types(
+			final List<String> semTypes,
+			final AuthToken token)
+			throws TypeDelegationException {
+		return delegate(token, c -> c.translateToMD5Types(semTypes));
+	}
+
+	@Override
+	public TypeInfo getTypeInfo(final String type, final AuthToken token)
+			throws TypeDelegationException {
+		return delegate(token, c -> c.getTypeInfo(type));
+	}
+
+	@Override
+	public List<TypeInfo> getAllTypeInfo(final String mod, final AuthToken token)
+			throws TypeDelegationException {
+		return delegate(token, c -> c.getAllTypeInfo(mod));
+	}
+
+	@Override
+	public FuncInfo getFuncInfo(final String func, final AuthToken token)
+			throws TypeDelegationException {
+		return delegate(token, c -> c.getFuncInfo(func));
+	}
+
+	@Override
+	public List<FuncInfo> getAllFuncInfo(final String mod, final AuthToken token)
+			throws TypeDelegationException {
+		return delegate(token, c -> c.getAllFuncInfo(mod));
+	}
+
+	@Override
+	public Map<String, Map<String, String>> listAllTypes(
+			final ListAllTypesParams params,
+			final AuthToken token)
+			throws TypeDelegationException {
+		return delegate(token, c -> c.listAllTypes(params));
+	}
+	
+	/** Run an administration command.
+	 * @param command the command.
+	 * @param token the user's token.
+	 * @return the results of the command.
+	 * @throws TypeDelegationException if a delegation exception occurs.
+	 */
+	public UObject administer(final UObject command, final AuthToken token)
+			throws TypeDelegationException {
+		return delegate(token, c -> c.administer(command));
+	}
+	
+	@FunctionalInterface
+	private interface WorkspaceCommand<T> {
+		
+		T execute(WorkspaceClient client) throws ServerException, JsonClientException, IOException;
+	}
+	
+	private <T> T delegate(final AuthToken token, final WorkspaceCommand<T> cmd)
+			throws TypeDelegationException {
+		final WorkspaceClient client;
+		try {
+			if (token == null) {
+				client = wsprovider.getClient(targetURL);
+			} else {
+				client = wsprovider.getClient(targetURL, token);
+			}
+		} catch (UnauthorizedException | IOException e) {
+			// This should probably be handled by the provider, but it makes it easier for
+			// the provider to be written. The client constructors never actually throw these
+			// for URL / token combinations.
+			throw new RuntimeException("This should be impossible", e);
+		}
+		if (targetURL.getProtocol().equals("http")) {
+			client.setIsInsecureHttpConnectionAllowed(true);
+		}
+		try {
+			return cmd.execute(client);
+		} catch (ServerException e) {
+			// This is nasty tricksy hobbitses stuff right here. Don't want the data to show up
+			// in the exception message but don't want to lose it either
+			// Surely there's some better way to handle this but I'm not seeing one for now
+			throw new TypeDelegationException(e.getMessage(),
+					new TypeDelegationException(e.getData(), e));
+		} catch (JsonClientException | IOException e) {
+			throw new TypeDelegationException(e.getMessage(), e);
+		}
+	}
+
+}

--- a/src/us/kbase/workspace/kbase/TypeDelegationException.java
+++ b/src/us/kbase/workspace/kbase/TypeDelegationException.java
@@ -1,0 +1,23 @@
+package us.kbase.workspace.kbase;
+
+/** Thrown when attempting to get type information from another service fails. */
+public class TypeDelegationException extends Exception {
+	
+	private static final long serialVersionUID = 1L;
+	
+	/** Create the exception.
+	 * @param message the exception message.
+	 */
+	public TypeDelegationException(final String message) {
+		super(message);
+	}
+	
+	/** Create the exception.
+	 * @param message the exception message.
+	 * @param cause the cause of the exception, if any.
+	 */
+	public TypeDelegationException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/src/us/kbase/workspace/kbase/TypeServerMethods.java
+++ b/src/us/kbase/workspace/kbase/TypeServerMethods.java
@@ -27,7 +27,6 @@ import us.kbase.workspace.RegisterTypespecParams;
 import us.kbase.workspace.RemoveModuleOwnershipParams;
 import us.kbase.workspace.TypeInfo;
 import us.kbase.workspace.WorkspaceServer;
-import us.kbase.workspace.kbase.WorkspaceDelegator.WorkspaceDelegationException;
 
 /** The documentation for the methods here is identical to the corresponding methods in
  * {@link WorkspaceServer}. Refer to that class for documentation.
@@ -38,81 +37,81 @@ public interface TypeServerMethods {
 			final GrantModuleOwnershipParams params,
 			final AuthToken token,
 			final boolean asAdmin)
-			throws TypeStorageException, NoSuchPrivilegeException, WorkspaceDelegationException;
+			throws TypeStorageException, NoSuchPrivilegeException, TypeDelegationException;
 	
 	void removeModuleOwnership(
 			final RemoveModuleOwnershipParams params,
 			final AuthToken token,
 			final boolean asAdmin)
-			throws NoSuchPrivilegeException, TypeStorageException, WorkspaceDelegationException;
+			throws NoSuchPrivilegeException, TypeStorageException, TypeDelegationException;
 
 	void requestModuleOwnership(final String mod, final AuthToken token)
-			throws TypeStorageException, WorkspaceDelegationException;
+			throws TypeStorageException, TypeDelegationException;
 	
 	Map<String,String> registerTypespec(
 			final RegisterTypespecParams params,
 			final AuthToken token)
 			throws SpecParseException, TypeStorageException, NoSuchPrivilegeException,
-				NoSuchModuleException, WorkspaceDelegationException;
+				NoSuchModuleException, TypeDelegationException;
 
 	Long registerTypespecCopy(
 			final RegisterTypespecCopyParams params,
 			final AuthToken token)
 			throws UnauthorizedException, MalformedURLException, IOException, JsonClientException,
 				NoSuchModuleException, TypeStorageException, SpecParseException,
-				NoSuchPrivilegeException, WorkspaceDelegationException;
+				NoSuchPrivilegeException, TypeDelegationException;
 
 	List<String> releaseModule(final String mod, final AuthToken token)
 			throws NoSuchModuleException, TypeStorageException, NoSuchPrivilegeException,
-				WorkspaceDelegationException;
+				TypeDelegationException;
 	
 	List<String> listModules(final ListModulesParams params)
-			throws TypeStorageException, WorkspaceDelegationException;
+			throws TypeStorageException, TypeDelegationException;
 
 	ModuleVersions listModuleVersions(
 			final ListModuleVersionsParams params,
 			final AuthToken token)
 			throws NoSuchModuleException, TypeStorageException, NoSuchPrivilegeException,
-				NoSuchTypeException, WorkspaceDelegationException;
+				NoSuchTypeException, TypeDelegationException;
 	
 	ModuleInfo getModuleInfo(
 			final GetModuleInfoParams params,
 			final AuthToken token)
 			throws NoSuchModuleException, TypeStorageException, NoSuchPrivilegeException,
-				WorkspaceDelegationException;
+				TypeDelegationException;
 	
 	String getJsonschema(final String type, final AuthToken token)
 			throws NoSuchTypeException, NoSuchModuleException, TypeStorageException,
-				WorkspaceDelegationException;
+				TypeDelegationException;
 
 	Map<String,List<String>> translateFromMD5Types(final List<String> md5Types)
 			throws TypeStorageException, NoSuchTypeException, NoSuchModuleException,
-				WorkspaceDelegationException;
+				TypeDelegationException;
 	
 	Map<String,String> translateToMD5Types(
 			final List<String> semTypes,
 			final AuthToken token)
 			throws TypeStorageException, NoSuchTypeException, NoSuchModuleException,
-				WorkspaceDelegationException;
+				TypeDelegationException;
 	
 	TypeInfo getTypeInfo(final String type, final AuthToken token)
 			throws NoSuchModuleException, TypeStorageException, NoSuchTypeException,
-				WorkspaceDelegationException;
+				TypeDelegationException;
 	
 	List<TypeInfo> getAllTypeInfo(final String mod, final AuthToken token)
 			throws NoSuchModuleException, TypeStorageException, NoSuchPrivilegeException,
-				NoSuchTypeException, WorkspaceDelegationException;
+				NoSuchTypeException, TypeDelegationException;
 	
 	FuncInfo getFuncInfo(final String func, final AuthToken token)
 			throws NoSuchModuleException, TypeStorageException, NoSuchFuncException,
-				WorkspaceDelegationException;
+				TypeDelegationException;
 	
 	List<FuncInfo> getAllFuncInfo(final String mod, final AuthToken token)
 			throws NoSuchModuleException, TypeStorageException, NoSuchPrivilegeException,
-				NoSuchFuncException, WorkspaceDelegationException;
+				NoSuchFuncException, TypeDelegationException;
 
 	Map<String,Map<String,String>> listAllTypes(
 			final ListAllTypesParams params,
 			final AuthToken token)
-			throws TypeStorageException, NoSuchModuleException, WorkspaceDelegationException;
+			throws TypeStorageException, NoSuchModuleException, TypeDelegationException;
 }

--- a/src/us/kbase/workspace/kbase/WorkspaceDelegator.java
+++ b/src/us/kbase/workspace/kbase/WorkspaceDelegator.java
@@ -14,26 +14,6 @@ import us.kbase.workspace.WorkspaceClient;
 /** Assists with delegating commands to another workspace instance. */
 public class WorkspaceDelegator {
 	
-	/** Thrown when delegating a workspace call to another workspace fails. */
-	public static class WorkspaceDelegationException extends Exception {
-		private static final long serialVersionUID = 1L;
-		
-		/** Create the exception.
-		 * @param message the exception message.
-		 */
-		public WorkspaceDelegationException(final String message) {
-			super(message);
-		}
-		
-		/** Create the exception.
-		 * @param message the exception message.
-		 * @param cause the cause of the exception, if any.
-		 */
-		public WorkspaceDelegationException(final String message, final Throwable cause) {
-			super(message, cause);
-		}
-	}
-	
 	/** Provides a workspace client. */
 	public interface WorkspaceClientProvider {
 		
@@ -100,10 +80,10 @@ public class WorkspaceDelegator {
 	 * @param token the user's token or null if none is provided.
 	 * @param cmd the command to run.
 	 * @return the result of the command.
-	 * @throws WorkspaceDelegationException if the delegation fails.
+	 * @throws TypeDelegationException if the delegation fails.
 	 */
 	public <T> T delegate(final AuthToken token, final WorkspaceCommand<T> cmd)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		final WorkspaceClient client;
 		try {
 			if (token == null) {
@@ -126,10 +106,10 @@ public class WorkspaceDelegator {
 			// This is nasty tricksy hobbitses stuff right here. Don't want the data to show up
 			// in the exception message but don't want to lose it either
 			// Surely there's some better way to handle this but I'm not seeing one for now
-			throw new WorkspaceDelegationException(e.getMessage(),
-					new WorkspaceDelegationException(e.getData(), e));
+			throw new TypeDelegationException(e.getMessage(),
+					new TypeDelegationException(e.getData(), e));
 		} catch (JsonClientException | IOException e) {
-			throw new WorkspaceDelegationException(e.getMessage(), e);
+			throw new TypeDelegationException(e.getMessage(), e);
 		}
 	}
 

--- a/src/us/kbase/workspace/kbase/admin/AdministrationCommandSetInstaller.java
+++ b/src/us/kbase/workspace/kbase/admin/AdministrationCommandSetInstaller.java
@@ -45,8 +45,8 @@ import us.kbase.workspace.database.WorkspaceInformation;
 import us.kbase.workspace.database.WorkspaceUser;
 import us.kbase.workspace.database.DynamicConfig.DynamicConfigUpdate;
 import us.kbase.workspace.kbase.LocalTypeServerMethods;
+import us.kbase.workspace.kbase.TypeDelegationException;
 import us.kbase.workspace.kbase.WorkspaceDelegator;
-import us.kbase.workspace.kbase.WorkspaceDelegator.WorkspaceDelegationException;
 import us.kbase.workspace.kbase.WorkspaceServerMethods;
 import us.kbase.workspace.kbase.admin.WorkspaceAdministration.AdminCommandSpecification;
 import us.kbase.workspace.kbase.admin.WorkspaceAdministration.Builder;
@@ -206,11 +206,11 @@ public class AdministrationCommandSetInstaller {
 			true));
 	}
 
-	public static Object delegate(
+	private static Object delegate(
 			final WorkspaceDelegator delegator,
 			final AdminCommand cmd,
 			final AuthToken token)
-			throws WorkspaceDelegationException {
+			throws TypeDelegationException {
 		final UObject res = delegator.delegate(token, c -> c.administer(new UObject(cmd)));
 		return res == null ? null : res.isNull() ? null : res.asClassInstance(Object.class);
 	}

--- a/src/us/kbase/workspace/test/kbase/TypeClientTest.java
+++ b/src/us/kbase/workspace/test/kbase/TypeClientTest.java
@@ -1,0 +1,462 @@
+package us.kbase.workspace.test.kbase;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static us.kbase.common.test.TestCommon.list;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.auth.AuthToken;
+import us.kbase.common.service.JsonClientException;
+import us.kbase.common.service.ServerException;
+import us.kbase.common.service.UObject;
+import us.kbase.common.service.UnauthorizedException;
+import us.kbase.common.test.TestCommon;
+import us.kbase.workspace.FuncInfo;
+import us.kbase.workspace.GetModuleInfoParams;
+import us.kbase.workspace.GrantModuleOwnershipParams;
+import us.kbase.workspace.ListAllTypesParams;
+import us.kbase.workspace.ListModuleVersionsParams;
+import us.kbase.workspace.ListModulesParams;
+import us.kbase.workspace.ModuleInfo;
+import us.kbase.workspace.ModuleVersions;
+import us.kbase.workspace.RegisterTypespecCopyParams;
+import us.kbase.workspace.RegisterTypespecParams;
+import us.kbase.workspace.RemoveModuleOwnershipParams;
+import us.kbase.workspace.TypeInfo;
+import us.kbase.workspace.WorkspaceClient;
+import us.kbase.workspace.kbase.TypeClient;
+import us.kbase.workspace.kbase.TypeDelegationException;
+import us.kbase.workspace.kbase.TypeClient.WorkspaceClientProvider;
+
+public class TypeClientTest {
+
+	// rather than test every method with and without a token, we stagger token usage
+	// same for http vs. https urls
+	
+	// the tests use identity for equals for SDK compiled classes since that's the expected
+	// behavior and doing otherwise would blow up the tests
+	
+	// note the urls are weird as it appears that calling equals on a url actually tries to
+	// access the site. Bad urls seem to be a lot faster than urls that might hit a real
+	// server
+	
+	private static class TestMocks {
+		private final WorkspaceClient wc;
+		private final WorkspaceClientProvider wcp;
+		private final TypeClient tc;
+
+		public TestMocks(
+				final WorkspaceClient wc,
+				final WorkspaceClientProvider wcp,
+				final TypeClient dtsm) {
+			this.wc = wc;
+			this.wcp = wcp;
+			this.tc = dtsm;
+		}
+	}
+	
+	private TestMocks initTestMocks(final URL targetURL) {
+		final WorkspaceClient wc = mock(WorkspaceClient.class);
+		final WorkspaceClientProvider wcp = mock(WorkspaceClientProvider.class);
+		final TypeClient tc = new TypeClient(targetURL, wcp);
+		return new TestMocks(wc, wcp, tc);
+	}
+	
+	@Test
+	public void construct() throws Exception {
+		final TypeClient tc = initTestMocks(new URL("https://cipherisalwaysabadguy.com")).tc;
+		assertThat("incorrect url",
+				tc.getTargetURL(), is(new URL("https://cipherisalwaysabadguy.com")));
+	}
+	
+	@Test
+	public void constructFail() throws Exception {
+		failConstruct(
+				null, mock(WorkspaceClientProvider.class), new NullPointerException("targetURL"));
+		failConstruct(new URL("http://foo.com"), null, new NullPointerException("wsprovider"));
+	}
+	
+	private void failConstruct(
+			final URL url,
+			final WorkspaceClientProvider wcp,
+			final Exception expected) {
+		try {
+			new TypeClient(url, wcp);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+	
+	@Test
+	public void grantModuleOwnership() throws Exception {
+		for (final boolean asAdmin: list(true, false)) {
+			// admin should make no difference
+			final TestMocks m = initTestMocks(new URL("https://whee1111.com"));
+			
+			when(m.wcp.getClient(new URL("https://whee1111.com"))).thenReturn(m.wc);
+			
+			final GrantModuleOwnershipParams params = new GrantModuleOwnershipParams()
+					.withMod("m");
+			m.tc.grantModuleOwnership(params, null, asAdmin);
+
+			verify(m.wc).grantModuleOwnership(params);
+			verify(m.wc, never()).setIsInsecureHttpConnectionAllowed(true);
+		}
+	}
+	
+	@Test
+	public void removeModuleOwnership() throws Exception {
+		for (final boolean asAdmin: list(true, false)) {
+			// admin should make no difference
+			final TestMocks m = initTestMocks(new URL("http://whoo1111.com"));
+			
+			when(m.wcp.getClient(new URL("http://whoo1111.com"), new AuthToken("t", "u")))
+					.thenReturn(m.wc);
+			
+			final RemoveModuleOwnershipParams params = new RemoveModuleOwnershipParams()
+					.withMod("mod");
+			m.tc.removeModuleOwnership(params, new AuthToken("t", "u"), asAdmin);
+			verify(m.wc).removeModuleOwnership(params);
+			verify(m.wc).setIsInsecureHttpConnectionAllowed(true);
+		}
+	}
+	
+	@Test
+	public void requestModuleOwnership() throws Exception {
+		final TestMocks m = initTestMocks(new URL("https://whoopsie1111.com"));
+		
+		when(m.wcp.getClient(new URL("https://whoopsie1111.com"))).thenReturn(m.wc);
+		
+		m.tc.requestModuleOwnership("somemod", null);
+		verify(m.wc).requestModuleOwnership("somemod");
+		verify(m.wc, never()).setIsInsecureHttpConnectionAllowed(true);
+	}
+	
+	@Test
+	public void registerTypespec() throws Exception {
+		final TestMocks m = initTestMocks(new URL("http://insecure111.com"));
+		
+		final RegisterTypespecParams params = new RegisterTypespecParams().withMod("m2");
+		when(m.wcp.getClient(new URL("http://insecure111.com"), new AuthToken("t1", "u1")))
+				.thenReturn(m.wc);
+		when(m.wc.registerTypespec(params)).thenReturn(ImmutableMap.of("foo", "bar"));
+
+		final Map<String, String> res = m.tc.registerTypespec(params, new AuthToken("t1", "u1"));
+		assertThat("incorrect result", res, is(ImmutableMap.of("foo", "bar")));
+		verify(m.wc).setIsInsecureHttpConnectionAllowed(true);
+	}
+	
+	@Test
+	public void registerTypespecCopy() throws Exception {
+		final TestMocks m = initTestMocks(new URL("https://rtc111.com"));
+		
+		final RegisterTypespecCopyParams params = new RegisterTypespecCopyParams().withMod("m2");
+		when(m.wcp.getClient(new URL("https://rtc111.com"))).thenReturn(m.wc);
+		when(m.wc.registerTypespecCopy(params)).thenReturn(42L);
+		
+		final long res = m.tc.registerTypespecCopy(params, null);
+		assertThat("incorrect result", res, is(42L));
+		verify(m.wc, never()).setIsInsecureHttpConnectionAllowed(true);
+	}
+	
+	@Test
+	public void releaseModule() throws Exception {
+		final TestMocks m = initTestMocks(new URL("http://rm1111xxxx.com"));
+		
+		when(m.wcp.getClient(new URL("http://rm1111xxxx.com"), new AuthToken("t7", "u7")))
+				.thenReturn(m.wc);
+		when(m.wc.releaseModule("moddie")).thenReturn(list("yay"));
+		
+		final List<String> res = m.tc.releaseModule("moddie", new AuthToken("t7", "u7"));
+		assertThat("incorrect result", res, is(list("yay")));
+		verify(m.wc).setIsInsecureHttpConnectionAllowed(true);
+	}
+	
+	@Test
+	public void listModules() throws Exception {
+		final TestMocks m = initTestMocks(new URL("https://lm.com"));
+		
+		final ListModulesParams params = new ListModulesParams().withOwner("Trump Holdings Inc");
+		when(m.wcp.getClient(new URL("https://lm.com"))).thenReturn(m.wc);
+		when(m.wc.listModules(params)).thenReturn(list("well done steak", "ketchup"));
+		
+		final List<String> res = m.tc.listModules(params);
+		assertThat("incorrect result", res, is(list("well done steak", "ketchup")));
+		verify(m.wc, never()).setIsInsecureHttpConnectionAllowed(true);
+	}
+	
+	@Test
+	public void listModuleVersions() throws Exception {
+		final TestMocks m = initTestMocks(new URL("http://lmv1111xx.com"));
+		
+		final ListModuleVersionsParams params = new ListModuleVersionsParams().withMod("m3");
+		final ModuleVersions mv = new ModuleVersions().withMod("m3 plus 1");
+		when(m.wcp.getClient(new URL("http://lmv1111xx.com"))).thenReturn(m.wc);
+		when(m.wc.listModuleVersions(params)).thenReturn(mv);
+
+		final ModuleVersions res = m.tc.listModuleVersions(params, null);
+		assertThat("incorrect result", res, is(mv));
+		verify(m.wc).setIsInsecureHttpConnectionAllowed(true);
+	}
+	
+	@Test
+	public void getModuleInfo() throws Exception {
+		final TestMocks m = initTestMocks(new URL("https://gmi.com"));
+		
+		final GetModuleInfoParams params = new GetModuleInfoParams().withMod("m42");
+		final ModuleInfo mi = new ModuleInfo().withVer(89L);
+		when(m.wcp.getClient(new URL("https://gmi.com"), new AuthToken("t7", "u8")))
+				.thenReturn(m.wc);
+		when(m.wc.getModuleInfo(params)).thenReturn(mi);
+
+		final ModuleInfo res = m.tc.getModuleInfo(params, new AuthToken("t7", "u8"));
+		assertThat("incorrect result", res, is(mi));
+		verify(m.wc, never()).setIsInsecureHttpConnectionAllowed(true);
+	}
+
+	@Test
+	public void getJsonSchema() throws Exception {
+		final TestMocks m = initTestMocks(new URL("http://gjc.com"));
+		
+		when(m.wcp.getClient(new URL("http://gjc.com"))).thenReturn(m.wc);
+		when(m.wc.getJsonschema("sometype")).thenReturn("jssooooonscheeeemaaaa");
+		
+		final String res = m.tc.getJsonschema("sometype", null);
+		assertThat("incorrect result", res, is("jssooooonscheeeemaaaa"));
+		verify(m.wc).setIsInsecureHttpConnectionAllowed(true);
+	}
+	
+	@Test
+	public void translateFromMD5Types() throws Exception {
+		final TestMocks m = initTestMocks(new URL("https://tfmt111.com"));
+		
+		when(m.wcp.getClient(new URL("https://tfmt111.com"))).thenReturn(m.wc);
+		when(m.wc.translateFromMD5Types(list("foo"))).thenReturn(
+				ImmutableMap.of("foo", list("bar")));
+
+		final Map<String, List<String>> res = m.tc.translateFromMD5Types(list("foo"));
+		assertThat("incorrect result", res, is(ImmutableMap.of("foo", list("bar"))));
+		verify(m.wc, never()).setIsInsecureHttpConnectionAllowed(true);
+	}
+	
+	@Test
+	public void translateToMD5Types() throws Exception {
+		final TestMocks m = initTestMocks(new URL("http://ttmt1111.com"));
+		
+		when(m.wcp.getClient(new URL("http://ttmt1111.com"), new AuthToken("t", "u")))
+				.thenReturn(m.wc);
+		when(m.wc.translateToMD5Types(list("foo"))).thenReturn(ImmutableMap.of("foo", "bar"));
+		
+		final Map<String, String> res = m.tc.translateToMD5Types(
+				list("foo"), new AuthToken("t", "u"));
+		assertThat("incorrect result", res, is(ImmutableMap.of("foo", "bar")));
+		verify(m.wc).setIsInsecureHttpConnectionAllowed(true);
+	}
+	
+	@Test
+	public void getTypeInfo() throws Exception {
+		final TestMocks m = initTestMocks(new URL("https://gti.com"));
+		
+		final TypeInfo ti = new TypeInfo().withDescription("some type or other");
+		when(m.wcp.getClient(new URL("https://gti.com"))).thenReturn(m.wc);
+		when(m.wc.getTypeInfo("type67")).thenReturn(ti);
+
+		final TypeInfo res = m.tc.getTypeInfo("type67", null);
+		assertThat("incorrect result", res, is(ti));
+		verify(m.wc, never()).setIsInsecureHttpConnectionAllowed(true);
+	}
+	
+	@Test
+	public void getAllTypeInfo() throws Exception {
+		final TestMocks m = initTestMocks(new URL("http://gati1111.com"));
+		
+		final TypeInfo ti = new TypeInfo().withDescription("some type or other");
+		when(m.wcp.getClient(new URL("http://gati1111.com"), new AuthToken("secrits", "someguy")))
+				.thenReturn(m.wc);
+		when(m.wc.getAllTypeInfo("somemod")).thenReturn(list(ti));
+
+		final List<TypeInfo> res = m.tc.getAllTypeInfo(
+				"somemod", new AuthToken("secrits", "someguy"));
+		assertThat("incorrect result", res, is(list(ti)));
+		verify(m.wc).setIsInsecureHttpConnectionAllowed(true);
+		
+	}
+
+	@Test
+	public void getFuncInfo() throws Exception {
+		final TestMocks m = initTestMocks(new URL("https://gfi.com"));
+		
+		final FuncInfo fi = new FuncInfo().withDescription("some function or other");
+		when(m.wcp.getClient(new URL("https://gfi.com"))).thenReturn(m.wc);
+		when(m.wc.getFuncInfo("funcky chicken")).thenReturn(fi);
+
+		final FuncInfo res = m.tc.getFuncInfo("funcky chicken", null);
+		assertThat("incorrect result", res, is(fi));
+		verify(m.wc, never()).setIsInsecureHttpConnectionAllowed(true);
+	}
+	
+	@Test
+	public void getAllFuncInfo() throws Exception {
+		final TestMocks m = initTestMocks(new URL("http://gafi1111.com"));
+		
+		final FuncInfo fi = new FuncInfo().withDescription("some function or other");
+		when(m.wcp.getClient(new URL("http://gafi1111.com"), new AuthToken(
+						"password123", "Executive VP of Network Security")))
+				.thenReturn(m.wc);
+		when(m.wc.getAllFuncInfo("somemod")).thenReturn(list(fi));
+
+		final List<FuncInfo> res = m.tc.getAllFuncInfo("somemod", new AuthToken(
+				"password123", "Executive VP of Network Security"));
+		assertThat("incorrect result", res, is(list(fi)));
+		verify(m.wc).setIsInsecureHttpConnectionAllowed(true);
+	}
+	
+	@Test
+	public void listAllTypes() throws Exception {
+		final TestMocks m = initTestMocks(new URL("https://lat.com"));
+		
+		final ListAllTypesParams params = new ListAllTypesParams().withWithEmptyModules(1L);
+		when(m.wcp.getClient(new URL("https://lat.com"))).thenReturn(m.wc);
+		when(m.wc.listAllTypes(params))
+				.thenReturn(ImmutableMap.of("foo", ImmutableMap.of("bar", "baz")));
+
+		final Map<String, Map<String, String>> res = m.tc.listAllTypes(params, null);
+		assertThat("incorrect result",
+				res, is(ImmutableMap.of("foo", ImmutableMap.of("bar", "baz"))));
+		verify(m.wc, never()).setIsInsecureHttpConnectionAllowed(true);
+	}
+	
+	@Test
+	public void administrate() throws Exception {
+		final TestMocks m = initTestMocks(new URL("http://adminfakexxxx.com"));
+		
+		final UObject cmd = new UObject("foo");
+		final UObject out = new UObject("out");
+		when(m.wcp.getClient(new URL("http://adminfakexxxx.com"), new AuthToken("token", "user")))
+				.thenReturn(m.wc);
+		when(m.wc.administer(cmd)).thenReturn(out);
+		
+		final UObject got = m.tc.administer(cmd, new AuthToken("token", "user"));
+		assertThat("incorrect result", got, is(out));
+		verify(m.wc).setIsInsecureHttpConnectionAllowed(true);
+	}
+	
+	/* #####  FAILURE TESTS
+	 * Since all the methods under the hood delegate to the same code that
+	 * handles failures, we just test each failure mode once, rather than testing the same thing
+	 * over and over for all 18 odd methods.
+	 * 
+	 * If you change how this works be sure to change the tests as well.
+	 * #####
+	 */
+	
+	@Test
+	public void getClientFailNoTokenUnauthorizedException() throws Exception {
+		final String url = "https://donate.doctorswithoutborders.org/secure/donate";
+		final TestMocks m = initTestMocks(new URL(url));
+		
+		when(m.wcp.getClient(new URL(url))).thenThrow(new UnauthorizedException("whoops"));
+		
+		try {
+			m.tc.getJsonschema("Foo.bar", null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(
+					got, new RuntimeException("This should be impossible"));
+			TestCommon.assertExceptionCorrect(got.getCause(), new UnauthorizedException("whoops"));
+		}
+	}
+	
+	@Test
+	public void getClientFailWithTokenIOException() throws Exception {
+		final String url = "https://poopyfartbutts.com";
+		final TestMocks m = initTestMocks(new URL(url));
+		
+		when(m.wcp.getClient(new URL(url), new AuthToken("t", "u")))
+				.thenThrow(new IOException("serious tests for serious people"));
+		try {
+			m.tc.getTypeInfo("Mod.type", new AuthToken("t", "u"));
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(
+					got, new RuntimeException("This should be impossible"));
+			TestCommon.assertExceptionCorrect(
+					got.getCause(), new IOException("serious tests for serious people"));
+		}
+	}
+	
+	@Test
+	public void executeFailJsonClientException() throws Exception {
+		final String url = "https://elegantliving.svalbard.gov";
+		final TestMocks m = initTestMocks(new URL(url));
+		
+		when(m.wcp.getClient(new URL(url))).thenReturn(m.wc);
+		when(m.wc.releaseModule("MyMod")).thenThrow(new JsonClientException("dang bruh"));
+		
+		try {
+			m.tc.releaseModule("MyMod", null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new TypeDelegationException("dang bruh"));
+			TestCommon.assertExceptionCorrect(
+					got.getCause(), new JsonClientException("dang bruh"));
+		}
+	}
+	
+	@Test
+	public void executeFailIOException() throws Exception {
+		final String url = "https://how-to-avoid-getting-eaten-by-a-polar-bear.svalbard.gov";
+		final TestMocks m = initTestMocks(new URL(url));
+		
+		when(m.wcp.getClient(new URL(url))).thenReturn(m.wc);
+		doThrow(new IOException("ow my liver")).when(m.wc).requestModuleOwnership("Mod");
+		
+		try {
+			m.tc.requestModuleOwnership("Mod", null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new TypeDelegationException("ow my liver"));
+			TestCommon.assertExceptionCorrect(got.getCause(), new IOException("ow my liver"));
+		}
+	}
+	
+	@Test
+	public void delegateFailOnExecuteServerException() throws Exception {
+		final String url = "https://svalbard-beach-activies.svalbard.gov";
+		final TestMocks m = initTestMocks(new URL(url));
+		
+		when(m.wcp.getClient(new URL(url))).thenReturn(m.wc);
+		when(m.wc.getAllTypeInfo("Somemod")).thenThrow(new ServerException(
+				"reindeer prodding",
+				42,
+				"SomeException",
+				"server side\nstacktrace goes here\nline 1: int foo = 0"));
+		try {
+			m.tc.getAllTypeInfo("Somemod", null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(
+					got, new TypeDelegationException("reindeer prodding"));
+			TestCommon.assertExceptionCorrect(got.getCause(), new TypeDelegationException(
+					"server side\nstacktrace goes here\nline 1: int foo = 0"));
+			TestCommon.assertExceptionCorrect(
+					got.getCause().getCause(),
+					new ServerException("reindeer prodding", 42, "SomeException"));
+		}
+	}
+}

--- a/src/us/kbase/workspace/test/kbase/WorkspaceDelegatorTest.java
+++ b/src/us/kbase/workspace/test/kbase/WorkspaceDelegatorTest.java
@@ -21,10 +21,10 @@ import us.kbase.common.service.ServerException;
 import us.kbase.common.service.UnauthorizedException;
 import us.kbase.common.test.TestCommon;
 import us.kbase.workspace.WorkspaceClient;
+import us.kbase.workspace.kbase.TypeDelegationException;
 import us.kbase.workspace.kbase.WorkspaceDelegator;
 import us.kbase.workspace.kbase.WorkspaceDelegator.WorkspaceClientProvider;
 import us.kbase.workspace.kbase.WorkspaceDelegator.WorkspaceCommand;
-import us.kbase.workspace.kbase.WorkspaceDelegator.WorkspaceDelegationException;
 
 public class WorkspaceDelegatorTest {
 	
@@ -140,7 +140,7 @@ public class WorkspaceDelegatorTest {
 		when(m.wc.getTypeInfo("sometype")).thenThrow(new JsonClientException("dang bruh"));
 		
 		final Exception got = failDelegate(m.del, null, c -> c.getTypeInfo("sometype"),
-				new WorkspaceDelegationException("dang bruh"));
+				new TypeDelegationException("dang bruh"));
 		TestCommon.assertExceptionCorrect(got.getCause(), new JsonClientException("dang bruh"));
 	}
 	
@@ -153,7 +153,7 @@ public class WorkspaceDelegatorTest {
 		when(m.wc.getTypeInfo("sometype")).thenThrow(new IOException("ow my liver"));
 		
 		final Exception got = failDelegate(m.del, null, c -> c.getTypeInfo("sometype"),
-				new WorkspaceDelegationException("ow my liver"));
+				new TypeDelegationException("ow my liver"));
 		TestCommon.assertExceptionCorrect(got.getCause(), new IOException("ow my liver"));
 	}
 	
@@ -170,8 +170,8 @@ public class WorkspaceDelegatorTest {
 				"server side\nstacktrace goes here\nline 1: int foo = 0"));
 		
 		final Exception got = failDelegate(m.del, null, c -> c.getTypeInfo("sometype"),
-				new WorkspaceDelegationException("reindeer prodding"));
-		TestCommon.assertExceptionCorrect(got.getCause(), new WorkspaceDelegationException(
+				new TypeDelegationException("reindeer prodding"));
+		TestCommon.assertExceptionCorrect(got.getCause(), new TypeDelegationException(
 				"server side\nstacktrace goes here\nline 1: int foo = 0"));
 		TestCommon.assertExceptionCorrect(
 				got.getCause().getCause(),

--- a/src/us/kbase/workspace/test/workspace/WorkspaceUnitTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceUnitTest.java
@@ -103,7 +103,6 @@ public class WorkspaceUnitTest {
 	
 	private class TestMocks {
 		private final WorkspaceDatabase db;
-		@SuppressWarnings("unused")
 		private final TypedObjectValidator val;
 		@SuppressWarnings("unused")
 		private final ResourceUsageConfiguration cfg;


### PR DESCRIPTION
Effectively combines DelegatingTypeServerMethods and WorkspaceDelegator into one class. This has 2 benefits:

1) It makes it much simpler to switch to a TypeServiceClient when that exists since you only have to worry about changing one class
2) It makes the tests much simpler since all the delegation functional interface stuff is hidden

Next step is replacing the 2 classes with the new class.