### PR TITLE
CE-93: implement PIDs; use shared constants

### DIFF
--- a/src/us/kbase/common/test/TestCommon.java
+++ b/src/us/kbase/common/test/TestCommon.java
@@ -290,15 +290,6 @@ public class TestCommon {
 	public static final Optional<Long> EL = Optional.empty();
 	public static final Optional<Integer> EI = Optional.empty();
 
-        public static final Long NL = null;
-        public static final Long L = (long) 123456;
-
-        public static final String NS = null;
-        public static final String WHITESPACE = "\n\n    \f     \t\t  \r\n   ";
-        public static final String STRING = "some string of stingy stringy strings strung together";
-        public static final String STRING_WITH_WHITESPACE = "\n\n    \f  some string of stingy stringy strings strung together \t  \n";
-
-
 	public static <T> Optional<T> opt(final T obj) {
 		return Optional.of(obj);
 	}

--- a/src/us/kbase/workspace/database/Util.java
+++ b/src/us/kbase/workspace/database/Util.java
@@ -66,14 +66,40 @@ public class Util {
 		}
 	}
 
-	/** Check that a string is non-null and has at least one non-whitespace character.
+        /** Check that a string is non-null and has at least one non-whitespace character.
+	 * @param s the string to check.
+	 * @param name the name of the string to use in any error messages.
+         * @param max maximum number of code points in the string.
+	 * @return the trimmed string.
+	 */
+	public static String checkString(
+			final String s,
+			final String name,
+			final int max) throws IllegalArgumentException {
+                return checkString(s, name, max, false);
+        }
+
+        /** Check that a string is either null or that it has at least one non-whitespace character.
+	 * @param s the string to check.
+	 * @param name the name of the string to use in any error messages.
+         * @param optional whether or not the field can be null.
+	 * @return the trimmed string.
+	 */
+        public static String checkString(
+                final String s,
+                final String name,
+                final boolean optional) throws IllegalArgumentException {
+                return checkString(s, name, -1, optional);
+        }
+
+        /** Check that a string is non-null and has at least one non-whitespace character.
 	 * @param s the string to check.
 	 * @param name the name of the string to use in any error messages.
 	 * @return the trimmed string.
 	 */
 	public static String checkString(final String s, final String name)
 			throws IllegalArgumentException {
-		return checkString(s, name, -1);
+		return checkString(s, name, -1, false);
 	}
 
 	/** Check that a string is non-null, has at least one non-whitespace character, and is below
@@ -82,21 +108,28 @@ public class Util {
 	 * @param name the name of the string to use in any error messages.
 	 * @param max the maximum number of code points in the string. If 0 or less, the length is not
 	 * checked.
+         * @param optional whether or not the field is optional; if the field is optional,
+         *                 checkString will not throw an error for null or whitespace-only values.
 	 * @return the trimmed string.
 	 */
 	public static String checkString(
 			final String s,
 			final String name,
-			final int max) {
+			final int max,
+                        final boolean optional) {
 		if (isNullOrEmpty(s)) {
-			throw new IllegalArgumentException(name + " cannot be null or whitespace only");
-		}
+                        if (optional) {
+                                return null;
+                        }
+                        throw new IllegalArgumentException(name + " cannot be null or whitespace only");
+                }
 		if (max > 0 && codePoints(s.trim()) > max) {
 			throw new IllegalArgumentException(
 					name + " size greater than limit " + max);
 		}
 		return s.trim();
 	}
+
 
 	/** Return the number of code points in a string. Equivalent to
 	 * {@link String#codePointCount(int, int)} with arguments of 0 and {@link String#length()}.

--- a/src/us/kbase/workspace/database/Util.java
+++ b/src/us/kbase/workspace/database/Util.java
@@ -23,7 +23,7 @@ public class Util {
 	 * @param s the string to test.
 	 * @return true if the string is null or whitespace only, false otherwise.
 	 */
