### PR TITLE
CE-225: Award => grant, org name/ID to Organization object

### DIFF
--- a/src/us/kbase/workspace/database/provenance/FundingReference.java
+++ b/src/us/kbase/workspace/database/provenance/FundingReference.java
@@ -98,7 +98,7 @@ public class FundingReference {
 	/** A builder for an {@link FundingReference}. */
 	public static class Builder {
 
-		private Organization funder;
+		private final Organization funder;
 		private String grantID = null;
 		private String grantTitle = null;
 		private URL grantURL = null;

--- a/src/us/kbase/workspace/database/provenance/FundingReference.java
+++ b/src/us/kbase/workspace/database/provenance/FundingReference.java
@@ -5,83 +5,69 @@ import java.util.Objects;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Optional;
-import us.kbase.workspace.database.Util;
 
 /**
- * A funding reference for a resource, including the funding body and the grant
- * awarded.
+ * A funding reference for a resource, including the funding body and the grant.
  */
 public class FundingReference {
 
-	private final String funderID;
-	private final String funderName;
-	private final String awardID;
-	private final String awardTitle;
-	private final URL awardURL;
+	private final Organization funder;
+	private final String grantID;
+	private final String grantTitle;
+	private final URL grantURL;
 
 	private FundingReference(
-			final String funderID,
-			final String funderName,
-			final String awardID,
-			final String awardTitle,
-			final URL awardURL) {
-		this.funderID = funderID;
-		this.funderName = funderName;
-		this.awardID = awardID;
-		this.awardTitle = awardTitle;
-		this.awardURL = awardURL;
+			final Organization funder,
+			final String grantID,
+			final String grantTitle,
+			final URL grantURL) {
+		this.funder = funder;
+		this.grantID = grantID;
+		this.grantTitle = grantTitle;
+		this.grantURL = grantURL;
 	}
 
 	/**
-	 * Gets the funder ID, for example ROR:04xm1d337.
+	 * Gets the funding organization.
 	 *
-	 * @return the funder ID, if present.
+	 * @return the funder organization.
 	 */
-	public Optional<String> getFunderID() {
-		return Optional.ofNullable(funderID);
+	public Organization getFunder() {
+		return funder;
 	}
 
 	/**
-	 * Gets the funder name, for example US Department of Energy.
-	 *
-	 * @return the funder name.
-	 */
-	public String getFunderName() {
-		return funderName;
-	}
-
-	/**
-	 * Gets the code assigned by the funder to the award, for example
+	 * Gets the code assigned by the funder to the grant, for example
 	 * DOI:10.46936/10.25585/60000745.
 	 *
-	 * @return the award ID, if present.
+	 * @return the grant ID, if present.
 	 */
-	public Optional<String> getAwardID() {
-		return Optional.ofNullable(awardID);
+	public Optional<String> getGrantID() {
+		return Optional.ofNullable(grantID);
 	}
 
 	/**
-	 * Gets the title of the award, for example "Metagenomic analysis of the
+	 * Gets the title of the grant, for example "Metagenomic analysis of the
 	 * rhizosphere of three biofuel crops at the KBS intensive site".
 	 *
-	 * @return the award title, if present.
+	 * @return the grant title, if present.
 	 */
-	public Optional<String> getAwardTitle() {
-		return Optional.ofNullable(awardTitle);
+	public Optional<String> getGrantTitle() {
+		return Optional.ofNullable(grantTitle);
 	}
 
 	/**
-	 * Gets the URL of the award.
+	 * Gets the URL of the grant.
 	 *
-	 * @return the award URL, if present.
+	 * @return the grant URL, if present.
 	 */
-	public Optional<URL> getAwardURL() {
-		return Optional.ofNullable(awardURL);
+	public Optional<URL> getGrantURL() {
+		return Optional.ofNullable(grantURL);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(awardID, awardTitle, awardURL, funderID, funderName);
+		return Objects.hash(grantID, grantTitle, grantURL, funder);
 	}
 
 	@Override
@@ -93,97 +79,77 @@ public class FundingReference {
 		if (getClass() != obj.getClass())
 			return false;
 		FundingReference other = (FundingReference) obj;
-		return Objects.equals(awardID, other.awardID) && Objects.equals(awardTitle, other.awardTitle)
-				&& Objects.equals(awardURL, other.awardURL) && Objects.equals(funderID, other.funderID)
-				&& Objects.equals(funderName, other.funderName);
+		return Objects.equals(grantID, other.grantID) && Objects.equals(grantTitle, other.grantTitle)
+				&& Objects.equals(grantURL, other.grantURL) && Objects.equals(funder, other.funder);
 	}
 
 	/**
 	 * Gets a builder for an {@link FundingReference}.
 	 *
-	 * @param funderName
-	 *                name of the funding body
+	 * @param funder
+	 *                the funding body
 	 *
 	 * @return the builder.
 	 */
-	public static Builder getBuilder(final String funderName) {
-		return new Builder(funderName);
+	public static Builder getBuilder(final Organization funder) {
+		return new Builder(funder);
 	}
 
 	/** A builder for an {@link FundingReference}. */
 	public static class Builder {
 
-		private String funderID = null;
-		private String funderName;
-		private String awardID = null;
-		private String awardTitle = null;
-		private URL awardURL = null;
+		private Organization funder;
+		private String grantID = null;
+		private String grantTitle = null;
+		private URL grantURL = null;
 		private List<String> errorList = new ArrayList<>();
 
-		private Builder(final String funderName) {
-			try {
-				this.funderName = Util.checkString(funderName, "funderName");
-			} catch (Exception e) {
-				this.errorList.add(e.getMessage());
+		private Builder(final Organization funder) {
+			if (funder == null) {
+				this.errorList.add("funder cannot be null");
 			}
+			this.funder = funder;
 		}
 
 		/**
-		 * Sets the ID of the funder, for example ROR:04xm1d337.
+		 * Sets the ID of the grant, for example DOI:10.46936/10.25585/60000745.
+		 * N.b. not all grant IDs conform to the standard PID syntax.
 		 *
-		 * @param funderID
-		 *                the ID of the funder. Null or the empty string removes any
+		 * @param grantID
+		 *                the ID of the grant. Null or the empty string removes any
 		 *                current ID in the builder.
 		 * @return this builder.
 		 */
-		public Builder withFunderID(final String funderID) {
-			try {
-				this.funderID = Common.checkPid(funderID, "funderID", true);
-			} catch (Exception e) {
-				this.errorList.add(e.getMessage());
-			}
+		public Builder withGrantID(final String grantID) {
+			this.grantID = Common.processString(grantID);
 			return this;
 		}
 
 		/**
-		 * Sets the ID of the award, for example DOI:10.46936/10.25585/60000745.
-		 * N.b. not all award IDs conform to the standard PID syntax.
-		 *
-		 * @param awardID
-		 *                the ID of the award. Null or the empty string removes any
-		 *                current ID in the builder.
-		 * @return this builder.
-		 */
-		public Builder withAwardID(final String awardID) {
-			this.awardID = Common.processString(awardID);
-			return this;
-		}
-
-		/**
-		 * Sets the title of the award, for example "Metagenomic analysis of the
+		 * Sets the title of the grant, for example "Metagenomic analysis of the
 		 * rhizosphere of three biofuel crops at the KBS intensive site".
 		 *
-		 * @param awardTitle
-		 *                the title of the award. Null or the empty string removes
+		 * @param grantTitle
+		 *                the title of the grant. Null or the empty string removes
 		 *                any current ID in the builder.
 		 * @return this builder.
 		 */
-		public Builder withAwardTitle(final String awardTitle) {
-			this.awardTitle = Common.processString(awardTitle);
+		public Builder withGrantTitle(final String grantTitle) {
+			this.grantTitle = Common.processString(grantTitle);
 			return this;
 		}
 
 		/**
-		 * Sets the URL for the award.
+		 * Sets the URL for the grant.
 		 *
-		 * @param awardURL
-		 *                the URL for the award. Null or the empty string removes any
+		 * @param grantURL
+		 *                the URL for the grant. Null or the empty string removes any
 		 *                current url in the builder.
 		 * @return this builder.
 		 */
-		public Builder withAwardURL(final String awardURL) {
+		public Builder withGrantURL(final String grantURL) {
 			try {
-				this.awardURL = Common.processURL(awardURL, "awardURL");
+				this.grantURL = Common.processURL(grantURL, "grantURL");
 			} catch (Exception e) {
 				this.errorList.add(e.getMessage());
 			}
@@ -191,16 +157,16 @@ public class FundingReference {
 		}
 
 		/**
-		 * Sets the URL for the award.
+		 * Sets the URL for the grant.
 		 *
-		 * @param awardURL
-		 *                the URL of the award. Null removes any current url in the
+		 * @param grantURL
+		 *                the URL of the grant. Null removes any current url in the
 		 *                builder.
 		 * @return this builder.
 		 */
-		public Builder withAwardURL(final URL awardURL) {
+		public Builder withGrantURL(final URL grantURL) {
 			try {
-				this.awardURL = Common.processURL(awardURL, "awardURL");
+				this.grantURL = Common.processURL(grantURL, "grantURL");
 			} catch (Exception e) {
 				this.errorList.add(e.getMessage());
 			}
@@ -214,7 +180,7 @@ public class FundingReference {
 		 */
 		public FundingReference build() {
 			if (errorList.isEmpty()) {
-				return new FundingReference(funderID, funderName, awardID, awardTitle, awardURL);
+				return new FundingReference(funder, grantID, grantTitle, grantURL);
 			}
 			throw new IllegalArgumentException("Errors in FundingReference construction:\n" +
 					String.join("\n", errorList));

--- a/src/us/kbase/workspace/test/database/provenance/CreditMetadataTest.java
+++ b/src/us/kbase/workspace/test/database/provenance/CreditMetadataTest.java
@@ -33,12 +33,14 @@ import us.kbase.workspace.database.provenance.CreditMetadata.ResourceType;
 import us.kbase.workspace.database.provenance.Event;
 import us.kbase.workspace.database.provenance.EventDate;
 import us.kbase.workspace.database.provenance.FundingReference;
+import us.kbase.workspace.database.provenance.Organization;
 import us.kbase.workspace.database.provenance.PermanentID;
 import us.kbase.workspace.database.provenance.Title;
 
 public class CreditMetadataTest {
 
 	private static final String INCORRECT = "incorrect ";
+	private static final String NO_MUTATION = "no mutation";
 	// field names
 	private static final String COMMENTS = "comments";
 	private static final String ID = "identifier";
@@ -134,11 +136,13 @@ public class CreditMetadataTest {
 	private static final List<EventDate> DATE_LIST_DUPES_NULLS = Arrays.asList(
 			ED1, ED2, null, ED1, ED2, null, ED1, ED2, null);
 
+	private static final Organization ORG_1 = Organization.getBuilder("Ransome the Clown's Emporium of Wonder").build();
+	private static final Organization ORG_2 = Organization.getBuilder("Pillowtronics").build();
 
 	private static final FundingReference F1 = FundingReference
-			.getBuilder("New World Order LLC").build();
+			.getBuilder(ORG_1).build();
 	private static final FundingReference F2 = FundingReference
-			.getBuilder("Daddy Warbucks").build();
+			.getBuilder(ORG_2).build();
 
 	private static final List<FundingReference> FUNDING_LIST = Arrays.asList(F1);
 	private static final List<FundingReference> FUNDING_LIST_DUPES_NULLS = Arrays.asList(
@@ -508,7 +512,7 @@ public class CreditMetadataTest {
 
 		// mutating the input list should not affect the contributor list
 		contributorList.add(C3);
-		assertThat("no mutation", contributorList, is(Arrays.asList(C1, C2, C3)));
+		assertThat(NO_MUTATION, contributorList, is(Arrays.asList(C1, C2, C3)));
 		assertThat(INCORRECT_CONTRIBUTORS, cm.getContributors(), is(CONTRIBUTOR_LIST));
 
 		try {
@@ -534,7 +538,7 @@ public class CreditMetadataTest {
 
 		// mutating the input list should not affect the comments
 		commentList.add("blah blah blah");
-		assertThat("no mutation", commentList, is(Arrays.asList(
+		assertThat(NO_MUTATION, commentList, is(Arrays.asList(
 				"What a load of nonsense",
 				"Prime codswallop",
 				"blah blah blah"
@@ -564,7 +568,7 @@ public class CreditMetadataTest {
 
 		// mutating the input list should not affect the date list
 		dateList.add(ED3);
-		assertThat("no mutation", dateList, is(Arrays.asList(ED1, ED2, ED3)));
+		assertThat(NO_MUTATION, dateList, is(Arrays.asList(ED1, ED2, ED3)));
 		assertThat(INCORRECT_DATES, cm.getDates(), is(DATE_LIST));
 
 		try {
@@ -588,7 +592,7 @@ public class CreditMetadataTest {
 
 		// mutating the input list should not affect the funding list
 		fundingList.add(F2);
-		assertThat("no mutation", fundingList, is(Arrays.asList(F1, F2)));
+		assertThat(NO_MUTATION, fundingList, is(Arrays.asList(F1, F2)));
 		assertThat(INCORRECT_FUNDING, cm.getFunding(), is(FUNDING_LIST));
 
 		try {
@@ -611,7 +615,7 @@ public class CreditMetadataTest {
 				.build();
 		// mutating the input list should not affect the related ID list
 		pidList.add(PID3);
-		assertThat("no mutation", pidList, is(Arrays.asList(PID1, PID2, PID3)));
+		assertThat(NO_MUTATION, pidList, is(Arrays.asList(PID1, PID2, PID3)));
 		assertThat(INCORRECT_RELATED_IDS, cm.getRelatedIdentifiers(), is(RELATED_ID_LIST));
 
 		try {
@@ -633,7 +637,7 @@ public class CreditMetadataTest {
 				.build();
 		// mutating the input list should not affect the title list
 		titleList.add(T3);
-		assertThat("no mutation", titleList, is(Arrays.asList(T1, T2, T3)));
+		assertThat(NO_MUTATION, titleList, is(Arrays.asList(T1, T2, T3)));
 		assertThat(INCORRECT_TITLES, cm.getTitles(), is(TITLE_LIST));
 
 		try {

--- a/src/us/kbase/workspace/test/database/provenance/FundingReferenceTest.java
+++ b/src/us/kbase/workspace/test/database/provenance/FundingReferenceTest.java
@@ -160,8 +160,8 @@ public class FundingReferenceTest {
 	@Test
 	public void buildFailInvalidGrantURL() throws Exception {
 		buildFundingRefFailWithError(
-				FundingReference.getBuilder(ORG_1).withGrantURL(GRANT_ID_STRING),
-				"Illegal grantURL url '" + GRANT_ID_STRING + "': no protocol: " + GRANT_ID_STRING);
+				FundingReference.getBuilder(ORG_1).withGrantURL("ror:123"),
+				"Illegal grantURL url 'ror:123': unknown protocol: ror");
 
 		buildFundingRefFailWithError(
 				FundingReference.getBuilder(ORG_1)
@@ -184,10 +184,6 @@ public class FundingReferenceTest {
 	@Test
 	public void buildFailNullFunder() throws Exception {
 		buildFundingRefFailWithError(
-				FundingReference.getBuilder(null),
-				"funder cannot be null");
-
-		buildFundingRefFailWithError(
 			FundingReference.getBuilder((Organization) null),
 			"funder cannot be null");
 	}
@@ -196,7 +192,7 @@ public class FundingReferenceTest {
 	public void buildFailAllFieldsWithValidation() throws Exception {
 		final String notAnURL = "this is not an URL";
 		buildFundingRefFailWithError(
-				FundingReference.getBuilder(null)
+				FundingReference.getBuilder((Organization) null)
 						.withGrantURL(notAnURL),
 						"funder cannot be null\n" +
 						"Illegal grantURL url '" + notAnURL + "': no protocol: "

--- a/src/us/kbase/workspace/test/database/provenance/FundingReferenceTest.java
+++ b/src/us/kbase/workspace/test/database/provenance/FundingReferenceTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import static us.kbase.common.test.TestCommon.optn;
-import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.INVALID_PID_LIST;
 import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.WHITESPACE_STRINGS_WITH_NULL;
 
 import java.net.URL;
@@ -196,15 +195,11 @@ public class FundingReferenceTest {
 	@Test
 	public void buildFailAllFieldsWithValidation() throws Exception {
 		final String notAnURL = "this is not an URL";
-		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
-			for (String invalidPid : INVALID_PID_LIST) {
-				buildFundingRefFailWithError(
-						FundingReference.getBuilder(null)
-								.withGrantURL(notAnURL),
-								"funder cannot be null\n" +
-								"Illegal grantURL url '" + notAnURL + "': no protocol: "
-								+ notAnURL);
-			}
-		}
+		buildFundingRefFailWithError(
+				FundingReference.getBuilder(null)
+						.withGrantURL(notAnURL),
+						"funder cannot be null\n" +
+						"Illegal grantURL url '" + notAnURL + "': no protocol: "
+						+ notAnURL);
 	}
 }

--- a/src/us/kbase/workspace/test/database/provenance/FundingReferenceTest.java
+++ b/src/us/kbase/workspace/test/database/provenance/FundingReferenceTest.java
@@ -4,21 +4,17 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-import static us.kbase.common.test.TestCommon.ES;
-import static us.kbase.common.test.TestCommon.opt;
 import static us.kbase.common.test.TestCommon.optn;
 import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.INVALID_PID_LIST;
-import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.VALID_PID_MAP;
 import static us.kbase.workspace.test.database.provenance.ProvenanceTestCommon.WHITESPACE_STRINGS_WITH_NULL;
 
-import com.google.common.collect.ImmutableMap;
 import java.net.URL;
-import java.util.Map;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 import us.kbase.common.test.TestCommon;
 import us.kbase.workspace.database.provenance.FundingReference;
+import us.kbase.workspace.database.provenance.Organization;
 
 public class FundingReferenceTest {
 
@@ -26,37 +22,25 @@ public class FundingReferenceTest {
 	static final String EXP_EXC = "expected exception";
 
 	// field names
-	static final String FUNDER_NAME = "funder name";
-	static final String FUNDER_ID = "funder ID";
-	static final String AWARD_ID = "award ID";
-	static final String AWARD_TITLE = "award title";
-	static final String AWARD_URL = "award URL";
+	static final String FUNDER = "funder";
+	static final String GRANT_ID = "grant ID";
+	static final String GRANT_TITLE = "grant title";
+	static final String GRANT_URL = "grant URL";
 
-	static final String INCORRECT_FUNDER_NAME = INCORRECT + " " + FUNDER_NAME;
-	static final String INCORRECT_FUNDER_ID = INCORRECT + " " + FUNDER_ID;
-	static final String INCORRECT_AWARD_ID = INCORRECT + " " + AWARD_ID;
-	static final String INCORRECT_AWARD_TITLE = INCORRECT + " " + AWARD_TITLE;
-	static final String INCORRECT_AWARD_URL = INCORRECT + " " + AWARD_URL;
+	static final String INCORRECT_FUNDER = INCORRECT + " " + FUNDER;
+	static final String INCORRECT_GRANT_ID = INCORRECT + " " + GRANT_ID;
+	static final String INCORRECT_GRANT_TITLE = INCORRECT + " " + GRANT_TITLE;
+	static final String INCORRECT_GRANT_URL = INCORRECT + " " + GRANT_URL;
 
-	static final String FUNDER_NAME_STRING = "World's Richest Funding Body";
-	static final String FUNDER_NAME_STRING_UNTRIMMED = "\t \f \n \r" + FUNDER_NAME_STRING + "\t \f \r \n";
-	static final String FUNDER_ID_STRING = "ROR:04xm1d337";
-	static final String FUNDER_ID_STRING_UNTRIMMED = "\t\t\t   " + FUNDER_ID_STRING + "  \f  \r \n\n";
-	static final String AWARD_ID_STRING = "198170392";
-	static final String AWARD_ID_STRING_UNTRIMMED = "\n     " + AWARD_ID_STRING + "    \t";
-	static final String AWARD_URL_STRING = "http://example.com/cgi-bin/wtf.cgi";
-	static final String AWARD_URL_STRING_UNTRIMMED = "  \t  \r\n " + AWARD_URL_STRING + "                \n";
-	static final String AWARD_TITLE_STRING = "The Best Little Toaster";
-	static final String AWARD_TITLE_STRING_UNTRIMMED = "\r\n  \f   " + AWARD_TITLE_STRING + "   \t \n\n \t";
+	static final String GRANT_ID_STRING = "198170392";
+	static final String GRANT_ID_STRING_UNTRIMMED = "\n     " + GRANT_ID_STRING + "    \t";
+	static final String GRANT_URL_STRING = "http://example.com/cgi-bin/wtf.cgi";
+	static final String GRANT_URL_STRING_UNTRIMMED = "  \t  \r\n " + GRANT_URL_STRING + "                \n";
+	static final String GRANT_TITLE_STRING = "The Best Little Toaster";
+	static final String GRANT_TITLE_STRING_UNTRIMMED = "\r\n  \f   " + GRANT_TITLE_STRING + "   \t \n\n \t";
 
-	static final Map<String, String> MINIMAL_MAP = ImmutableMap.of(
-			FUNDER_NAME, FUNDER_NAME_STRING);
-
-	static final Map<String, String> ALL_MAP = ImmutableMap.of(
-			FUNDER_NAME, FUNDER_NAME_STRING,
-			FUNDER_ID, FUNDER_ID_STRING,
-			AWARD_ID, AWARD_ID_STRING,
-			AWARD_TITLE, AWARD_TITLE_STRING);
+	private static final Organization ORG_1 = Organization.getBuilder("Ransome the Clown's Emporium of Wonder").build();
+	private static final Organization ORG_2 = Organization.getBuilder("Pillowtronics").build();
 
 	@Test
 	public void equals() throws Exception {
@@ -71,101 +55,87 @@ public class FundingReferenceTest {
 	 * @param expectedMap
 	 *                key/value pairs are the field names and values for the
 	 *                string fields that are expected not to be null
-	 * @param awardURL
-	 *                expected awardURL field
+	 * @param grantURL
+	 *                expected grantURL field
 	 */
 	private void assertFundingReferenceFields(
 			final FundingReference fr,
-			final Map<String, String> expectedMap,
-			final URL awardUrl) {
-		assertThat(INCORRECT_FUNDER_NAME, fr.getFunderName(), is(expectedMap.get(FUNDER_NAME)));
-		assertThat(INCORRECT_FUNDER_ID, fr.getFunderID(),
-				is(expectedMap.containsKey(FUNDER_ID) ? opt(expectedMap.get(FUNDER_ID)) : ES));
-		assertThat(INCORRECT_AWARD_ID, fr.getAwardID(),
-				is(expectedMap.containsKey(AWARD_ID) ? opt(expectedMap.get(AWARD_ID)) : ES));
-		assertThat(INCORRECT_AWARD_TITLE, fr.getAwardTitle(),
-				is(expectedMap.containsKey(AWARD_TITLE) ? opt(expectedMap.get(AWARD_TITLE)) : ES));
-		assertThat(INCORRECT_AWARD_URL, fr.getAwardURL(), is(optn(awardUrl)));
+			final Organization funder,
+			final String grantId,
+			final String grantTitle,
+			final URL grantUrl) {
+		assertThat(INCORRECT_FUNDER, fr.getFunder(), is(funder));
+		assertThat(INCORRECT_GRANT_ID, fr.getGrantID(), is(optn(grantId)));
+		assertThat(INCORRECT_GRANT_TITLE, fr.getGrantTitle(), is(optn(grantTitle)));
+		assertThat(INCORRECT_GRANT_URL, fr.getGrantURL(), is(optn(grantUrl)));
 	}
 
 	@Test
 	public void buildMinimal() throws Exception {
-		final FundingReference fr = FundingReference.getBuilder(FUNDER_NAME_STRING).build();
-		assertFundingReferenceFields(fr, MINIMAL_MAP, null);
+		final FundingReference fr = FundingReference.getBuilder(ORG_1).build();
+		assertFundingReferenceFields(fr, ORG_1, null, null, null);
 	}
 
 	@Test
 	public void buildMinimalWithNullURL() throws Exception {
-		final FundingReference fr = FundingReference.getBuilder(FUNDER_NAME_STRING)
-			.withAwardURL((URL) null)
+		final FundingReference fr = FundingReference.getBuilder(ORG_2)
+			.withGrantURL((URL) null)
 			.build();
-		assertFundingReferenceFields(fr, MINIMAL_MAP, null);
+		assertFundingReferenceFields(fr, ORG_2, null, null, null);
 	}
 
 	@Test
 	public void buildMaximal() throws Exception {
-		final FundingReference fr = FundingReference.getBuilder(FUNDER_NAME_STRING)
-				.withFunderID(FUNDER_ID_STRING)
-				.withAwardID(AWARD_ID_STRING)
-				.withAwardTitle(AWARD_TITLE_STRING)
-				.withAwardURL(AWARD_URL_STRING)
+		final FundingReference fr = FundingReference.getBuilder(ORG_1)
+				.withGrantID(GRANT_ID_STRING)
+				.withGrantTitle(GRANT_TITLE_STRING)
+				.withGrantURL(GRANT_URL_STRING)
 				.build();
-		assertFundingReferenceFields(fr, ALL_MAP, new URL(AWARD_URL_STRING));
+		assertFundingReferenceFields(fr, ORG_1, GRANT_ID_STRING, GRANT_TITLE_STRING, new URL(GRANT_URL_STRING));
 	}
 
 	@Test
 	public void buildMaximalWithURL() throws Exception {
-		final URL awardURL = new URL(AWARD_URL_STRING);
-		final FundingReference fr = FundingReference.getBuilder(FUNDER_NAME_STRING)
-				.withFunderID(FUNDER_ID_STRING)
-				.withAwardID(AWARD_ID_STRING)
-				.withAwardTitle(AWARD_TITLE_STRING)
-				.withAwardURL(awardURL)
+		final URL grantURL = new URL(GRANT_URL_STRING);
+		final FundingReference fr = FundingReference.getBuilder(ORG_1)
+				.withGrantID(GRANT_ID_STRING)
+				.withGrantTitle(GRANT_TITLE_STRING)
+				.withGrantURL(grantURL)
 				.build();
-		assertFundingReferenceFields(fr, ALL_MAP, awardURL);
+		assertFundingReferenceFields(fr, ORG_1, GRANT_ID_STRING, GRANT_TITLE_STRING, grantURL);
 	}
 
 	@Test
 	public void buildAndTrimMaximal() throws Exception {
-		for (Map.Entry<String, String> entry : VALID_PID_MAP.entrySet()) {
-			final FundingReference fr = FundingReference.getBuilder(FUNDER_NAME_STRING_UNTRIMMED)
-					.withFunderID(entry.getKey())
-					.withAwardID(AWARD_ID_STRING_UNTRIMMED)
-					.withAwardTitle(AWARD_TITLE_STRING_UNTRIMMED)
-					.withAwardURL(AWARD_URL_STRING_UNTRIMMED)
-					.build();
-			final Map<String, String> expectedMap = ImmutableMap.of(
-				FUNDER_NAME, FUNDER_NAME_STRING,
-				FUNDER_ID, entry.getValue(),
-				AWARD_ID, AWARD_ID_STRING,
-				AWARD_TITLE, AWARD_TITLE_STRING);
-			assertFundingReferenceFields(fr, expectedMap, new URL(AWARD_URL_STRING));
-		}
+		final FundingReference fr = FundingReference.getBuilder(ORG_2)
+				.withGrantID(GRANT_ID_STRING_UNTRIMMED)
+				.withGrantTitle(GRANT_TITLE_STRING_UNTRIMMED)
+				.withGrantURL(GRANT_URL_STRING_UNTRIMMED)
+				.build();
+		assertFundingReferenceFields(fr, ORG_2, GRANT_ID_STRING, GRANT_TITLE_STRING, new URL(GRANT_URL_STRING));
 	}
 
 	@Test
 	public void buildWithNullOrWhitespace() throws Exception {
 		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
-			final FundingReference fr = FundingReference.getBuilder(FUNDER_NAME_STRING)
-					.withFunderID(nullOrWs)
-					.withAwardID(nullOrWs)
-					.withAwardTitle(nullOrWs)
-					.withAwardURL(nullOrWs)
+			final FundingReference fr = FundingReference.getBuilder(ORG_1)
+					.withGrantID(nullOrWs)
+					.withGrantTitle(nullOrWs)
+					.withGrantURL(nullOrWs)
 					.build();
-			assertFundingReferenceFields(fr, MINIMAL_MAP, null);
+			assertFundingReferenceFields(fr, ORG_1, null, null, null);
 		}
 	}
 
 	@Test
 	public void buildAndOverwrite() throws Exception {
 		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
-			final FundingReference fr = FundingReference.getBuilder(FUNDER_NAME_STRING)
-					.withFunderID(FUNDER_ID_STRING).withFunderID(nullOrWs)
-					.withAwardID(AWARD_ID_STRING).withAwardID(nullOrWs)
-					.withAwardTitle(AWARD_TITLE_STRING).withAwardTitle(nullOrWs)
-					.withAwardURL(AWARD_URL_STRING).withAwardURL(nullOrWs)
+			final FundingReference fr = FundingReference.getBuilder(ORG_1)
+					.withGrantID(GRANT_ID_STRING).withGrantID(nullOrWs)
+					.withGrantTitle(GRANT_TITLE_STRING).withGrantTitle(nullOrWs)
+					.withGrantURL(GRANT_URL_STRING).withGrantURL(nullOrWs)
 					.build();
-			assertFundingReferenceFields(fr, MINIMAL_MAP, null);
+			assertFundingReferenceFields(fr, ORG_1, null, null, null);
 		}
 	}
 
@@ -189,46 +159,38 @@ public class FundingReferenceTest {
 	}
 
 	@Test
-	public void buildFailInvalidPIDs() throws Exception {
-		for (String invalidPid : INVALID_PID_LIST) {
-			buildFundingRefFailWithError(
-					FundingReference.getBuilder(FUNDER_NAME_STRING).withFunderID(invalidPid),
-					"Illegal format for funderID: \"" + invalidPid + "\"\n" +
-							"It should match the pattern \"^([a-zA-Z0-9][a-zA-Z0-9\\.]+)\\s*:\\s*(\\S.+)$\"");
-		}
-	}
-
-	@Test
-	public void buildFailInvalidAwardURL() throws Exception {
+	public void buildFailInvalidGrantURL() throws Exception {
 		buildFundingRefFailWithError(
-				FundingReference.getBuilder(FUNDER_NAME_STRING).withAwardURL(FUNDER_ID_STRING),
-				"Illegal awardURL url '" + FUNDER_ID_STRING + "': unknown protocol: ror");
+				FundingReference.getBuilder(ORG_1).withGrantURL(GRANT_ID_STRING),
+				"Illegal grantURL url '" + GRANT_ID_STRING + "': no protocol: " + GRANT_ID_STRING);
 
 		buildFundingRefFailWithError(
-				FundingReference.getBuilder(FUNDER_NAME_STRING)
-						.withAwardURL("a random string with no protocol"),
-				"Illegal awardURL url 'a random string with no protocol': no protocol: a random string with no protocol");
+				FundingReference.getBuilder(ORG_1)
+						.withGrantURL("a random string with no protocol"),
+				"Illegal grantURL url 'a random string with no protocol': no protocol: a random string with no protocol");
 
 		buildFundingRefFailWithError(
-				FundingReference.getBuilder(FUNDER_NAME_STRING).withAwardURL("https://kb^ase.us/"),
-				"Illegal awardURL url 'https://kb^ase.us/': Illegal character in authority at " +
+				FundingReference.getBuilder(ORG_1).withGrantURL("https://kb^ase.us/"),
+				"Illegal grantURL url 'https://kb^ase.us/': Illegal character in authority at " +
 						"index 8: https://kb^ase.us/");
 
 		// class input
 		buildFundingRefFailWithError(
-				FundingReference.getBuilder(FUNDER_NAME_STRING)
-						.withAwardURL(new URL("https://kb^ase.us/")),
-				"Illegal awardURL url 'https://kb^ase.us/': Illegal character in authority at " +
+				FundingReference.getBuilder(ORG_1)
+						.withGrantURL(new URL("https://kb^ase.us/")),
+				"Illegal grantURL url 'https://kb^ase.us/': Illegal character in authority at " +
 						"index 8: https://kb^ase.us/");
 	}
 
 	@Test
-	public void buildFailNullOrWhitespaceFunderName() throws Exception {
-		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
-			buildFundingRefFailWithError(
-					FundingReference.getBuilder(nullOrWs),
-					"funderName cannot be null or whitespace only");
-		}
+	public void buildFailNullFunder() throws Exception {
+		buildFundingRefFailWithError(
+				FundingReference.getBuilder(null),
+				"funder cannot be null");
+
+		buildFundingRefFailWithError(
+			FundingReference.getBuilder((Organization) null),
+			"funder cannot be null");
 	}
 
 	@Test
@@ -237,14 +199,10 @@ public class FundingReferenceTest {
 		for (String nullOrWs : WHITESPACE_STRINGS_WITH_NULL) {
 			for (String invalidPid : INVALID_PID_LIST) {
 				buildFundingRefFailWithError(
-						FundingReference.getBuilder(nullOrWs).withFunderID(invalidPid)
-								.withAwardURL(notAnURL),
-						"funderName cannot be null or whitespace only\n" +
-								"Illegal format for funderID: \"" + invalidPid + "\"\n"
-								+
-								"It should match the pattern \"^([a-zA-Z0-9][a-zA-Z0-9\\.]+)\\s*:\\s*(\\S.+)$\"\n"
-								+
-								"Illegal awardURL url '" + notAnURL + "': no protocol: "
+						FundingReference.getBuilder(null)
+								.withGrantURL(notAnURL),
+								"funder cannot be null\n" +
+								"Illegal grantURL url '" + notAnURL + "': no protocol: "
 								+ notAnURL);
 			}
 		}


### PR DESCRIPTION
Some schema changes brought about after aligning the schema with schema.org:
- use an organisation object instead of having funder_name and funder_id
- switch from using 'award' to using 'grant' instead

I'll need to update the spec and the generated classes but have a few other schema alterations to make, so will do them first.