### PR TITLE
CE-94 revisited: Adding PID class with tests

### DIFF
--- a/src/us/kbase/workspace/database/provenance/Common.java
+++ b/src/us/kbase/workspace/database/provenance/Common.java
@@ -55,17 +55,21 @@ class Common {
 	}
 
 	/**
-	 * Trims leading and trailing whitespace and then checks that a string is either null,
-	 * or has at least one non-whitespace character and conforms to the specified regular
-	 * expression. If replace is not null, it is used for a replaceAll operation, and the
+	 * Trims leading and trailing whitespace, converts empty strings to null, and then
+         * checks that a string is either null or has at least one non-whitespace character
+         * and conforms to the specified regular expression.
+         * If optional is true, null is a valid output value; if false, null will throw an error.
+         * If replace is not null, it is used for a replaceAll operation, and the
 	 * resulting string returned. Otherwise, the trimmed string is returned.
 	 *
 	 * @param stringToCheck the string to check.
 	 * @param pattern       the pattern to validate against.
 	 * @param replace       if non-null, the pattern to use for the replaceAll operation.
 	 * @param name          the name of the string to use in any error messages.
-	 * @param optional      whether or not the field is optional. If true, null is a valid value for the field.
-	 * @return the trimmed field.
+	 * @param optional      whether or not the field is optional. If false, null and
+         *                      empty or whitespace-only input strings will throw an error.
+         *
+	 * @return the trimmed field, or null if the input string was null or whitespace.
 	 */
 	static String checkAgainstRegex(final String stringToCheck, final Pattern pattern, final String replace, final String name, final boolean optional)
 			throws IllegalArgumentException {
@@ -86,27 +90,33 @@ class Common {
 	}
 
 	/**
-	 * Trims leading and trailing whitespace, and then checks that a string is either null, or
-	 * has at least one non-whitespace character and conforms to the specified regular expression.
+	 * Trims leading and trailing whitespace, converts empty strings to null, and then
+         * checks that a string is either null or has at least one non-whitespace character
+         * and conforms to the specified regular expression.
+         * If optional is true, null is a valid output value; if false, null will throw an error.
 	 *
 	 * @param stringToCheck the string to check.
 	 * @param pattern       the pattern to validate against.
 	 * @param name          the name of the string to use in any error messages.
-	 * @param optional      whether or not the field is optional. If true, null is a valid value for the field.
-	 * @return the trimmed field.
+	 * @param optional      whether or not the field is optional. If false, null and
+         *                      empty or whitespace-only input strings will throw an error.
+	 * @return the trimmed field, or null if the input string was null or whitespace.
 	 */
 	static String checkAgainstRegex(final String stringToCheck, final Pattern pattern, final String name, final boolean optional) {
 		return checkAgainstRegex(stringToCheck, pattern, null, name, optional);
 	}
 
 	/**
-	 * Trims leading and trailing whitespace, and then checks that a putative PID is either null,
-	 * or has at least one non-whitespace character and conforms to the specified regular expression.
+	 * Trims leading and trailing whitespace, converts empty strings to null, and then
+         * checks that a string is either null or has at least one non-whitespace character
+         * and conforms to the specified regular expression.
+         * If optional is true, null is a valid output value; if false, null will throw an error.
 	 *
-	 * @param putativePid the putative PID string.
-	 * @param name        the name of the string to use in any error messages.
-	 * @param optional    whether or not the field is optional. If true, null is a valid value for the field.
-	 * @return the trimmed field.
+	 * @param putativePid   the putative PID string.
+	 * @param name          the name of the string to use in any error messages.
+	 * @param optional      whether or not the field is optional. If false, null and
+         *                      empty or whitespace-only input strings will throw an error.
+	 * @return the trimmed field, or null if the input string was null or whitespace.
 	 */
 	static String checkPid(final String putativePid, final String name, final boolean optional)
 			throws IllegalArgumentException {

--- a/src/us/kbase/workspace/database/provenance/Common.java
+++ b/src/us/kbase/workspace/database/provenance/Common.java
@@ -55,16 +55,19 @@ class Common {
 	}
 
 	/**
-	 * Checks that a string is either null, or has at least one non-whitespace
-	 * character and conforms to the specified regular expression.
+	 * Trims leading and trailing whitespace and then checks that a string is either null,
+	 * or has at least one non-whitespace character and conforms to the specified regular
+	 * expression. If replace is not null, it is used for a replaceAll operation, and the
+	 * resulting string returned. Otherwise, the trimmed string is returned.
 	 *
 	 * @param stringToCheck the string to check.
 	 * @param pattern       the pattern to validate against.
+	 * @param replace       if non-null, the pattern to use for the replaceAll operation.
 	 * @param name          the name of the string to use in any error messages.
 	 * @param optional      whether or not the field is optional. If true, null is a valid value for the field.
 	 * @return the trimmed field.
 	 */
-	static String checkAgainstRegex(final String stringToCheck, final Pattern pattern, final String name, final boolean optional)
+	static String checkAgainstRegex(final String stringToCheck, final Pattern pattern, final String replace, final String name, final boolean optional)
 			throws IllegalArgumentException {
 		final String checkedString = checkString(stringToCheck, name, optional);
 		if (checkedString == null) {
@@ -72,6 +75,9 @@ class Common {
 		}
 		final Matcher m = pattern.matcher(checkedString);
 		if (m.find()) {
+			if (replace != null) {
+				return m.replaceAll(replace);
+			}
 			return checkedString;
 		}
 		throw new IllegalArgumentException(String.format(
@@ -80,8 +86,22 @@ class Common {
 	}
 
 	/**
-	 * Checks that a putative PID is either null, or has at least one non-whitespace
-	 * character and conforms to the specified regular expression.
+	 * Trims leading and trailing whitespace, and then checks that a string is either null, or
+	 * has at least one non-whitespace character and conforms to the specified regular expression.
+	 *
+	 * @param stringToCheck the string to check.
+	 * @param pattern       the pattern to validate against.
+	 * @param name          the name of the string to use in any error messages.
+	 * @param optional      whether or not the field is optional. If true, null is a valid value for the field.
+	 * @return the trimmed field.
+	 */
+	static String checkAgainstRegex(final String stringToCheck, final Pattern pattern, final String name, final boolean optional) {
+		return checkAgainstRegex(stringToCheck, pattern, null, name, optional);
+	}
+
+	/**
+	 * Trims leading and trailing whitespace, and then checks that a putative PID is either null,
+	 * or has at least one non-whitespace character and conforms to the specified regular expression.
 	 *
 	 * @param putativePid the putative PID string.
 	 * @param name        the name of the string to use in any error messages.
@@ -90,12 +110,7 @@ class Common {
 	 */
 	static String checkPid(final String putativePid, final String name, final boolean optional)
 			throws IllegalArgumentException {
-		final String pid = checkAgainstRegex(putativePid, VALID_PID_REGEX, name, optional);
-		if (pid == null) {
-			return null;
-		}
-		final Matcher m = VALID_PID_REGEX.matcher(pid);
-		return m.replaceAll(VALID_PID_REPLACEMENT);
+		return checkAgainstRegex(putativePid, VALID_PID_REGEX, VALID_PID_REPLACEMENT, name, optional);
 	}
 
 	private static URL checkURL(final String putativeURL, final String name) {

--- a/src/us/kbase/workspace/database/provenance/PermanentID.java
+++ b/src/us/kbase/workspace/database/provenance/PermanentID.java
@@ -121,7 +121,9 @@ public class PermanentID {
 		/**
 		 * Builds the {@link PermanentID}.
 		 *
-		 * @return the external data.
+		 * @param id  the permanent ID, for example DOI:10.25982/59912.37.
+		 *
+		 * @return the permanent ID.
 		 */
 		public PermanentID build() {
 			return new PermanentID(id, description, relationshipType);

--- a/src/us/kbase/workspace/database/provenance/PermanentID.java
+++ b/src/us/kbase/workspace/database/provenance/PermanentID.java
@@ -1,0 +1,130 @@
+package us.kbase.workspace.database.provenance;
+
+import java.util.Objects;
+import java.util.Optional;
+import us.kbase.workspace.database.Util;
+
+/**
+ * Represents a permanent unique identifier for an entity with an optional
+ * relationship to some other entity. That entity is expected to hold a
+ * reference to the PID.
+ */
+public class PermanentID {
+
+	private final String id;
+	private final String description;
+	private final String relationshipType;
+
+	private PermanentID(final String id, final String description, final String relationshipType) {
+		this.id = id;
+		this.description = description;
+		this.relationshipType = relationshipType;
+	}
+
+	/**
+	 * Gets the ID, for example DOI:10.25982/59912.37.
+	 *
+	 * @return the id.
+	 */
+	public String getID() {
+		return id;
+	}
+
+	/**
+	 * Gets a free text description of the resource identified by the ID.
+	 *
+	 * @return the description, if present.
+	 */
+	public Optional<String> getDescription() {
+		return Optional.ofNullable(description);
+	}
+
+	/**
+	 * Gets the relationship between the ID and some other entity. For
+	 * example, when a {@link PermanentID] class is used to represent
+	 * objects in a {@link Resource}'s 'related_identifiers' field, this
+	 * field captures the relationship between the {@link Resource} and
+	 * the entity represented by this.id.
+	 *
+	 * This field is currently only settable by workspace admins. More
+	 * validation may be added in the future to control the field contents.
+	 *
+	 * @return the relationship type, if present.
+	 */
+	public Optional<String> getRelationshipType() {
+		return Optional.ofNullable(relationshipType);
+	}
+
+	/**
+	 * Gets a builder for an {@link PermanentID}.
+	 *
+	 * @return the builder.
+	 */
+	public static Builder getBuilder(final String id) {
+		return new Builder(id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(description, id, relationshipType);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if ((obj == null) || (getClass() != obj.getClass()))
+			return false;
+		PermanentID other = (PermanentID) obj;
+		return Objects.equals(description, other.description) && Objects.equals(id, other.id)
+				&& Objects.equals(relationshipType, other.relationshipType);
+	}
+
+	/** A builder for an {@link PermanentID}. */
+	public static class Builder {
+
+		private String id;
+		private String description = null;
+		private String relationshipType = null;
+
+		private Builder(final String id) {
+			this.id = Common.checkPid(id, "id", false);
+		}
+
+		/**
+		 * Sets a free text description of the ID.
+		 *
+		 * @param description the description. Null, whitespace, or
+		 *                    the empty string will remove any
+		 *                    current content in the builder.
+		 * @return this builder.
+		 */
+		public Builder withDescription(final String description) {
+			this.description = Util.checkString(description, "description", true);
+			return this;
+		}
+
+		/**
+		 * Sets the relationship type between the ID and the resource.
+		 *
+		 * @param relationshipType the relationship type. Null, whitespace, or
+		 *                         the empty string will remove the
+		 *                         current content in the builder.
+		 *
+		 * @return this builder.
+		 */
+		public Builder withRelationshipType(final String relationshipType) {
+			this.relationshipType = Util.checkString(relationshipType, "relationshipType", true);
+			return this;
+		}
+
+		/**
+		 * Builds the {@link PermanentID}.
+		 *
+		 * @return the external data.
+		 */
+		public PermanentID build() {
+			return new PermanentID(id, description, relationshipType);
+		}
+	}
+}

--- a/src/us/kbase/workspace/database/provenance/PermanentID.java
+++ b/src/us/kbase/workspace/database/provenance/PermanentID.java
@@ -58,6 +58,7 @@ public class PermanentID {
 	/**
 	 * Gets a builder for an {@link PermanentID}.
 	 *
+	 * @param id  the permanent ID, for example DOI:10.25982/59912.37.
 	 * @return the builder.
 	 */
 	public static Builder getBuilder(final String id) {
@@ -120,8 +121,6 @@ public class PermanentID {
 
 		/**
 		 * Builds the {@link PermanentID}.
-		 *
-		 * @param id  the permanent ID, for example DOI:10.25982/59912.37.
 		 *
 		 * @return the permanent ID.
 		 */

--- a/src/us/kbase/workspace/test/database/UtilTest.java
+++ b/src/us/kbase/workspace/test/database/UtilTest.java
@@ -82,15 +82,15 @@ public class UtilTest {
 
 	@Test
 	public void isNullOrWhitespacePass() throws Exception {
-		for (String empty : WHITESPACE_STRINGS_WITH_NULL) {
-			assertThat(INCORRECT_NULL_WHITESPACE, Util.isNullOrWhitespace(empty), is(true));
+		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
+			assertThat(INCORRECT_NULL_WHITESPACE, Util.isNullOrWhitespace(nullOrWs), is(true));
 		}
 	}
 
 	@Test
 	public void isNullOrWhitespaceFail() throws Exception {
-		for (String nullOrEmpty : NON_WHITESPACE_STRINGS) {
-			assertThat(INCORRECT_NULL_WHITESPACE, Util.isNullOrWhitespace(nullOrEmpty), is(false));
+		for (String nonWhitespaceString : NON_WHITESPACE_STRINGS) {
+			assertThat(INCORRECT_NULL_WHITESPACE, Util.isNullOrWhitespace(nonWhitespaceString), is(false));
 		}
 	}
 
@@ -228,10 +228,10 @@ public class UtilTest {
 	}
 
 	@Test
-	public void checkStringFailNullOrEmpty() throws Exception {
-		for (String emptyNullString : WHITESPACE_STRINGS_WITH_NULL) {
+	public void checkStringFailNullOrWhitespace() throws Exception {
+		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
 			try {
-				Util.checkString(emptyNullString, TYPE_NAME);
+				Util.checkString(nullOrWs, TYPE_NAME);
 				fail(EXP_EXC);
 			} catch (Exception got) {
 				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
@@ -241,11 +241,11 @@ public class UtilTest {
 	}
 
 	@Test
-	public void checkStringPassNullOrEmpty() throws Exception {
-		for (String emptyNullString : WHITESPACE_STRINGS_WITH_NULL) {
+	public void checkStringPassNullOrWhitespace() throws Exception {
+		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
 			assertThat(
 				INCORRECT_CHECKSTRING,
-				Util.checkString(emptyNullString, TYPE_NAME, true),
+				Util.checkString(nullOrWs, TYPE_NAME, true),
 				is(NS));
 		}
 	}
@@ -253,9 +253,9 @@ public class UtilTest {
 	@Test
 	public void checkStringFailTooLong() throws Exception {
 		final int max = 1;
-		for (String nonEmptyString : NON_WHITESPACE_STRINGS) {
+		for (String nonWhitespaceString : NON_WHITESPACE_STRINGS) {
 			try {
-				Util.checkString(nonEmptyString, TYPE_NAME, max);
+				Util.checkString(nonWhitespaceString, TYPE_NAME, max);
 				fail(EXP_EXC);
 			} catch (Exception got) {
 				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(

--- a/src/us/kbase/workspace/test/database/provenance/OrganizationTest.java
+++ b/src/us/kbase/workspace/test/database/provenance/OrganizationTest.java
@@ -57,7 +57,7 @@ public class OrganizationTest {
 	}
 
 	@Test
-	public void buildWithNullOrEmptyOrgId() throws Exception {
+	public void buildWithNullOrWhitespaceOrgId() throws Exception {
 		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
 			final Organization org1 = Organization.getBuilder(ORG_NAME)
 					.withOrganizationID(nullOrWs)
@@ -68,7 +68,7 @@ public class OrganizationTest {
 	}
 
 	@Test
-	public void buildAndOverwriteOrgIdWithNullOrEmpty() throws Exception {
+	public void buildAndOverwriteOrgIdWithNullOrWhitespace() throws Exception {
 		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
 			final Organization org1 = Organization.getBuilder(ORG_NAME)
 					.withOrganizationID(PID_STRING)
@@ -89,14 +89,14 @@ public class OrganizationTest {
 				fail(EXP_EXC);
 			} catch (Exception got) {
 				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
-						"Illegal ID format for organizationID: \"" + invalidPid + "\"\n" +
-								"PIDs should match the pattern \"^([a-zA-Z0-9][a-zA-Z0-9\\.]+)\\s*:\\s*(\\S.+)$\""));
+						"Illegal format for organizationID: \"" + invalidPid + "\"\n" +
+								"It should match the pattern \"^([a-zA-Z0-9][a-zA-Z0-9\\.]+)\\s*:\\s*(\\S.+)$\""));
 			}
 		}
 	}
 
 	@Test
-	public void buildFailNullOrEmptyOrgName() throws Exception {
+	public void buildFailNullOrWhitespaceOrgName() throws Exception {
 		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
 			try {
 				Organization.getBuilder(nullOrWs).build();

--- a/src/us/kbase/workspace/test/database/provenance/PermanentIDTest.java
+++ b/src/us/kbase/workspace/test/database/provenance/PermanentIDTest.java
@@ -1,0 +1,130 @@
+package us.kbase.workspace.test.database.provenance;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.Map;
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import us.kbase.common.test.TestCommon;
+import static us.kbase.common.test.TestCommon.opt;
+import static us.kbase.common.test.TestCommon.ES;
+import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.INVALID_PID_LIST;
+import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.VALID_PID_MAP;
+import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.WHITESPACE_STRINGS_WITH_NULL;
+
+import us.kbase.workspace.database.provenance.PermanentID;
+
+public class PermanentIDTest {
+
+	static final String INCORRECT_PID = "incorrect resolvable PID";
+	static final String INCORRECT_DESC = "incorrect description";
+	static final String INCORRECT_REL_TYPE = "incorrect relationship type";
+	static final String EXP_EXC = "expected exception";
+
+	static final String DESC_STRING = "some string of stingy stringy strings strung together";
+	static final String DESC_STRING_UNTRIMMED = "\n\n    \f  some string of stingy stringy strings strung together \t  \n";
+
+	static final String REL_STRING = "isVersionOf";
+	static final String REL_STRING_UNTRIMMED = " \f\f   \t isVersionOf  \n\r\n";
+
+	@Test
+	public void equals() throws Exception {
+		EqualsVerifier.forClass(PermanentID.class).usingGetClass().verify();
+	}
+
+	@Test
+	public void buildMinimal() throws Exception {
+		for (Map.Entry<String, String> mapElement : VALID_PID_MAP.entrySet()) {
+			final PermanentID pid1 = PermanentID.getBuilder(mapElement.getKey()).build();
+			assertThat(INCORRECT_PID, pid1.getID(), is(mapElement.getValue()));
+			assertThat(INCORRECT_DESC, pid1.getDescription(), is(ES));
+			assertThat(INCORRECT_REL_TYPE, pid1.getRelationshipType(), is(ES));
+		}
+	}
+
+	@Test
+	public void buildMaximal() throws Exception {
+		for (Map.Entry<String, String> mapElement : VALID_PID_MAP.entrySet()) {
+			final PermanentID pid1 = PermanentID.getBuilder(mapElement.getKey())
+					.withDescription(DESC_STRING)
+					.withRelationshipType(REL_STRING)
+					.build();
+			assertThat(INCORRECT_PID, pid1.getID(), is(mapElement.getValue()));
+			assertThat(INCORRECT_DESC, pid1.getDescription(), is(opt(DESC_STRING)));
+			assertThat(INCORRECT_REL_TYPE, pid1.getRelationshipType(), is(opt(REL_STRING)));
+		}
+	}
+
+	@Test
+	public void buildTrimAllFields() throws Exception {
+		for (Map.Entry<String, String> mapElement : VALID_PID_MAP.entrySet()) {
+			final PermanentID pid1 = PermanentID.getBuilder(mapElement.getKey())
+					.withDescription(DESC_STRING_UNTRIMMED)
+					.withRelationshipType(REL_STRING_UNTRIMMED)
+					.build();
+			assertThat(INCORRECT_PID, pid1.getID(), is(mapElement.getValue()));
+			assertThat(INCORRECT_DESC, pid1.getDescription(), is(opt(DESC_STRING)));
+			assertThat(INCORRECT_REL_TYPE, pid1.getRelationshipType(), is(opt(REL_STRING)));
+		}
+	}
+
+	@Test
+	public void buildWithNullOrWhitespaceDescriptionRelationshipType() throws Exception {
+		for (Map.Entry<String, String> mapElement : VALID_PID_MAP.entrySet()) {
+			for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
+				final PermanentID pid1 = PermanentID.getBuilder(mapElement.getKey())
+						.withDescription(nullOrWs)
+						.withRelationshipType(nullOrWs).build();
+				assertThat(INCORRECT_PID, pid1.getID(), is(mapElement.getValue()));
+				assertThat(INCORRECT_DESC, pid1.getDescription(), is(ES));
+				assertThat(INCORRECT_REL_TYPE, pid1.getRelationshipType(), is(ES));
+			}
+		}
+	}
+
+	@Test
+	public void buildAndOverwriteDescriptionRelationshipType() throws Exception {
+		for (Map.Entry<String, String> mapElement : VALID_PID_MAP.entrySet()) {
+			for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
+				final PermanentID pid1 = PermanentID.getBuilder(mapElement.getKey())
+						.withDescription(DESC_STRING).withDescription(nullOrWs)
+						.withRelationshipType(REL_STRING).withRelationshipType(nullOrWs)
+						.build();
+				assertThat(INCORRECT_PID, pid1.getID(), is(mapElement.getValue()));
+				assertThat(INCORRECT_DESC, pid1.getDescription(), is(ES));
+				assertThat(INCORRECT_REL_TYPE, pid1.getRelationshipType(), is(ES));
+			}
+		}
+	}
+
+	@Test
+	public void buildFailInvalidPID() throws Exception {
+		for (String invalidPid : INVALID_PID_LIST) {
+			try {
+				PermanentID.getBuilder(invalidPid).build();
+				fail(EXP_EXC);
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+						"Illegal format for id: \"" + invalidPid + "\"\n" +
+								"It should match the pattern "
+								+ "\"^([a-zA-Z0-9][a-zA-Z0-9\\.]+)\\s*:\\s*(\\S.+)$\""));
+			}
+		}
+	}
+
+	@Test
+	public void buildFailNullOrEmptyID() throws Exception {
+		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
+			try {
+				PermanentID.getBuilder(nullOrWs).build();
+				fail(EXP_EXC);
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+						"id cannot be null or whitespace only"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
PermanentID class:
id: mandatory, must match regex
description: optional, free text
relationshipType: optional, currently free text but may be restricted to a controlled vocab in the future