-	public static boolean isNullOrEmpty(final String s) {
+	public static boolean isNullOrWhitespace(final String s) {
 		return s == null || s.trim().isEmpty();
 	}
 
@@ -59,7 +59,7 @@ public class Util {
 	public static void checkNoNullsOrEmpties(final Collection<String> strings, final String name) {
 		checkNotNull(strings, name);
 		for (final String s: strings) {
-			if (isNullOrEmpty(s)) {
+			if (isNullOrWhitespace(s)) {
 				throw new IllegalArgumentException(
 						"Null or whitespace only string in collection " + name);
 			}
@@ -117,7 +117,7 @@ public class Util {
 			final String name,
 			final int max,
                         final boolean optional) {
-		if (isNullOrEmpty(s)) {
+		if (isNullOrWhitespace(s)) {
                         if (optional) {
                                 return null;
                         }

--- a/src/us/kbase/workspace/database/provenance/Common.java
+++ b/src/us/kbase/workspace/database/provenance/Common.java
@@ -3,6 +3,7 @@ package us.kbase.workspace.database.provenance;
 import static us.kbase.workspace.database.Util.checkNoNullsOrEmpties;
 import static us.kbase.workspace.database.Util.isNullOrEmpty;
 import static us.kbase.workspace.database.Util.noNulls;
+import static us.kbase.workspace.database.Util.checkString;
 
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -10,13 +11,18 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /* This is an internal only class for shared code between the provenance classes.
  * Tests are all via testing the public provenance class APIs.
  */
 class Common {
-	
-	private Common() {};
+
+	static final Pattern VALID_PID_REGEX = Pattern.compile("^([a-zA-Z0-9][a-zA-Z0-9\\.]+)\\s*:\\s*(\\S.+)$");
+	static final String VALID_PID_REGEX_STRING = VALID_PID_REGEX.toString();
+
+	private Common() {}
 
 	static String processString(final String input) {
 		return isNullOrEmpty(input) ? null : input.trim();
@@ -29,7 +35,7 @@ class Common {
 	static URL processURL(final URL url, final String name) {
 		return url == null ? null : checkURL(url, name);
 	}
-	
+
 	static List<String> processSimpleStringList(final List<String> list, final String name) {
 		if (list == null || list.isEmpty()) {
 			return null;
@@ -38,7 +44,7 @@ class Common {
 			return Common.immutable(list);
 		}
 	}
-	
+
 	static <T> List<T> processSimpleList(final List<T> list, final String name) {
 		if (list == null || list.isEmpty()) {
 			return null;
@@ -47,7 +53,25 @@ class Common {
 			return Common.immutable(list);
 		}
 	}
-	
+
+	/** Check that a PID string is non-null, has at least one non-whitespace character,
+	 * and conforms to the specified regular expression.
+	 * @param putativePid the string to check.
+	 * @param name the name of the string to use in any error messages.
+	 * @return the trimmed PID.
+	 */
+	static String checkPid(final String putativePid, final String name)
+			throws IllegalArgumentException {
+		final String pid = checkString(putativePid, name, -1);
+		final Matcher m = VALID_PID_REGEX.matcher(pid);
+		if (m.find()) {
+			return m.replaceAll("$1:$2");
+		}
+		throw new IllegalArgumentException(String.format(
+				"Illegal ID format for %s: \"%s\"%nPIDs should match the pattern \"%s\"",
+				name, putativePid, VALID_PID_REGEX_STRING));
+	}
+
 	private static URL checkURL(final String putativeURL, final String name) {
 		final URL url;
 		try {
@@ -58,7 +82,7 @@ class Common {
 		}
 		return checkURL(url, name);
 	}
-	
+
 	private static URL checkURL(final URL url, final String name) {
 		try {
 			url.toURI();
@@ -68,17 +92,17 @@ class Common {
 					"Illegal %s url '%s': %s", name, url, e.getLocalizedMessage()), e);
 		}
 	}
-	
+
 	static <T> List<T> immutable(final List<T> list) {
 		/* makes a list immutable by
 		 * 1) making changes to the returned list impossible
 		 * 2) making a copy of the list so mutating the old list doesn't mutate the new one.
-		 * 
+		 *
 		 * Note the individual items of the list can still be mutated, since they aren't copied.
 		 */
 		return Collections.unmodifiableList(new ArrayList<>(list));
 	}
-	
+
 	static <T> List<T> getList(final List<T> list) {
 		return list == null ? Collections.emptyList() : list;
 	}

--- a/src/us/kbase/workspace/database/provenance/Common.java
+++ b/src/us/kbase/workspace/database/provenance/Common.java
@@ -74,21 +74,8 @@ class Common {
 			return m.replaceAll("$1:$2");
 		}
 		throw new IllegalArgumentException(String.format(
-				"Illegal ID format for %s: \"%s\"%nPIDs should match the pattern \"%s\"",
+				"Illegal ID format for %s: \"%s\"\nPIDs should match the pattern \"%s\"",
 				name, putativePid, VALID_PID_REGEX_STRING));
-	}
-
-	/**
-	 * Checks that a PID string is non-null with at least one
-	 * non-whitespace character, and conforms to the specified regular expression.
-	 *
-	 * @param putativePid the string to check.
-	 * @param name        the name of the string to use in any error messages.
-	 * @return the trimmed PID or null.
-	 */
-
-	static String checkPid(final String putativePid, final String name) {
-		return checkPid(putativePid, name, false);
 	}
 
 	private static URL checkURL(final String putativeURL, final String name) {

--- a/src/us/kbase/workspace/database/provenance/Common.java
+++ b/src/us/kbase/workspace/database/provenance/Common.java
@@ -54,10 +54,13 @@ class Common {
 		}
 	}
 
-	/** Check that a PID string is non-null, has at least one non-whitespace character,
+	/**
+	 * Checks that a PID string is non-null, has at least one non-whitespace
+	 * character,
 	 * and conforms to the specified regular expression.
+	 *
 	 * @param putativePid the string to check.
-	 * @param name the name of the string to use in any error messages.
+	 * @param name        the name of the string to use in any error messages.
 	 * @return the trimmed PID.
 	 */
 	static String checkPid(final String putativePid, final String name)
@@ -70,6 +73,23 @@ class Common {
 		throw new IllegalArgumentException(String.format(
 				"Illegal ID format for %s: \"%s\"%nPIDs should match the pattern \"%s\"",
 				name, putativePid, VALID_PID_REGEX_STRING));
+	}
+
+	/**
+	 * Checks that a PID string is either null or that it has at least one
+	 * non-whitespace character,
+	 * and conforms to the specified regular expression.
+	 *
+	 * @param putativePid the string to check.
+	 * @param name        the name of the string to use in any error messages.
+	 * @return the trimmed PID or null.
+	 */
+
+	static String checkOptionalPid(final String putativePid, final String name) {
+		if (isNullOrEmpty(putativePid)) {
+			return null;
+		}
+		return checkPid(putativePid, name);
 	}
 
 	private static URL checkURL(final String putativeURL, final String name) {
@@ -94,7 +114,8 @@ class Common {
 	}
 
 	static <T> List<T> immutable(final List<T> list) {
-		/* makes a list immutable by
+		/*
+		 * makes a list immutable by
 		 * 1) making changes to the returned list impossible
 		 * 2) making a copy of the list so mutating the old list doesn't mutate the new one.
 		 *

--- a/src/us/kbase/workspace/database/provenance/Common.java
+++ b/src/us/kbase/workspace/database/provenance/Common.java
@@ -1,7 +1,7 @@
 package us.kbase.workspace.database.provenance;
 
 import static us.kbase.workspace.database.Util.checkNoNullsOrEmpties;
-import static us.kbase.workspace.database.Util.isNullOrEmpty;
+import static us.kbase.workspace.database.Util.isNullOrWhitespace;
 import static us.kbase.workspace.database.Util.noNulls;
 import static us.kbase.workspace.database.Util.checkString;
 
@@ -25,11 +25,11 @@ class Common {
 	private Common() {}
 
 	static String processString(final String input) {
-		return isNullOrEmpty(input) ? null : input.trim();
+		return isNullOrWhitespace(input) ? null : input.trim();
 	}
 
 	static URL processURL(final String url, final String name) {
-		return isNullOrEmpty(url) ? null : checkURL(url, name);
+		return isNullOrWhitespace(url) ? null : checkURL(url, name);
 	}
 
 	static URL processURL(final URL url, final String name) {

--- a/src/us/kbase/workspace/database/provenance/Common.java
+++ b/src/us/kbase/workspace/database/provenance/Common.java
@@ -55,17 +55,20 @@ class Common {
 	}
 
 	/**
-	 * Checks that a PID string is non-null, has at least one non-whitespace
-	 * character,
-	 * and conforms to the specified regular expression.
+	 * Checks that a PID string is either null, or has at least one non-whitespace
+	 * character and conforms to the specified regular expression.
 	 *
 	 * @param putativePid the string to check.
 	 * @param name        the name of the string to use in any error messages.
+	 * @param optional    whether or not the field is optional. If true, null is a valid value for the PID.
 	 * @return the trimmed PID.
 	 */
-	static String checkPid(final String putativePid, final String name)
+	static String checkPid(final String putativePid, final String name, final boolean optional)
 			throws IllegalArgumentException {
-		final String pid = checkString(putativePid, name, -1);
+		final String pid = checkString(putativePid, name, optional);
+		if (pid == null) {
+			return null;
+		}
 		final Matcher m = VALID_PID_REGEX.matcher(pid);
 		if (m.find()) {
 			return m.replaceAll("$1:$2");
@@ -76,20 +79,16 @@ class Common {
 	}
 
 	/**
-	 * Checks that a PID string is either null or that it has at least one
-	 * non-whitespace character,
-	 * and conforms to the specified regular expression.
+	 * Checks that a PID string is non-null with at least one
+	 * non-whitespace character, and conforms to the specified regular expression.
 	 *
 	 * @param putativePid the string to check.
 	 * @param name        the name of the string to use in any error messages.
 	 * @return the trimmed PID or null.
 	 */
 
-	static String checkOptionalPid(final String putativePid, final String name) {
-		if (isNullOrEmpty(putativePid)) {
-			return null;
-		}
-		return checkPid(putativePid, name);
+	static String checkPid(final String putativePid, final String name) {
+		return checkPid(putativePid, name, false);
 	}
 
 	private static URL checkURL(final String putativeURL, final String name) {

--- a/src/us/kbase/workspace/database/provenance/Organization.java
+++ b/src/us/kbase/workspace/database/provenance/Organization.java
@@ -79,7 +79,7 @@ public class Organization {
 		 * @return this builder.
 		 */
 		public Builder withOrganizationID(final String organizationID) {
-			this.organizationID = Common.processString(organizationID);
+			this.organizationID = Common.checkOptionalPid(organizationID, "organizationID");
 			return this;
 		}
 

--- a/src/us/kbase/workspace/database/provenance/Organization.java
+++ b/src/us/kbase/workspace/database/provenance/Organization.java
@@ -1,9 +1,8 @@
 package us.kbase.workspace.database.provenance;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.Objects;
 import java.util.Optional;
+import us.kbase.workspace.database.Util;
 
 /**
  * Information about an organization.
@@ -68,7 +67,7 @@ public class Organization {
 		private String organizationID = null;
 
 		private Builder(final String organizationName) {
-			this.organizationName = requireNonNull(Common.processString(organizationName), "organizationName");
+			this.organizationName = Util.checkString(organizationName, "organizationName");
 		}
 
 		/**
@@ -79,7 +78,7 @@ public class Organization {
 		 * @return this builder.
 		 */
 		public Builder withOrganizationID(final String organizationID) {
-			this.organizationID = Common.checkOptionalPid(organizationID, "organizationID");
+			this.organizationID = Common.checkPid(organizationID, "organizationID", true);
 			return this;
 		}
 

--- a/src/us/kbase/workspace/test/database/UtilTest.java
+++ b/src/us/kbase/workspace/test/database/UtilTest.java
@@ -13,15 +13,15 @@ import static org.junit.Assert.fail;
 
 import us.kbase.common.test.TestCommon;
 import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.NS;
-import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.EMPTY_STRINGS;
-import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.EMPTY_STRINGS_WITH_NULL;
+import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.WHITESPACE_STRINGS;
+import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.WHITESPACE_STRINGS_WITH_NULL;
 
 import us.kbase.workspace.database.Util;
 
 public class UtilTest {
 
 	private static final String EXP_EXC = "expected exception";
-	private static final String INCORRECT_NULL_EMPTY = "incorrect null or empty";
+	private static final String INCORRECT_NULL_WHITESPACE = "incorrect null or empty";
 	private static final String INCORRECT_CHECKSTRING = "incorrect checkString";
 	private static final String TYPE_NAME = "some type";
 
@@ -36,7 +36,7 @@ public class UtilTest {
 	public static final String STRING2 = "A Series of Unfortunate Elephants";
 	public static final String STRING2_WITH_WHITESPACE = "\n\t   \t  A Series of Unfortunate Elephants\n\n ";
 
-	private static final List<String> NON_EMPTY_STRINGS = Arrays.asList(
+	private static final List<String> NON_WHITESPACE_STRINGS = Arrays.asList(
 			STRING,
 			STRING2,
 			"ab",
@@ -45,7 +45,7 @@ public class UtilTest {
 			STRING2_WITH_WHITESPACE,
 			FUN_UNICODE_STRING);
 
-	private static final List<String> NON_EMPTY_STRINGS_WITH_NULL = Arrays.asList(
+	private static final List<String> NON_WHITESPACE_STRINGS_WITH_NULL = Arrays.asList(
 			STRING,
 			STRING2,
 			"ab",
@@ -82,23 +82,23 @@ public class UtilTest {
 
 	@Test
 	public void isNullOrEmptyPass() throws Exception {
-		for (String empty : EMPTY_STRINGS_WITH_NULL) {
-			assertThat(INCORRECT_NULL_EMPTY, Util.isNullOrEmpty(empty), is(true));
+		for (String empty : WHITESPACE_STRINGS_WITH_NULL) {
+			assertThat(INCORRECT_NULL_WHITESPACE, Util.isNullOrEmpty(empty), is(true));
 		}
 	}
 
 	@Test
 	public void isNullOrEmptyFail() throws Exception {
-		for (String nullOrEmpty : NON_EMPTY_STRINGS) {
-			assertThat(INCORRECT_NULL_EMPTY, Util.isNullOrEmpty(nullOrEmpty), is(false));
+		for (String nullOrEmpty : NON_WHITESPACE_STRINGS) {
+			assertThat(INCORRECT_NULL_WHITESPACE, Util.isNullOrEmpty(nullOrEmpty), is(false));
 		}
 	}
 
 	@Test
 	public void nonNullPass() throws Exception {
 		final List<String> testList = new ArrayList<>();
-		testList.addAll(EMPTY_STRINGS);
-		testList.addAll(NON_EMPTY_STRINGS);
+		testList.addAll(WHITESPACE_STRINGS);
+		testList.addAll(NON_WHITESPACE_STRINGS);
 
 		for (String testString : testList) {
 			Util.nonNull(testString, "some message");
@@ -117,15 +117,15 @@ public class UtilTest {
 
 	@Test
 	public void noNullsPass() throws Exception {
-		Util.noNulls(NON_EMPTY_STRINGS, TYPE_NAME);
-		Util.noNulls(EMPTY_STRINGS, TYPE_NAME);
+		Util.noNulls(NON_WHITESPACE_STRINGS, TYPE_NAME);
+		Util.noNulls(WHITESPACE_STRINGS, TYPE_NAME);
 	}
 
 	@Test
 	public void noNullsFail() throws Exception {
 		final List<List<String>> testList = new ArrayList<>();
-		testList.add(EMPTY_STRINGS_WITH_NULL);
-		testList.add(NON_EMPTY_STRINGS_WITH_NULL);
+		testList.add(WHITESPACE_STRINGS_WITH_NULL);
+		testList.add(NON_WHITESPACE_STRINGS_WITH_NULL);
 
 		for (List<String> testListItem : testList) {
 			try {
@@ -139,15 +139,15 @@ public class UtilTest {
 
 	@Test
 	public void checkNoNullsOrEmptiesPass() throws Exception {
-		Util.checkNoNullsOrEmpties(NON_EMPTY_STRINGS, TYPE_NAME);
+		Util.checkNoNullsOrEmpties(NON_WHITESPACE_STRINGS, TYPE_NAME);
 	}
 
 	@Test
 	public void checkNoNullsOrEmptiesFail() throws Exception {
 		final List<List<String>> testList = new ArrayList<>();
-		testList.add(EMPTY_STRINGS);
-		testList.add(EMPTY_STRINGS_WITH_NULL);
-		testList.add(NON_EMPTY_STRINGS_WITH_NULL);
+		testList.add(WHITESPACE_STRINGS);
+		testList.add(WHITESPACE_STRINGS_WITH_NULL);
+		testList.add(NON_WHITESPACE_STRINGS_WITH_NULL);
 
 		for (List<String> testListItem : testList) {
 			try {
@@ -229,7 +229,7 @@ public class UtilTest {
 
 	@Test
 	public void checkStringFailNullOrEmpty() throws Exception {
-		for (String emptyNullString : EMPTY_STRINGS_WITH_NULL) {
+		for (String emptyNullString : WHITESPACE_STRINGS_WITH_NULL) {
 			try {
 				Util.checkString(emptyNullString, TYPE_NAME);
 				fail(EXP_EXC);
@@ -241,9 +241,19 @@ public class UtilTest {
 	}
 
 	@Test
+	public void checkStringPassNullOrEmpty() throws Exception {
+		for (String emptyNullString : WHITESPACE_STRINGS_WITH_NULL) {
+			assertThat(
+				INCORRECT_CHECKSTRING,
+				Util.checkString(emptyNullString, TYPE_NAME, true),
+				is(NS));
+		}
+	}
+
+	@Test
 	public void checkStringFailTooLong() throws Exception {
 		final int max = 1;
-		for (String nonEmptyString : NON_EMPTY_STRINGS) {
+		for (String nonEmptyString : NON_WHITESPACE_STRINGS) {
 			try {
 				Util.checkString(nonEmptyString, TYPE_NAME, max);
 				fail(EXP_EXC);

--- a/src/us/kbase/workspace/test/database/UtilTest.java
+++ b/src/us/kbase/workspace/test/database/UtilTest.java
@@ -81,16 +81,16 @@ public class UtilTest {
 	}
 
 	@Test
-	public void isNullOrEmptyPass() throws Exception {
+	public void isNullOrWhitespacePass() throws Exception {
 		for (String empty : WHITESPACE_STRINGS_WITH_NULL) {
-			assertThat(INCORRECT_NULL_WHITESPACE, Util.isNullOrEmpty(empty), is(true));
+			assertThat(INCORRECT_NULL_WHITESPACE, Util.isNullOrWhitespace(empty), is(true));
 		}
 	}
 
 	@Test
-	public void isNullOrEmptyFail() throws Exception {
+	public void isNullOrWhitespaceFail() throws Exception {
 		for (String nullOrEmpty : NON_WHITESPACE_STRINGS) {
-			assertThat(INCORRECT_NULL_WHITESPACE, Util.isNullOrEmpty(nullOrEmpty), is(false));
+			assertThat(INCORRECT_NULL_WHITESPACE, Util.isNullOrWhitespace(nullOrEmpty), is(false));
 		}
 	}
 

--- a/src/us/kbase/workspace/test/database/UtilTest.java
+++ b/src/us/kbase/workspace/test/database/UtilTest.java
@@ -12,247 +12,245 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import us.kbase.common.test.TestCommon;
-import static us.kbase.common.test.TestCommon.L;
-import static us.kbase.common.test.TestCommon.NL;
-import static us.kbase.common.test.TestCommon.NS;
-import static us.kbase.common.test.TestCommon.WHITESPACE;
-import static us.kbase.common.test.TestCommon.STRING;
-import static us.kbase.common.test.TestCommon.STRING_WITH_WHITESPACE;
+import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.NS;
+import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.EMPTY_STRINGS;
+import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.EMPTY_STRINGS_WITH_NULL;
+
 import us.kbase.workspace.database.Util;
 
 public class UtilTest {
 
-    private static final String EXP_EXC = "expected exception";
-    private static final String INCORRECT_NULL_EMPTY = "incorrect null or empty";
-    private static final String INCORRECT_CHECKSTRING = "incorrect checkString";
-    private static final String TYPE_NAME = "some type";
+	private static final String EXP_EXC = "expected exception";
+	private static final String INCORRECT_NULL_EMPTY = "incorrect null or empty";
+	private static final String INCORRECT_CHECKSTRING = "incorrect checkString";
+	private static final String TYPE_NAME = "some type";
 
-    private static final String FUN_UNICODE_STRING = "❌❉ ⨍∪ℕ ᏬᏁᎥς๏๔є sтя⌽ηg ❉❓❗";
+	private static final String FUN_UNICODE_STRING = "❌❉ ⨍∪ℕ ᏬᏁᎥς๏๔є sтя⌽ηg ❉❓❗";
 
-    private static final List<String> EMPTY_STRINGS = Arrays.asList(
-            "",
-            "   ",
-            "\n",
-            WHITESPACE);
 
-    private static final List<String> NON_EMPTY_STRINGS = Arrays.asList(
-            STRING,
-            "ab",
-            "\n5\n6\n7\n8\n",
-            STRING_WITH_WHITESPACE,
-            FUN_UNICODE_STRING);
+	private static final Long NL = null;
+	private static final long VALID_LONG = 1234567890;
 
-    private static final List<String> EMPTY_STRINGS_WITH_NULL = Arrays.asList(
-            "",
-            "   ",
-            NS,
-            "\n",
-            WHITESPACE);
+	public static final String STRING = "some string of stingy stringy strings strung together";
+	public static final String STRING_WITH_WHITESPACE = "\n\n    \f  some string of stingy stringy strings strung together \t  \n";
+	public static final String STRING2 = "A Series of Unfortunate Elephants";
+	public static final String STRING2_WITH_WHITESPACE = "\n\t   \t  A Series of Unfortunate Elephants\n\n ";
 
-    private static final List<String> NON_EMPTY_STRINGS_WITH_NULL = Arrays.asList(
-            STRING,
-            "ab",
-            "\n5\n6\n7\n8\n",
-            NS,
-            STRING_WITH_WHITESPACE,
-            FUN_UNICODE_STRING);
+	private static final List<String> NON_EMPTY_STRINGS = Arrays.asList(
+			STRING,
+			STRING2,
+			"ab",
+			"\n5\n6\n7\n8\n",
+			STRING_WITH_WHITESPACE,
+			STRING2_WITH_WHITESPACE,
+			FUN_UNICODE_STRING);
 
-    @Test
-    public void xorNameIdPass() throws Exception {
-        Util.xorNameId(NS, L, TYPE_NAME);
-        Util.xorNameId(STRING, NL, TYPE_NAME);
-    }
+	private static final List<String> NON_EMPTY_STRINGS_WITH_NULL = Arrays.asList(
+			STRING,
+			STRING2,
+			"ab",
+			"\n5\n6\n7\n8\n",
+			NS,
+			STRING_WITH_WHITESPACE,
+			STRING2_WITH_WHITESPACE,
+			FUN_UNICODE_STRING);
 
-    @Test
-    public void xorNameIdFail() throws Exception {
-        try {
-            Util.xorNameId(NS, NL, TYPE_NAME);
-            fail(EXP_EXC);
-        } catch (Exception got) {
-            TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
-                    "Must provide one and only one of some type name (was: null) or id (was: null)"));
-        }
+	@Test
+	public void xorNameIdPass() throws Exception {
+		Util.xorNameId(NS, VALID_LONG, TYPE_NAME);
+		Util.xorNameId(STRING, NL, TYPE_NAME);
+	}
 
-        try {
-            Util.xorNameId(STRING, L, "a different type");
-            fail(EXP_EXC);
-        } catch (Exception got) {
-            TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
-                    "Must provide one and only one of a different type name (was: some string of stingy stringy strings strung together) or id (was: 123456)"));
-        }
-    }
+	@Test
+	public void xorNameIdFail() throws Exception {
+		try {
+			Util.xorNameId(NS, NL, TYPE_NAME);
+			fail(EXP_EXC);
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+					"Must provide one and only one of some type name (was: null) or id (was: null)"));
+		}
 
-    @Test
-    public void isNullOrEmptyPass() throws Exception {
-        for (String empty : EMPTY_STRINGS_WITH_NULL) {
-            assertThat(INCORRECT_NULL_EMPTY, Util.isNullOrEmpty(empty), is(true));
-        }
-    }
+		try {
+			Util.xorNameId(STRING, VALID_LONG, "a different type");
+			fail(EXP_EXC);
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+					"Must provide one and only one of a different type name (was: some string of stingy stringy strings strung together) or id (was: 1234567890)"));
+		}
+	}
 
-    @Test
-    public void isNullOrEmptyFail() throws Exception {
-        for (String nullOrEmpty : NON_EMPTY_STRINGS) {
-            assertThat(INCORRECT_NULL_EMPTY, Util.isNullOrEmpty(nullOrEmpty), is(false));
-        }
-    }
+	@Test
+	public void isNullOrEmptyPass() throws Exception {
+		for (String empty : EMPTY_STRINGS_WITH_NULL) {
+			assertThat(INCORRECT_NULL_EMPTY, Util.isNullOrEmpty(empty), is(true));
+		}
+	}
 
-    @Test
-    public void nonNullPass() throws Exception {
-        for (String empty : EMPTY_STRINGS) {
-            Util.nonNull(empty, STRING);
-        }
+	@Test
+	public void isNullOrEmptyFail() throws Exception {
+		for (String nullOrEmpty : NON_EMPTY_STRINGS) {
+			assertThat(INCORRECT_NULL_EMPTY, Util.isNullOrEmpty(nullOrEmpty), is(false));
+		}
+	}
 
-        for (String nonEmpty : NON_EMPTY_STRINGS) {
-            Util.nonNull(nonEmpty, STRING);
-        }
-    }
+	@Test
+	public void nonNullPass() throws Exception {
+		final List<String> testList = new ArrayList<>();
+		testList.addAll(EMPTY_STRINGS);
+		testList.addAll(NON_EMPTY_STRINGS);
 
-    @Test
-    public void nonNullFail() throws Exception {
-        try {
-            Util.nonNull(null, STRING);
-            fail(EXP_EXC);
-        } catch (Exception got) {
-            TestCommon.assertExceptionCorrect(got, new NullPointerException(STRING));
-        }
-    }
+		for (String testString : testList) {
+			Util.nonNull(testString, "some message");
+		}
+	}
 
-    @Test
-    public void noNullsPass() throws Exception {
-        Util.noNulls(NON_EMPTY_STRINGS, TYPE_NAME);
-        Util.noNulls(EMPTY_STRINGS, TYPE_NAME);
-    }
+	@Test
+	public void nonNullFail() throws Exception {
+		try {
+			Util.nonNull(null, "error message");
+			fail(EXP_EXC);
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("error message"));
+		}
+	}
 
-    @Test
-    public void noNullsFail() throws Exception {
-        final List<List<String>> testList = new ArrayList<>();
-        testList.add(EMPTY_STRINGS_WITH_NULL);
-        testList.add(NON_EMPTY_STRINGS_WITH_NULL);
+	@Test
+	public void noNullsPass() throws Exception {
+		Util.noNulls(NON_EMPTY_STRINGS, TYPE_NAME);
+		Util.noNulls(EMPTY_STRINGS, TYPE_NAME);
+	}
 
-        for (List<String> testListItem : testList) {
-            try {
-                Util.noNulls(testListItem, STRING);
-                fail(EXP_EXC);
-            } catch (Exception got) {
-                TestCommon.assertExceptionCorrect(got, new NullPointerException(STRING));
-            }
-        }
-    }
+	@Test
+	public void noNullsFail() throws Exception {
+		final List<List<String>> testList = new ArrayList<>();
+		testList.add(EMPTY_STRINGS_WITH_NULL);
+		testList.add(NON_EMPTY_STRINGS_WITH_NULL);
 
-    @Test
-    public void checkNoNullsOrEmptiesPass() throws Exception {
-        Util.checkNoNullsOrEmpties(NON_EMPTY_STRINGS, TYPE_NAME);
-    }
+		for (List<String> testListItem : testList) {
+			try {
+				Util.noNulls(testListItem, "oh no!");
+				fail(EXP_EXC);
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new NullPointerException("oh no!"));
+			}
+		}
+	}
 
-    @Test
-    public void checkNoNullsOrEmptiesFail() throws Exception {
-        final List<List<String>> testList = new ArrayList<>();
-        testList.add(EMPTY_STRINGS);
-        testList.add(EMPTY_STRINGS_WITH_NULL);
-        testList.add(NON_EMPTY_STRINGS_WITH_NULL);
+	@Test
+	public void checkNoNullsOrEmptiesPass() throws Exception {
+		Util.checkNoNullsOrEmpties(NON_EMPTY_STRINGS, TYPE_NAME);
+	}
 
-        for (List<String> testListItem : testList) {
-            try {
-                Util.checkNoNullsOrEmpties(testListItem, TYPE_NAME);
-                fail(EXP_EXC);
-            } catch (Exception got) {
-                TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
-                        "Null or whitespace only string in collection some type"));
-            }
-        }
-    }
+	@Test
+	public void checkNoNullsOrEmptiesFail() throws Exception {
+		final List<List<String>> testList = new ArrayList<>();
+		testList.add(EMPTY_STRINGS);
+		testList.add(EMPTY_STRINGS_WITH_NULL);
+		testList.add(NON_EMPTY_STRINGS_WITH_NULL);
 
-    @Test
-    public void checkStringPass() throws Exception {
-        final Map<String, String> trimmedNonEmptyStrings = new HashMap<>();
-        trimmedNonEmptyStrings.put(STRING, STRING);
-        trimmedNonEmptyStrings.put("\n5\n6\n7\n8\n", "5\n6\n7\n8");
-        trimmedNonEmptyStrings.put(STRING_WITH_WHITESPACE, STRING);
+		for (List<String> testListItem : testList) {
+			try {
+				Util.checkNoNullsOrEmpties(testListItem, TYPE_NAME);
+				fail(EXP_EXC);
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+						"Null or whitespace only string in collection some type"));
+			}
+		}
+	}
 
-        for (Map.Entry<String, String> mapElement : trimmedNonEmptyStrings.entrySet()) {
-            assertThat(
-                    INCORRECT_CHECKSTRING,
-                    Util.checkString(mapElement.getKey(), TYPE_NAME),
-                    is(mapElement.getValue()));
-        }
+	@Test
+	public void checkStringPass() throws Exception {
+		final Map<String, String> trimmedNonEmptyStrings = new HashMap<>();
+		trimmedNonEmptyStrings.put(STRING, STRING);
+		trimmedNonEmptyStrings.put("\n5\n6\n7\n8\n", "5\n6\n7\n8");
+		trimmedNonEmptyStrings.put(STRING_WITH_WHITESPACE, STRING);
 
-        final int max = 53;
-        for (Map.Entry<String, String> mapElement : trimmedNonEmptyStrings.entrySet()) {
-            assertThat(
-                    INCORRECT_CHECKSTRING,
-                    Util.checkString(mapElement.getKey(), TYPE_NAME, max),
-                    is(mapElement.getValue()));
-            // max is only taken into account when larger than zero
-            assertThat(
-                    INCORRECT_CHECKSTRING,
-                    Util.checkString(mapElement.getKey(), TYPE_NAME, 0),
-                    is(mapElement.getValue()));
-            assertThat(
-                    INCORRECT_CHECKSTRING,
-                    Util.checkString(mapElement.getKey(), TYPE_NAME, -20),
-                    is(mapElement.getValue()));
-        }
+		for (Map.Entry<String, String> mapElement : trimmedNonEmptyStrings.entrySet()) {
+			assertThat(
+				INCORRECT_CHECKSTRING,
+				Util.checkString(mapElement.getKey(), TYPE_NAME),
+				is(mapElement.getValue()));
+		}
 
-    }
+		final int max = 53;
+		for (Map.Entry<String, String> mapElement : trimmedNonEmptyStrings.entrySet()) {
+			assertThat(
+				INCORRECT_CHECKSTRING,
+				Util.checkString(mapElement.getKey(), TYPE_NAME, max),
+				is(mapElement.getValue()));
+			// max is only taken into account when larger than zero
+			assertThat(
+				INCORRECT_CHECKSTRING,
+				Util.checkString(mapElement.getKey(), TYPE_NAME, 0),
+				is(mapElement.getValue()));
+			assertThat(
+				INCORRECT_CHECKSTRING,
+				Util.checkString(mapElement.getKey(), TYPE_NAME, -20),
+				is(mapElement.getValue()));
+		}
 
-    @Test
-    public void checkStringFancyUnicode() throws Exception {
+	}
 
-        // FUN_UNICODE_STRING should be 25 codePoints long.
-        final int codePointCount = 25;
-        assertThat(
-                INCORRECT_CHECKSTRING,
-                Util.checkString(FUN_UNICODE_STRING, TYPE_NAME, codePointCount),
-                is(FUN_UNICODE_STRING));
+	@Test
+	public void checkStringFancyUnicode() throws Exception {
 
-        // 𝔊 is two characters in length but only one code point
-        final String amendedFunString = FUN_UNICODE_STRING + "𝔊";
+		// FUN_UNICODE_STRING should be 25 codePoints long.
+		final int codePointCount = 25;
+		assertThat(
+			INCORRECT_CHECKSTRING,
+			Util.checkString(FUN_UNICODE_STRING, TYPE_NAME, codePointCount),
+			is(FUN_UNICODE_STRING));
 
-        assertThat(
-            "incorrect length vs codePointCount",
-            amendedFunString.length(),
-            is(amendedFunString.codePointCount(0, amendedFunString.length()) + 1));
+		// 𝔊 is two characters in length but only one code point
+		final String amendedFunString = FUN_UNICODE_STRING + "𝔊";
 
-        // the amended string will now fail
-        try {
-            Util.checkString(amendedFunString, TYPE_NAME, codePointCount);
-            fail(EXP_EXC);
-        } catch (Exception got) {
-            TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
-                    "some type size greater than limit 25"));
-        }
+		assertThat(
+			"incorrect length vs codePointCount",
+			amendedFunString.length(),
+			is(amendedFunString.codePointCount(0, amendedFunString.length()) + 1));
 
-        // but will pass with size 26
-        assertThat(
-                INCORRECT_CHECKSTRING,
-                Util.checkString(amendedFunString, TYPE_NAME, codePointCount + 1),
-                is(amendedFunString));
-    }
+		// the amended string will now fail
+		try {
+			Util.checkString(amendedFunString, TYPE_NAME, codePointCount);
+			fail(EXP_EXC);
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+					"some type size greater than limit 25"));
+		}
 
-    @Test
-    public void checkStringFailNullWhitespace() throws Exception {
-        for (String emptyNullString : EMPTY_STRINGS_WITH_NULL) {
-            try {
-                Util.checkString(emptyNullString, TYPE_NAME);
-                fail(EXP_EXC);
-            } catch (Exception got) {
-                TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
-                        "some type cannot be null or whitespace only"));
-            }
-        }
-    }
+		// but will pass with size 26
+		assertThat(
+			INCORRECT_CHECKSTRING,
+			Util.checkString(amendedFunString, TYPE_NAME, codePointCount + 1),
+			is(amendedFunString));
+	}
 
-    @Test
-    public void checkStringFailTooLong() throws Exception {
-        final int max = 1;
-        for (String nonEmptyString : NON_EMPTY_STRINGS) {
-            try {
-                Util.checkString(nonEmptyString, TYPE_NAME, max);
-                fail(EXP_EXC);
-            } catch (Exception got) {
-                TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
-                        "some type size greater than limit 1"));
-            }
-        }
-    }
+	@Test
+	public void checkStringFailNullOrEmpty() throws Exception {
+		for (String emptyNullString : EMPTY_STRINGS_WITH_NULL) {
+			try {
+				Util.checkString(emptyNullString, TYPE_NAME);
+				fail(EXP_EXC);
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+						"some type cannot be null or whitespace only"));
+			}
+		}
+	}
+
+	@Test
+	public void checkStringFailTooLong() throws Exception {
+		final int max = 1;
+		for (String nonEmptyString : NON_EMPTY_STRINGS) {
+			try {
+				Util.checkString(nonEmptyString, TYPE_NAME, max);
+				fail(EXP_EXC);
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+						"some type size greater than limit 1"));
+			}
+		}
+	}
 }

--- a/src/us/kbase/workspace/test/database/provenance/OrganizationTest.java
+++ b/src/us/kbase/workspace/test/database/provenance/OrganizationTest.java
@@ -12,7 +12,7 @@ import us.kbase.common.test.TestCommon;
 
 import static us.kbase.common.test.TestCommon.opt;
 import static us.kbase.common.test.TestCommon.ES;
-import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.EMPTY_STRINGS_WITH_NULL;
+import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.WHITESPACE_STRINGS_WITH_NULL;
 import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.VALID_PID_MAP;
 import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.INVALID_PID_LIST;
 
@@ -58,7 +58,7 @@ public class OrganizationTest {
 
 	@Test
 	public void buildWithNullOrEmptyOrgId() throws Exception {
-		for (String nullOrWs : EMPTY_STRINGS_WITH_NULL) {
+		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
 			final Organization org1 = Organization.getBuilder(ORG_NAME)
 					.withOrganizationID(nullOrWs)
 					.build();
@@ -69,7 +69,7 @@ public class OrganizationTest {
 
 	@Test
 	public void buildAndOverwriteOrgIdWithNullOrEmpty() throws Exception {
-		for (String nullOrWs : EMPTY_STRINGS_WITH_NULL) {
+		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
 			final Organization org1 = Organization.getBuilder(ORG_NAME)
 					.withOrganizationID(PID_STRING)
 					.withOrganizationID(nullOrWs)
@@ -97,12 +97,13 @@ public class OrganizationTest {
 
 	@Test
 	public void buildFailNullOrEmptyOrgName() throws Exception {
-		for (String nullOrWs : EMPTY_STRINGS_WITH_NULL) {
+		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
 			try {
 				Organization.getBuilder(nullOrWs).build();
 				fail(EXP_EXC);
 			} catch (Exception got) {
-				TestCommon.assertExceptionCorrect(got, new NullPointerException("organizationName"));
+				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+					"organizationName cannot be null or whitespace only"));
 			}
 		}
 	}

--- a/src/us/kbase/workspace/test/database/provenance/OrganizationTest.java
+++ b/src/us/kbase/workspace/test/database/provenance/OrganizationTest.java
@@ -3,16 +3,29 @@ package us.kbase.workspace.test.database.provenance;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static us.kbase.common.test.TestCommon.opt;
 
-import java.util.Optional;
+import java.util.Map;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import us.kbase.common.test.TestCommon;
+
+import static us.kbase.common.test.TestCommon.opt;
+import static us.kbase.common.test.TestCommon.ES;
+import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.EMPTY_STRINGS_WITH_NULL;
+import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.VALID_PID_MAP;
+import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.INVALID_PID_LIST;
+
 import us.kbase.workspace.database.provenance.Organization;
 
 public class OrganizationTest {
+	private static final String INCORRECT_NAME = "incorrect org name";
+	private static final String INCORRECT_ID = "incorrect org id";
+	private static final String EXP_EXC = "expected exception";
+
+	private static final String ORG_NAME = "The Illuminati, NorCal branch";
+	private static final String ORG_NAME_WITH_WHITESPACE = "\t    \r\n The Illuminati, NorCal branch\f\f  \n\r";
+	private static final String PID_STRING = "Some:reference";
 
 	@Test
 	public void equals() throws Exception {
@@ -21,72 +34,76 @@ public class OrganizationTest {
 
 	@Test
 	public void buildMinimal() throws Exception {
-		final Organization org1 = Organization.getBuilder("The Organisation").build();
-		assertThat("incorrect org name", org1.getOrganizationName(), is("The Organisation"));
-		assertThat("incorrect org ID", org1.getOrganizationID(), is(Optional.empty()));
+		final Organization org1 = Organization.getBuilder(ORG_NAME).build();
+		assertThat(INCORRECT_NAME, org1.getOrganizationName(), is(ORG_NAME));
+		assertThat(INCORRECT_ID, org1.getOrganizationID(), is(ES));
 	}
 
 	@Test
 	public void buildMaximal() throws Exception {
-		final Organization org1 = Organization.getBuilder("The Organisation").withOrganizationID("THIS:id").build();
-		assertThat("incorrect org name", org1.getOrganizationName(), is("The Organisation"));
-		assertThat("incorrect org ID", org1.getOrganizationID(), is(opt("THIS:id")));
+		final Organization org1 = Organization.getBuilder(ORG_NAME).withOrganizationID(PID_STRING).build();
+		assertThat(INCORRECT_NAME, org1.getOrganizationName(), is(ORG_NAME));
+		assertThat(INCORRECT_ID, org1.getOrganizationID(), is(opt(PID_STRING)));
 	}
 
 	@Test
 	public void buildTrimOrgNameAndId() throws Exception {
-		final Organization org1 = Organization.getBuilder("     \t\t    The Organisation      ")
-				.withOrganizationID("    \t\t THIS:id  \n   ").build();
-		assertThat("incorrect org name", org1.getOrganizationName(), is("The Organisation"));
-		assertThat("incorrect org ID", org1.getOrganizationID(), is(opt("THIS:id")));
-	}
-
-	@Test
-	public void buildWithWhitespaceOrgId() throws Exception {
-		final Organization org1 = Organization.getBuilder("The Organisation").withOrganizationID("    \t\t   \n   ")
-				.build();
-		assertThat("incorrect org name", org1.getOrganizationName(), is("The Organisation"));
-		assertThat("incorrect org ID", org1.getOrganizationID(), is(Optional.empty()));
-	}
-
-	@Test
-	public void buildWithNullOrgId() throws Exception {
-		final Organization org1 = Organization.getBuilder("The Organisation").withOrganizationID(null).build();
-		assertThat("incorrect org name", org1.getOrganizationName(), is("The Organisation"));
-		assertThat("incorrect org ID", org1.getOrganizationID(), is(Optional.empty()));
-	}
-
-	@Test
-	public void buildAndOverwriteOrgIdWithNull() throws Exception {
-		final Organization org1 = Organization.getBuilder("The Organisation").withOrganizationID("The:GrandWazoo")
-				.withOrganizationID("    \t\t   \n   ").build();
-		assertThat("incorrect org name", org1.getOrganizationName(), is("The Organisation"));
-		assertThat("incorrect org ID", org1.getOrganizationID(), is(Optional.empty()));
-
-		final Organization org2 = Organization.getBuilder("The Organisation").withOrganizationID("The:GrandWazoo")
-				.withOrganizationID(null).build();
-		assertThat("incorrect org name", org2.getOrganizationName(), is("The Organisation"));
-		assertThat("incorrect org ID", org2.getOrganizationID(), is(Optional.empty()));
-	}
-
-	@Test
-	public void buildFailWhitespaceOrgName() throws Exception {
-		try {
-			Organization.getBuilder("          ").build();
-			fail("expected exception");
-		} catch (Exception got) {
-			TestCommon.assertExceptionCorrect(got, new NullPointerException("organizationName"));
+		for (Map.Entry<String, String> mapElement : VALID_PID_MAP.entrySet()) {
+			final Organization org1 = Organization.getBuilder(ORG_NAME_WITH_WHITESPACE)
+					.withOrganizationID(mapElement.getKey()).build();
+			assertThat(INCORRECT_NAME, org1.getOrganizationName(), is(ORG_NAME));
+			assertThat(INCORRECT_ID, org1.getOrganizationID(), is(opt(mapElement.getValue())));
 		}
 	}
 
 	@Test
-	public void buildFailNullOrgName() throws Exception {
-		try {
-			Organization.getBuilder(null).build();
-			fail("expected exception");
-		} catch (Exception got) {
-			TestCommon.assertExceptionCorrect(got, new NullPointerException("organizationName"));
+	public void buildWithNullOrEmptyOrgId() throws Exception {
+		for (String nullOrWs : EMPTY_STRINGS_WITH_NULL) {
+			final Organization org1 = Organization.getBuilder(ORG_NAME)
+					.withOrganizationID(nullOrWs)
+					.build();
+			assertThat(INCORRECT_NAME, org1.getOrganizationName(), is(ORG_NAME));
+			assertThat(INCORRECT_ID, org1.getOrganizationID(), is(ES));
 		}
 	}
 
+	@Test
+	public void buildAndOverwriteOrgIdWithNullOrEmpty() throws Exception {
+		for (String nullOrWs : EMPTY_STRINGS_WITH_NULL) {
+			final Organization org1 = Organization.getBuilder(ORG_NAME)
+					.withOrganizationID(PID_STRING)
+					.withOrganizationID(nullOrWs)
+					.build();
+			assertThat(INCORRECT_NAME, org1.getOrganizationName(), is(ORG_NAME));
+			assertThat(INCORRECT_ID, org1.getOrganizationID(), is(ES));
+		}
+	}
+
+	@Test
+	public void buildFailInvalidPID() throws Exception {
+		for (String invalidPid : INVALID_PID_LIST) {
+			try {
+				Organization.getBuilder(ORG_NAME)
+						.withOrganizationID(invalidPid)
+						.build();
+				fail(EXP_EXC);
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+						"Illegal ID format for organizationID: \"" + invalidPid + "\"\n" +
+								"PIDs should match the pattern \"^([a-zA-Z0-9][a-zA-Z0-9\\.]+)\\s*:\\s*(\\S.+)$\""));
+			}
+		}
+	}
+
+	@Test
+	public void buildFailNullOrEmptyOrgName() throws Exception {
+		for (String nullOrWs : EMPTY_STRINGS_WITH_NULL) {
+			try {
+				Organization.getBuilder(nullOrWs).build();
+				fail(EXP_EXC);
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new NullPointerException("organizationName"));
+			}
+		}
+	}
 }

--- a/src/us/kbase/workspace/test/database/provenance/ProvenanceTestCommon.java
+++ b/src/us/kbase/workspace/test/database/provenance/ProvenanceTestCommon.java
@@ -1,0 +1,68 @@
+package us.kbase.workspace.test.database.provenance;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ProvenanceTestCommon {
+	public static final String NS = null;
+	public static final String WHITESPACE = "\n\n    \f     \t\t  \r\n   ";
+	public static final String STRING = "some string of stingy stringy strings strung together";
+	public static final String STRING_WITH_WHITESPACE = "\n\n    \f  some string of stingy stringy strings strung together \t  \n";
+	public static final String STRING2 = "A Series of Unfortunate Elephants";
+	public static final String STRING2_WITH_WHITESPACE = "\n\t   \t  A Series of Unfortunate Elephants\n\n ";
+	public static final String PID_STRING = "data.base:cross-reference";
+	public static final String PID_STRING_WITH_WHITESPACE = "  \ndata.base : cross-reference\t\t    \n  ";
+
+	public static final List<String> EMPTY_STRINGS = Collections.unmodifiableList(Arrays.asList(
+		"",
+		"   ",
+		" \f ",
+		"\r",
+		"\n",
+		WHITESPACE));
+
+	public static final List<String> EMPTY_STRINGS_WITH_NULL = Collections.unmodifiableList(Arrays.asList(
+		"",
+		"   ",
+		NS,
+		" \f ",
+		"\r",
+		"\n",
+		WHITESPACE));
+
+	public static final List<String> INVALID_PID_LIST = Collections.unmodifiableList(Arrays.asList(
+		// spaces in prefix
+		"Too long: didn't read",
+		"t\tl:d\tr",
+		// no prefix
+		":didn't read",
+		"\f  :didn't read",
+		"\t\t\t      :D\n  \t  ",
+		// invalid prefix
+		"too-long:didn'tread",
+		"'too.long:didnotread'",
+		".toolong:didnotread",
+		"too\blong:didn't.read",
+		// no suffix
+		"too long:",
+		"too long:\r\n   \f     \n"));
+
+	public static final Map<String, String> VALID_PID_MAP;
+	static {
+		final String tldr = "TL:DR";
+		Map<String, String> validPids = new HashMap<>();
+		validPids.put(tldr, tldr);
+		validPids.put("\r\n  TL:DR    \n\n\t ", tldr);
+		validPids.put("Too.Long:Didn't.Read", "Too.Long:Didn't.Read");
+		validPids.put("  toolong : didntread  ", "toolong:didntread");
+		validPids.put("\n2.long: didn't read\n", "2.long:didn't read");
+		validPids.put("too.long:\n\ndidn't.read", "too.long:didn't.read");
+		validPids.put("tl\n\n  :d\tr\n\n  ", "tl:d\tr");
+		validPids.put("tl: (┛ಠДಠ)┛彡┻━┻ ", "tl:(┛ಠДಠ)┛彡┻━┻");
+		validPids.put(" https://this.is.the.url/ ", "https://this.is.the.url/");
+		VALID_PID_MAP = Collections.unmodifiableMap(validPids);
+	}
+}

--- a/src/us/kbase/workspace/test/database/provenance/ProvenanceTestCommon.java
+++ b/src/us/kbase/workspace/test/database/provenance/ProvenanceTestCommon.java
@@ -9,12 +9,6 @@ import java.util.Map;
 public class ProvenanceTestCommon {
 	public static final String NS = null;
 	public static final String WHITESPACE = "\n\n    \f     \t\t  \r\n   ";
-	public static final String STRING = "some string of stingy stringy strings strung together";
-	public static final String STRING_WITH_WHITESPACE = "\n\n    \f  some string of stingy stringy strings strung together \t  \n";
-	public static final String STRING2 = "A Series of Unfortunate Elephants";
-	public static final String STRING2_WITH_WHITESPACE = "\n\t   \t  A Series of Unfortunate Elephants\n\n ";
-	public static final String PID_STRING = "data.base:cross-reference";
-	public static final String PID_STRING_WITH_WHITESPACE = "  \ndata.base : cross-reference\t\t    \n  ";
 
 	public static final List<String> EMPTY_STRINGS = Collections.unmodifiableList(Arrays.asList(
 		"",

--- a/src/us/kbase/workspace/test/database/provenance/ProvenanceTestCommon.java
+++ b/src/us/kbase/workspace/test/database/provenance/ProvenanceTestCommon.java
@@ -10,7 +10,7 @@ public class ProvenanceTestCommon {
 	public static final String NS = null;
 	public static final String WHITESPACE = "\n\n    \f     \t\t  \r\n   ";
 
-	public static final List<String> EMPTY_STRINGS = Collections.unmodifiableList(Arrays.asList(
+	public static final List<String> WHITESPACE_STRINGS = Collections.unmodifiableList(Arrays.asList(
 		"",
 		"   ",
 		" \f ",
@@ -18,7 +18,7 @@ public class ProvenanceTestCommon {
 		"\n",
 		WHITESPACE));
 
-	public static final List<String> EMPTY_STRINGS_WITH_NULL = Collections.unmodifiableList(Arrays.asList(
+	public static final List<String> WHITESPACE_STRINGS_WITH_NULL = Collections.unmodifiableList(Arrays.asList(
 		"",
 		"   ",
 		NS,


### PR DESCRIPTION
this should slot in before the [CE-94 / PID pull request](https://github.com/kbase/workspace_deluxe/pull/636).

- moved the various test constants out of TestCommon and into WorkspaceTestCommon
- implemented the PID checker and added the ability to return null if the dbxref is null or empty
- minor refactoring of the Organization tests to be better organised