### PR TITLE
CE-95: event date

### DIFF
--- a/src/us/kbase/workspace/database/provenance/Common.java
+++ b/src/us/kbase/workspace/database/provenance/Common.java
@@ -92,23 +92,6 @@ class Common {
 	/**
 	 * Trims leading and trailing whitespace, converts empty strings to null, and then
          * checks that a string is either null or has at least one non-whitespace character
-         * and conforms to the specified regular expression.
-         * If optional is true, null is a valid output value; if false, null will throw an error.
-	 *
-	 * @param stringToCheck the string to check.
-	 * @param pattern       the pattern to validate against.
-	 * @param name          the name of the string to use in any error messages.
-	 * @param optional      whether or not the field is optional. If false, null and
-         *                      empty or whitespace-only input strings will throw an error.
-	 * @return the trimmed field, or null if the input string was null or whitespace.
-	 */
-	static String checkAgainstRegex(final String stringToCheck, final Pattern pattern, final String name, final boolean optional) {
-		return checkAgainstRegex(stringToCheck, pattern, null, name, optional);
-	}
-
-	/**
-	 * Trims leading and trailing whitespace, converts empty strings to null, and then
-         * checks that a string is either null or has at least one non-whitespace character
          * and conforms to the regular expression VALID_PID_REGEX.
          * If optional is true, null is a valid output value; if false, null will throw an error.
 	 *

--- a/src/us/kbase/workspace/database/provenance/Event.java
+++ b/src/us/kbase/workspace/database/provenance/Event.java
@@ -2,6 +2,7 @@ package us.kbase.workspace.database.provenance;
 
 import java.util.HashMap;
 import java.util.Map;
+import us.kbase.workspace.database.Util;
 
 /**
  * A class representing resource lifecycle events
@@ -21,7 +22,6 @@ public enum Event {
 	WITHDRAWN("withdrawn"),
 	OTHER("other");
 
-	// mapping of PIDs and lowercaseNames to ContributorRole
 	private static final Map<String, Event> STRING_TO_EVENT_MAP = new HashMap<>();
 	static {
 		for (final Event e : Event.values()) {
@@ -36,9 +36,9 @@ public enum Event {
 	}
 
 	/**
-	 * Get the lowercase name of this contributor role.
+	 * Get the event name.
 	 *
-	 * @return the lowercaseName.
+	 * @return the eventName.
 	 */
 	public String getEventName() {
 		return eventName;
@@ -53,7 +53,7 @@ public enum Event {
 	 *                                  input string.
 	 */
 	public static Event getEvent(final String input) {
-		final String lowercaseInput = Common.processString(input.toLowerCase());
+		final String lowercaseInput = Util.checkString(input, "event").toLowerCase();
 		if (!STRING_TO_EVENT_MAP.containsKey(lowercaseInput)) {
 			throw new IllegalArgumentException("Invalid event: " + input);
 		}

--- a/src/us/kbase/workspace/database/provenance/Event.java
+++ b/src/us/kbase/workspace/database/provenance/Event.java
@@ -47,7 +47,7 @@ public enum Event {
 	/**
 	 * Get an event based on a supplied string.
 	 *
-	 * @param str a string representing an event.
+	 * @param input a string representing an event.
 	 * @return an Event.
 	 * @throws IllegalArgumentException if there is no event corresponding to the
 	 *                                  input string.

--- a/src/us/kbase/workspace/database/provenance/Event.java
+++ b/src/us/kbase/workspace/database/provenance/Event.java
@@ -1,0 +1,62 @@
+package us.kbase.workspace.database.provenance;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A class representing resource lifecycle events
+ */
+
+public enum Event {
+
+	ACCEPTED("accepted"),
+	AVAILABLE("available"),
+	COPYRIGHTED("copyrighted"),
+	COLLECTED("collected"),
+	CREATED("created"),
+	ISSUED("issued"),
+	SUBMITTED("submitted"),
+	UPDATED("updated"),
+	VALID("valid"),
+	WITHDRAWN("withdrawn"),
+	OTHER("other");
+
+	// mapping of PIDs and lowercaseNames to ContributorRole
+	private static final Map<String, Event> STRING_TO_EVENT_MAP = new HashMap<>();
+	static {
+		for (final Event e : Event.values()) {
+			STRING_TO_EVENT_MAP.put(e.getEventName(), e);
+		}
+	}
+
+	private final String eventName;
+
+	private Event(final String eventName) {
+		this.eventName = eventName;
+	}
+
+	/**
+	 * Get the lowercase name of this contributor role.
+	 *
+	 * @return the lowercaseName.
+	 */
+	public String getEventName() {
+		return eventName;
+	}
+
+	/**
+	 * Get an event based on a supplied string.
+	 *
+	 * @param str a string representing an event.
+	 * @return an Event.
+	 * @throws IllegalArgumentException if there is no event corresponding to the
+	 *                                  input string.
+	 */
+	public static Event getEvent(final String input) {
+		final String lowercaseInput = Common.processString(input.toLowerCase());
+		if (!STRING_TO_EVENT_MAP.containsKey(lowercaseInput)) {
+			throw new IllegalArgumentException("Invalid event: " + input);
+		}
+		return STRING_TO_EVENT_MAP.get(lowercaseInput);
+	}
+}

--- a/src/us/kbase/workspace/database/provenance/EventDate.java
+++ b/src/us/kbase/workspace/database/provenance/EventDate.java
@@ -10,7 +10,7 @@ import us.kbase.workspace.database.Util;
 public class EventDate {
 
 	private final String date;
-	private final String event;
+	private final Event event;
 
 	/**
 	 * VALID_DATE_REGEX ensures that dates are in one of the following formats:
@@ -26,7 +26,7 @@ public class EventDate {
 
 	private EventDate(
 			final String date,
-			final String event) {
+			final Event event) {
 		this.date = date;
 		this.event = event;
 	}
@@ -43,11 +43,11 @@ public class EventDate {
 	}
 
 	/**
-	 * Gets the event that occurred on the date in question, for example "updated".
+	 * Gets the event that occurred on the date in question, for example Event.UPDATED.
 	 *
 	 * @return the event.
 	 */
-	public String getEvent() {
+	public Event getEvent() {
 		return event;
 	}
 
@@ -73,10 +73,22 @@ public class EventDate {
 	 *
 	 * @param date  the date when the event occurred,
 	 *              in the format yyyy-MM-dd, yyyy-MM, or yyyy.
-	 * @param event the event that occurred on that date
+	 * @param event the event that occurred on that date, as a string
 	 * @return the builder.
 	 */
 	public static Builder getBuilder(final String date, final String event) {
+		return new Builder(date, event);
+	}
+
+	/**
+	 * Gets a builder for an {@link EventDate}.
+	 *
+	 * @param date  the date when the event occurred,
+	 *              in the format yyyy-MM-dd, yyyy-MM, or yyyy.
+	 * @param event the event that occurred on that date, as an Event
+	 * @return the builder.
+	 */
+	public static Builder getBuilder(final String date, final Event event) {
 		return new Builder(date, event);
 	}
 
@@ -84,10 +96,18 @@ public class EventDate {
 	public static class Builder {
 
 		private String date;
-		private String event;
+		private Event event;
 
 		private Builder(final String date, final String event) {
-			this.event = Util.checkString(event, "event");
+			final String protoEvent = Util.checkString(event, "event");
+			this.event = Event.getEvent(protoEvent);
+			final String protoDate = Util.checkString(date, "date");
+			this.date = Common.checkAgainstRegex(protoDate, VALID_DATE_REGEX, "date", false);
+		}
+
+		private Builder(final String date, final Event event) {
+			Objects.requireNonNull(event, "event cannot be null");
+			this.event = event;
 			final String protoDate = Util.checkString(date, "date");
 			this.date = Common.checkAgainstRegex(protoDate, VALID_DATE_REGEX, "date", false);
 		}

--- a/src/us/kbase/workspace/database/provenance/EventDate.java
+++ b/src/us/kbase/workspace/database/provenance/EventDate.java
@@ -1,0 +1,96 @@
+package us.kbase.workspace.database.provenance;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import us.kbase.workspace.database.Util;
+
+/**
+ * The date of a specified event.
+ */
+public class EventDate {
+
+	private final String date;
+	private final String dateFormat;
+	private final String event;
+
+	public static final Pattern VALID_DATE_FORMAT_REGEX = Pattern.compile("^YYYY(-MM(-DD)?)?$");
+
+	public static final Pattern VALID_DATE_REGEX = Pattern.compile("^[12]\\d{3}(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\\d|3[01]))?)?$");
+
+	private EventDate(
+		final String date,
+		final String dateFormat,
+		final String event) {
+		this.date = date;
+		this.dateFormat = dateFormat;
+		this.event = event;
+	}
+
+	/** Get the date, for example "2022-05-10".
+	 * @return the date.
+	 */
+	public String getDate() {
+		return date;
+	}
+
+	/** Get the format of the date, for example "YYYY-MM-DD".
+	 * @return the date format.
+	 */
+	public String getDateFormat() {
+		return dateFormat;
+	}
+
+	/** Get the event that occurred on the date in question, for example "updated".
+	 * @return the event.
+	 */
+	public String getEvent() {
+		return event;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(date, dateFormat, event);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		EventDate other = (EventDate) obj;
+		return Objects.equals(date, other.date) && Objects.equals(dateFormat, other.dateFormat)
+				&& Objects.equals(event, other.event);
+	}
+
+	/** Get a builder for an {@link EventDate}.
+	 * @return the builder.
+	 */
+	public static Builder getBuilder(final String date, final String dateFormat, final String event) {
+		return new Builder(date, dateFormat, event);
+	}
+
+	/** A builder for an {@link EventDate}. */
+	public static class Builder {
+
+		private String date;
+		private String dateFormat;
+		private String event;
+
+		private Builder(final String date, final String dateFormat, final String event) {
+			this.date = Common.checkAgainstRegex(date, VALID_DATE_REGEX, "date", false);
+			this.dateFormat = Common.checkAgainstRegex(dateFormat, VALID_DATE_FORMAT_REGEX, "dateFormat", false);
+			this.event = Util.checkString(event, "event");
+		}
+
+		/** Build the {@link EventDate}.
+		 * @return the external data.
+		 */
+		public EventDate build() {
+			return new EventDate(date, dateFormat, event);
+		}
+	}
+}

--- a/src/us/kbase/workspace/database/provenance/EventDate.java
+++ b/src/us/kbase/workspace/database/provenance/EventDate.java
@@ -18,27 +18,33 @@ public class EventDate {
 	 * yyyy-MM
 	 * yyyy-MM-dd
 	 *
-	 * It also ensures that months are in the range 00-12 and days are in the range 00-31.
+	 * It also ensures that months are in the range 00-12 and days are in the range
+	 * 00-31.
 	 */
-	public static final Pattern VALID_DATE_REGEX = Pattern.compile("^[12]\\d{3}(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\\d|3[01]))?)?$");
+	public static final Pattern VALID_DATE_REGEX = Pattern.compile(
+			"^[12]\\d{3}(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\\d|3[01]))?)?$");
 
 	private EventDate(
-		final String date,
-		final String event) {
+			final String date,
+			final String event) {
 		this.date = date;
 		this.event = event;
 	}
 
-	/** Gets the date, for example "2022-05-10".
-	 * Dates are returned in the format yyyy-MM-dd; if no data is available for the month
-	 * or day, the string is truncated to yyyy-MM or yyyy respectively.
+	/**
+	 * Gets the date, for example "2022-05-10".
+	 * Dates are returned in the format yyyy-MM-dd; if no data is available for the
+	 * month or day, the string is truncated to yyyy-MM or yyyy respectively.
+	 *
 	 * @return the date.
 	 */
 	public String getDate() {
 		return date;
 	}
 
-	/** Gets the event that occurred on the date in question, for example "updated".
+	/**
+	 * Gets the event that occurred on the date in question, for example "updated".
+	 *
 	 * @return the event.
 	 */
 	public String getEvent() {
@@ -62,11 +68,12 @@ public class EventDate {
 		return Objects.equals(date, other.date) && Objects.equals(event, other.event);
 	}
 
-	/** Gets a builder for an {@link EventDate}.
+	/**
+	 * Gets a builder for an {@link EventDate}.
 	 *
-	 * @param date        the date when the event occurred,
-	 *                    in the format yyyy-MM-dd, yyyy-MM, or yyyy.
-	 * @param event       the event that occurred on that date
+	 * @param date  the date when the event occurred,
+	 *              in the format yyyy-MM-dd, yyyy-MM, or yyyy.
+	 * @param event the event that occurred on that date
 	 * @return the builder.
 	 */
 	public static Builder getBuilder(final String date, final String event) {
@@ -85,7 +92,9 @@ public class EventDate {
 			this.date = Common.checkAgainstRegex(protoDate, VALID_DATE_REGEX, "date", false);
 		}
 
-		/** Builds the {@link EventDate}.
+		/**
+		 * Builds the {@link EventDate}.
+		 *
 		 * @return the event date.
 		 */
 		public EventDate build() {

--- a/src/us/kbase/workspace/database/provenance/EventDate.java
+++ b/src/us/kbase/workspace/database/provenance/EventDate.java
@@ -80,7 +80,7 @@ public class EventDate {
 	 * @param date  the date when the event occurred,
 	 *              in the format yyyy-MM-dd, yyyy-MM, or yyyy.
 	 * @param event the event that occurred on that date, as an Event
-	 * @return the new EventDate.
+	 * @return the new {@link EventDate}.
 	 */
 	public static EventDate build(final String date, final Event event) {
 		Objects.requireNonNull(event, "event cannot be null");

--- a/src/us/kbase/workspace/database/provenance/EventDate.java
+++ b/src/us/kbase/workspace/database/provenance/EventDate.java
@@ -66,7 +66,8 @@ public class EventDate {
 	 *
 	 * @param date  the date when the event occurred,
 	 *              in the format yyyy-MM-dd, yyyy-MM, or yyyy.
-	 * @param event the event that occurred on that date, as a string
+	 * @param event the event that occurred on that date, as a string.
+	 *              See the {@link Event} class for valid string values.
 	 * @return the new {@link EventDate}.
 	 */
 	public static EventDate build(final String date, final String event) {
@@ -114,6 +115,6 @@ public class EventDate {
 				// report the error below as an IllegalArgumentException
 			}
 		}
-		throw new IllegalArgumentException("Invalid date: \"" + protoDate + "\"\ndate must be in the format yyyy, yyyy-MM, or yyyy-MM-dd");
+		throw new IllegalArgumentException("Invalid date: \"" + protoDate + "\"\ndate must be in the format yyyy, yyyy-MM, or yyyy-MM-dd and be a valid combination of day, month, and year.");
 	}
 }

--- a/src/us/kbase/workspace/database/provenance/EventDate.java
+++ b/src/us/kbase/workspace/database/provenance/EventDate.java
@@ -2,7 +2,6 @@ package us.kbase.workspace.database.provenance;
 
 import java.util.Objects;
 import java.util.regex.Pattern;
-
 import us.kbase.workspace.database.Util;
 
 /**
@@ -11,37 +10,35 @@ import us.kbase.workspace.database.Util;
 public class EventDate {
 
 	private final String date;
-	private final String dateFormat;
 	private final String event;
 
-	public static final Pattern VALID_DATE_FORMAT_REGEX = Pattern.compile("^YYYY(-MM(-DD)?)?$");
-
+	/**
+	 * VALID_DATE_REGEX ensures that dates are in one of the following formats:
+	 * yyyy
+	 * yyyy-MM
+	 * yyyy-MM-dd
+	 *
+	 * It also ensures that months are in the range 00-12 and days are in the range 00-31.
+	 */
 	public static final Pattern VALID_DATE_REGEX = Pattern.compile("^[12]\\d{3}(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\\d|3[01]))?)?$");
 
 	private EventDate(
 		final String date,
-		final String dateFormat,
 		final String event) {
 		this.date = date;
-		this.dateFormat = dateFormat;
 		this.event = event;
 	}
 
-	/** Get the date, for example "2022-05-10".
+	/** Gets the date, for example "2022-05-10".
+	 * Dates are returned in the format yyyy-MM-dd; if no data is available for the month
+	 * or day, the string is truncated to yyyy-MM or yyyy respectively.
 	 * @return the date.
 	 */
 	public String getDate() {
 		return date;
 	}
 
-	/** Get the format of the date, for example "YYYY-MM-DD".
-	 * @return the date format.
-	 */
-	public String getDateFormat() {
-		return dateFormat;
-	}
-
-	/** Get the event that occurred on the date in question, for example "updated".
+	/** Gets the event that occurred on the date in question, for example "updated".
 	 * @return the event.
 	 */
 	public String getEvent() {
@@ -50,7 +47,7 @@ public class EventDate {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(date, dateFormat, event);
+		return Objects.hash(date, event);
 	}
 
 	@Override
@@ -62,35 +59,37 @@ public class EventDate {
 		if (getClass() != obj.getClass())
 			return false;
 		EventDate other = (EventDate) obj;
-		return Objects.equals(date, other.date) && Objects.equals(dateFormat, other.dateFormat)
-				&& Objects.equals(event, other.event);
+		return Objects.equals(date, other.date) && Objects.equals(event, other.event);
 	}
 
-	/** Get a builder for an {@link EventDate}.
+	/** Gets a builder for an {@link EventDate}.
+	 *
+	 * @param date        the date when the event occurred,
+	 *                    in the format yyyy-MM-dd, yyyy-MM, or yyyy.
+	 * @param event       the event that occurred on that date
 	 * @return the builder.
 	 */
-	public static Builder getBuilder(final String date, final String dateFormat, final String event) {
-		return new Builder(date, dateFormat, event);
+	public static Builder getBuilder(final String date, final String event) {
+		return new Builder(date, event);
 	}
 
 	/** A builder for an {@link EventDate}. */
 	public static class Builder {
 
 		private String date;
-		private String dateFormat;
 		private String event;
 
-		private Builder(final String date, final String dateFormat, final String event) {
-			this.date = Common.checkAgainstRegex(date, VALID_DATE_REGEX, "date", false);
-			this.dateFormat = Common.checkAgainstRegex(dateFormat, VALID_DATE_FORMAT_REGEX, "dateFormat", false);
+		private Builder(final String date, final String event) {
 			this.event = Util.checkString(event, "event");
+			final String protoDate = Util.checkString(date, "date");
+			this.date = Common.checkAgainstRegex(protoDate, VALID_DATE_REGEX, "date", false);
 		}
 
-		/** Build the {@link EventDate}.
-		 * @return the external data.
+		/** Builds the {@link EventDate}.
+		 * @return the event date.
 		 */
 		public EventDate build() {
-			return new EventDate(date, dateFormat, event);
+			return new EventDate(date, event);
 		}
 	}
 }

--- a/src/us/kbase/workspace/database/provenance/EventDate.java
+++ b/src/us/kbase/workspace/database/provenance/EventDate.java
@@ -43,7 +43,7 @@ public class EventDate {
 	}
 
 	/**
-	 * Gets the event that occurred on the date in question, for example Event.UPDATED.
+	 * Gets the event that occurred on the date in question, for example {@link Event#UPDATED}.
 	 *
 	 * @return the event.
 	 */

--- a/src/us/kbase/workspace/database/provenance/EventDate.java
+++ b/src/us/kbase/workspace/database/provenance/EventDate.java
@@ -67,7 +67,7 @@ public class EventDate {
 	 * @param date  the date when the event occurred,
 	 *              in the format yyyy-MM-dd, yyyy-MM, or yyyy.
 	 * @param event the event that occurred on that date, as a string
-	 * @return the new EventDate.
+	 * @return the new {@link EventDate}.
 	 */
 	public static EventDate build(final String date, final String event) {
 		final Event eventObject = Event.getEvent(Util.checkString(event, "event"));

--- a/src/us/kbase/workspace/test/database/provenance/EventDateTest.java
+++ b/src/us/kbase/workspace/test/database/provenance/EventDateTest.java
@@ -14,6 +14,7 @@ import us.kbase.common.test.TestCommon;
 import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.WHITESPACE_STRINGS_WITH_NULL;
 
 import us.kbase.workspace.database.provenance.EventDate;
+import us.kbase.workspace.database.provenance.Event;
 
 public class EventDateTest {
 	static final String INCORRECT_DATE = "incorrect date";
@@ -21,9 +22,9 @@ public class EventDateTest {
 	static final String EXP_EXC = "expected exception";
 
 	static final String DATE_STRING = "2022-12-12";
-	static final String EVENT_STRING = "blah blah blah";
-	static final String EVENT_STRING_UNTRIMMED = " \n\n\n blah blah blah \r\n  ";
-
+	static final String EVENT_STRING = "accepted";
+	static final String EVENT_STRING_UNTRIMMED = " \n\n\n accepted \r\n  ";
+	static final Event SOME_EVENT = Event.ACCEPTED;
 	static final Map<String, String> DATE_INPUTS;
 	static {
 		Map<String, String> dateInputs = new HashMap<>();
@@ -56,20 +57,31 @@ public class EventDateTest {
 	}
 
 	@Test
-	public void buildEventDate() throws Exception {
-		for (String key : DATE_INPUTS.keySet()) {
-			final EventDate ed1 = EventDate.getBuilder(key, EVENT_STRING).build();
-			assertThat(INCORRECT_DATE, ed1.getDate(), is(DATE_INPUTS.get(key)));
-			assertThat(INCORRECT_EVENT, ed1.getEvent(), is(EVENT_STRING));
+	public void buildEventDateWithEnum() throws Exception {
+		for (Map.Entry<String, String> entry : DATE_INPUTS.entrySet()) {
+			final EventDate ed1 = EventDate.getBuilder(entry.getKey(), SOME_EVENT).build();
+			assertThat(INCORRECT_DATE, ed1.getDate(), is(entry.getValue()));
+			assertThat(INCORRECT_EVENT, ed1.getEvent(), is(SOME_EVENT));
 
 		}
 	}
 
 	@Test
+	public void buildEventDateWithString() throws Exception {
+		for (Map.Entry<String, String> entry : DATE_INPUTS.entrySet()) {
+			final EventDate ed1 = EventDate.getBuilder(entry.getKey(), EVENT_STRING).build();
+			assertThat(INCORRECT_DATE, ed1.getDate(), is(entry.getValue()));
+			assertThat(INCORRECT_EVENT, ed1.getEvent(), is(SOME_EVENT));
+
+		}
+	}
+
+
+	@Test
 	public void buildEventDateFailDate() throws Exception {
 		for (String dateStr : invalidDateStrings) {
 			try {
-				EventDate.getBuilder(dateStr, EVENT_STRING).build();
+				EventDate.getBuilder(dateStr, SOME_EVENT).build();
 				fail(EXP_EXC);
 			} catch (Exception got) {
 				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
@@ -81,10 +93,36 @@ public class EventDateTest {
 	}
 
 	@Test
+	public void buildEventDateFailEvent() throws Exception {
+		try {
+			EventDate.getBuilder(DATE_STRING, "kookaburra").build();
+			fail(EXP_EXC);
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+				"Invalid event: kookaburra"
+			));
+		}
+	}
+
+	@Test
+	public void buildEventDateFailNullEvent() throws Exception {
+		final Event nullEvent = null;
+		try {
+			EventDate.getBuilder(DATE_STRING, nullEvent).build();
+			fail(EXP_EXC);
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException(
+				"event cannot be null"
+			));
+		}
+	}
+
+
+	@Test
 	public void buildAndTrimEvent() throws Exception {
 		final EventDate ed1 = EventDate.getBuilder(DATE_STRING, EVENT_STRING_UNTRIMMED).build();
 		assertThat(INCORRECT_DATE, ed1.getDate(), is(DATE_STRING));
-		assertThat(INCORRECT_EVENT, ed1.getEvent(), is(EVENT_STRING));
+		assertThat(INCORRECT_EVENT, ed1.getEvent(), is(SOME_EVENT));
 	}
 
 	@Test

--- a/src/us/kbase/workspace/test/database/provenance/EventDateTest.java
+++ b/src/us/kbase/workspace/test/database/provenance/EventDateTest.java
@@ -1,0 +1,142 @@
+package us.kbase.workspace.test.database.provenance;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import us.kbase.common.test.TestCommon;
+import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.WHITESPACE_STRINGS_WITH_NULL;
+
+import us.kbase.workspace.database.provenance.EventDate;
+
+public class EventDateTest {
+	static final String INCORRECT_DATE = "incorrect date";
+	static final String INCORRECT_FORMAT = "incorrect date format";
+	static final String INCORRECT_EVENT = "incorrect event";
+	static final String EXP_EXC = "expected exception";
+
+	static final String DATE_STRING = "2012-12-12";
+	static final String DATE_STRING_UNTRIMMED = "  2012-12-12   ";
+
+	static final String FORMAT_STRING = "YYYY-MM-DD";
+	static final String FORMAT_STRING_UNTRIMMED = "  YYYY-MM-DD   ";
+
+	static final String EVENT_STRING = "blah blah blah";
+	static final String EVENT_STRING_UNTRIMMED = "  blah blah blah   ";
+
+	static final String[] validDateFormatStrings = {
+		"YYYY",
+		"YYYY-MM",
+		FORMAT_STRING,
+		FORMAT_STRING_UNTRIMMED
+	};
+
+	static final String[] validDateStrings = {
+		"2022",
+		"2022-03",
+		"2022-12-31",
+		"1829-01-01",
+		DATE_STRING,
+		DATE_STRING_UNTRIMMED
+	};
+
+
+	static final String[] invalidDateFormatStrings = {
+		"yyyy",
+		"yyyy-dd",
+		"YYYY-DD",
+		"YY-MM",
+		"YY-MM-DD",
+		"YYYY-MM-DDTHH:MM:SS.fffZ",
+		"YYYY-M-D",
+		"YYYY.MM.DD"
+	};
+
+	static final String[] invalidDateStrings = {
+		"22",
+		"22.03.31",
+		"2022/12/31",
+		"2022-00-01",
+		"2022-05-00",
+		"2022-13-31",
+		"2022-00-31",
+		"2022-44-55",
+		"22-31",
+		"0987-01-01",
+	};
+
+
+	@Test
+	public void equals() throws Exception {
+		EqualsVerifier.forClass(EventDate.class).usingGetClass().verify();
+	}
+
+	@Test
+	public void buildEventDate() throws Exception {
+		final EventDate ed1 = EventDate.getBuilder(DATE_STRING, FORMAT_STRING, EVENT_STRING).build();
+		assertThat(INCORRECT_DATE, ed1.getDate(), is(DATE_STRING));
+		assertThat(INCORRECT_FORMAT, ed1.getDateFormat(), is(FORMAT_STRING));
+		assertThat(INCORRECT_EVENT, ed1.getEvent(), is(EVENT_STRING));
+	}
+
+	@Test
+	public void buildEventDateFailDate() throws Exception {
+		for (String dateStr : invalidDateStrings) {
+			try {
+				EventDate.getBuilder(dateStr, FORMAT_STRING, EVENT_STRING).build();
+				fail(EXP_EXC);
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+					"Illegal format for date: \"" + dateStr +
+					"\"\nIt should match the pattern \"" +  EventDate.VALID_DATE_REGEX.toString() + "\""
+				));
+			}
+		}
+	}
+
+	@Test
+	public void buildEventDateFailDateFormat() throws Exception {
+		for (String dateFormatStr : invalidDateFormatStrings) {
+			try {
+				EventDate.getBuilder(DATE_STRING, dateFormatStr, EVENT_STRING).build();
+				fail(EXP_EXC);
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+					"Illegal format for dateFormat: \"" + dateFormatStr +
+					"\"\nIt should match the pattern \"" +  EventDate.VALID_DATE_FORMAT_REGEX.toString() + "\""
+				));
+			}
+		}
+	}
+
+	@Test
+	public void buildAndTrimEventDate() throws Exception {
+		final EventDate ed1 = EventDate.getBuilder(DATE_STRING_UNTRIMMED, FORMAT_STRING_UNTRIMMED, EVENT_STRING_UNTRIMMED).build();
+		assertThat(INCORRECT_DATE, ed1.getDate(), is(DATE_STRING));
+		assertThat(INCORRECT_FORMAT, ed1.getDateFormat(), is(FORMAT_STRING));
+		assertThat(INCORRECT_EVENT, ed1.getEvent(), is(EVENT_STRING));
+	}
+
+	@Test
+	public void buildFailNullOrWhitespaceEventDate() throws Exception {
+		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
+			final String[][] nullOrWhitespaceArgs = {
+				{nullOrWs, FORMAT_STRING, EVENT_STRING, "date"},
+				{DATE_STRING, nullOrWs, EVENT_STRING, "dateFormat"},
+				{DATE_STRING, FORMAT_STRING, nullOrWs, "event"}
+			};
+
+			for (String[] arr : nullOrWhitespaceArgs) {
+				try {
+					EventDate.getBuilder(arr[0], arr[1], arr[2]).build();
+					fail(EXP_EXC);
+				} catch (Exception got) {
+					TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(arr[3] + " cannot be null or whitespace only"));
+				}
+			}
+		}
+	}
+}

--- a/src/us/kbase/workspace/test/database/provenance/EventDateTest.java
+++ b/src/us/kbase/workspace/test/database/provenance/EventDateTest.java
@@ -46,6 +46,7 @@ public class EventDateTest {
 		"2022-13-31",
 		"2022-00-31",
 		"2022-44-55",
+		"2022-04-31",
 		"22-31",
 		"987-01-01",
 	};
@@ -106,9 +107,8 @@ public class EventDateTest {
 
 	@Test
 	public void buildEventDateFailNullEvent() throws Exception {
-		final Event nullEvent = null;
 		try {
-			EventDate.getBuilder(DATE_STRING, nullEvent).build();
+			EventDate.getBuilder(DATE_STRING, (Event) null).build();
 			fail(EXP_EXC);
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, new NullPointerException(

--- a/src/us/kbase/workspace/test/database/provenance/EventDateTest.java
+++ b/src/us/kbase/workspace/test/database/provenance/EventDateTest.java
@@ -106,7 +106,7 @@ public class EventDateTest {
 				fail(EXP_EXC);
 			} catch (Exception got) {
 				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
- 					"Invalid date: \"" + dateStr + "\"\ndate must be in the format yyyy, yyyy-MM, or yyyy-MM-dd"
+ 					"Invalid date: \"" + dateStr + "\"\ndate must be in the format yyyy, yyyy-MM, or yyyy-MM-dd and be a valid combination of day, month, and year."
  				));
 			}
 		}

--- a/src/us/kbase/workspace/test/database/provenance/EventTest.java
+++ b/src/us/kbase/workspace/test/database/provenance/EventTest.java
@@ -1,0 +1,56 @@
+package us.kbase.workspace.test.database.provenance;
+
+import org.junit.Test;
+
+import us.kbase.workspace.database.provenance.Event;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import us.kbase.common.test.TestCommon;
+
+public class EventTest {
+
+	@Test
+	public void testGetEventName() throws Exception {
+		final Event wre = Event.ISSUED;
+		assertThat("incorrect eventName",
+				wre.getEventName(),
+				is("issued"));
+	}
+
+	@Test
+	public void testGetEvent() throws Exception {
+		final String[] validEvents = {
+				"collected",
+				"COLLECTED",
+				"    \r\r\nCOLLECTED\n\n",
+				"Collected\n"
+		};
+
+		for (final String validEvent : validEvents) {
+			assertThat("incorrect event",
+					Event.getEvent(validEvent),
+					is(Event.COLLECTED));
+		}
+	}
+
+	@Test
+	public void testGetEventFail() throws Exception {
+
+		final String[] invalidEvents = {
+				"catastrophic loss of life",
+				"Event:ISSUED",
+		};
+
+		for (final String invalidEvent : invalidEvents) {
+			try {
+				Event.getEvent(invalidEvent);
+				fail("expected exception");
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+						"Invalid event: " + invalidEvent));
+			}
+		}
+	}
+}

--- a/src/us/kbase/workspace/test/database/provenance/EventTest.java
+++ b/src/us/kbase/workspace/test/database/provenance/EventTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import us.kbase.common.test.TestCommon;
+import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.WHITESPACE_STRINGS_WITH_NULL;
 
 public class EventTest {
 
@@ -35,22 +36,34 @@ public class EventTest {
 		}
 	}
 
+	private void getEventFail(final String input, final Exception output) {
+		try {
+			Event.getEvent(input);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, output);
+		}
+	}
+
 	@Test
 	public void testGetEventFail() throws Exception {
-
 		final String[] invalidEvents = {
 				"catastrophic loss of life",
 				"Event:ISSUED",
+				"    Event:ISSUED\r",
 		};
 
 		for (final String invalidEvent : invalidEvents) {
-			try {
-				Event.getEvent(invalidEvent);
-				fail("expected exception");
-			} catch (Exception got) {
-				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
-						"Invalid event: " + invalidEvent));
-			}
+			getEventFail(invalidEvent, new IllegalArgumentException(
+				"Invalid event: " + invalidEvent));
+		}
+	}
+
+	@Test
+	public void testGetEventNullOrWs() throws Exception {
+		for (final String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
+			getEventFail(nullOrWs, new IllegalArgumentException(
+				"event cannot be null or whitespace only"));
 		}
 	}
 }


### PR DESCRIPTION
New event date class, all fields mandatory.

`date`: will be parsed by the credit engine and then formatted as YYYY, YYYY-MM, or YYYY-MM-DD, depending on the level of specificity of the input
`dateFormat`: string literal representing the date; will be `YYYY`, `YYYY-MM`, or `YYYY-MM-YY`
`event`: string describing what the event was -- e.g. dataset created, dataset published, dataset embargo lifted, etc.