### PR TITLE
CE-151: update to CreditMetadata schema

### DIFF
--- a/workspace.spec
+++ b/workspace.spec
@@ -963,14 +963,18 @@ module Workspace {
 
 		Required fields are:
 		- identifier
-		- resource_type
 		- versioning information: if the resource does not have an explicit version number,
 		one or more dates should be supplied: ideally the date of resource publication and
 		the last update (if applicable).
 		- contributors (one or more required)
 		- titles (one or more required)
 
-		comments - freeform text providing extra information about this credit metadata.
+		The resource_type field is required, but as there is currently only a single valid
+		value, 'dataset', it is automatically populated if no value is supplied.
+
+
+		comments - list of strings of freeform text providing extra information about this
+			credit metadata.
 			Examples:
 				- Credit metadata generated automatically from DOI:10.13039/100000015
 
@@ -1018,11 +1022,11 @@ module Workspace {
 
 	*/
 	typedef structure {
-		string comments;
 		string identifier;
 		string license;
 		string resource_type;
 		string version;
+		list<string> comments;
 		list<Contributor> contributors;
 		list<EventDate> dates;
 		list<FundingReference> funding;

--- a/workspace.spec
+++ b/workspace.spec
@@ -972,7 +972,6 @@ module Workspace {
 		The resource_type field is required, but as there is currently only a single valid
 		value, 'dataset', it is automatically populated if no value is supplied.
 
-
 		comments - list of strings of freeform text providing extra information about this
 			credit metadata.
 			Examples:
@@ -988,7 +987,8 @@ module Workspace {
 
 		license (optional) - usage license for the resource. May be a text string or an
 			URL. Abbreviations should be spelled out where possible (e.g. 'Creative
-			Commons 4.0' instead of 'CC-BY-4.0').
+			Commons 4.0' instead of 'CC-BY-4.0'). The license is interpreted as an URL
+			and checked for well-formedness if it starts with a series of letters, a colon, and slashes, e.g. "http://"; "https://"; "ftp://".
 			Examples:
 				- Creative Commons 4.0
 				- MIT

--- a/workspace.spec
+++ b/workspace.spec
@@ -988,7 +988,8 @@ module Workspace {
 		license (optional) - usage license for the resource. May be a text string or an
 			URL. Abbreviations should be spelled out where possible (e.g. 'Creative
 			Commons 4.0' instead of 'CC-BY-4.0'). The license is interpreted as an URL
-			and checked for well-formedness if it starts with a series of letters, a colon, and slashes, e.g. "http://"; "https://"; "ftp://".
+			and checked for well-formedness if it starts with a series of letters, a
+			colon, and slashes, e.g. "http://"; "https://"; "ftp://".
 			Examples:
 				- Creative Commons 4.0
 				- MIT

--- a/workspace.spec
+++ b/workspace.spec
@@ -1068,7 +1068,7 @@ module Workspace {
 		username saved_by;
 		string credit_metadata_schema_version;
 		epoch timestamp;
-	} CreditMetadataContainer;
+	} CreditMetadataEntry;
 
 	/*
 		Returns the version of the workspace service.
@@ -1521,7 +1521,7 @@ module Workspace {
 		list<obj_ref> path - the path to the object through the object reference graph. All the
 			references in the path are absolute.
 		list<ProvenanceAction> provenance - the object's provenance.
-		CreditMetadataContainer credit_metadata - the credit information for the object.
+		CreditMetadataEntry credit_metadata - the credit information for the object.
 		username creator - the user that first saved the object to the workspace.
 		ws_id orig_wsid - the id of the workspace in which this object was
 				originally saved. Missing for objects saved prior to version
@@ -1551,7 +1551,7 @@ module Workspace {
 		object_info info;
 		list<obj_ref> path;
 		list<ProvenanceAction> provenance;
-		CreditMetadataContainer credit_metadata;
+		CreditMetadataEntry credit_metadata;
 		username creator;
 		ws_id orig_wsid;
 		timestamp created;


### PR DESCRIPTION
Couple of minor spec changes:
- comments field is now a list of strings
- more text about the default resource_type, 'dataset'
- clarify license / license URL info
- rename CreditMetadataContainer -> CreditMetadataEntry to sound a bit more colloquial and less computer-y.