### PR TITLE
Add a MetadataUpdate class in preparation for batch object updates

### DIFF
--- a/src/us/kbase/workspace/WorkspaceServer.java
+++ b/src/us/kbase/workspace/WorkspaceServer.java
@@ -57,6 +57,7 @@ import us.kbase.typedobj.core.TempFilesManager;
 import us.kbase.typedobj.core.TypeDefId;
 import us.kbase.workspace.database.DependencyStatus;
 import us.kbase.workspace.database.ListObjectsParameters;
+import us.kbase.workspace.database.MetadataUpdate;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ResourceUsageConfigurationBuilder.ResourceUsageConfiguration;
 import us.kbase.workspace.database.Workspace;
@@ -427,7 +428,7 @@ public class WorkspaceServer extends JsonServerServlet {
 		}
 		final WorkspaceIdentifier wsi = processWorkspaceIdentifier(params.getWsi());
 		final WorkspaceUser user = wsmeth.getUser(authPart);
-		ws.setWorkspaceMetadata(user, wsi, meta, remove);
+		ws.setWorkspaceMetadata(user, wsi, new MetadataUpdate(meta, remove));
         //END alter_workspace_metadata
     }
 

--- a/src/us/kbase/workspace/database/MetadataUpdate.java
+++ b/src/us/kbase/workspace/database/MetadataUpdate.java
@@ -1,0 +1,77 @@
+package us.kbase.workspace.database;
+
+import static us.kbase.workspace.database.Util.noNulls;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/** An update to a a set of metadata, including keys to add or replace and keys to remove. */
+public class MetadataUpdate {
+	
+	private final WorkspaceUserMetadata meta;
+	private final Set<String> remove;
+	
+	/** Create the update.
+	 * @param meta keys to add to or replace in the target metadata.
+	 * @param toRemove keys to remove from the target metadata.
+	 */
+	public MetadataUpdate(final WorkspaceUserMetadata meta, final Collection<String> toRemove) {
+		this.meta = meta == null || meta.isEmpty() ? null : meta;
+		if (toRemove != null && !toRemove.isEmpty()) {
+			this.remove = Collections.unmodifiableSet(new HashSet<>(
+					noNulls(
+							toRemove,
+							"null metadata keys are not allowed in the remove parameter"
+					)
+			));
+		} else {
+			this.remove = null;
+		}
+	}
+
+	/** Get the keys to add or replace in the target metadata.
+	 * @return the keys.
+	 */
+	public Optional<WorkspaceUserMetadata> getMeta() {
+		return Optional.ofNullable(meta);
+	}
+
+	/** Get the keys to remove from the target metadata.
+	 * @return
+	 */
+	public Optional<Set<String>> getToRemove() {
+		return Optional.ofNullable(remove);
+	}
+
+	/** Return whether this metadata update has an update.
+	 * @return true if there are keys to add, replace, or remove in this update.
+	 */
+	public boolean hasUpdate() {
+		return meta != null || remove != null;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(meta, remove);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		MetadataUpdate other = (MetadataUpdate) obj;
+		return Objects.equals(meta, other.meta) && Objects.equals(remove, other.remove);
+	}
+	
+}

--- a/src/us/kbase/workspace/database/Util.java
+++ b/src/us/kbase/workspace/database/Util.java
@@ -42,13 +42,15 @@ public class Util {
 	 * @param col the collection to check.
 	 * @param message the exception message.
 	 * @param <T> the type of the elements in the collection.
+	 * @return the collection.
 	 */
-	public static <T> void noNulls(final Collection<T> col, final String message) {
+	public static <T> Collection<T> noNulls(final Collection<T> col, final String message) {
 		for (final T item: col) {
 			if (item == null) {
 				throw new NullPointerException(message);
 			}
 		}
+		return col;
 	}
 
 	/** Check that the provided collection is not null and contains no null or whitespace-only

--- a/src/us/kbase/workspace/database/WorkspaceDatabase.java
+++ b/src/us/kbase/workspace/database/WorkspaceDatabase.java
@@ -90,9 +90,7 @@ public interface WorkspaceDatabase {
 	 * duplicate key is supplied.
 	 * 
 	 * @param wsid the workspace for which metadata will be altered.
-	 * @param meta the metadata to add to the workspace.
-	 * @param remove the metadata keys to remove from the workspace. If any provided keys do
-	 * not exist they will be ignored.
+	 * @param meta the metadata update to apply to the workspace.
 	 * @return the workspace modification time if the metadata was altered, or an empty optional
 	 * if the changes had no practical effect.
 	 * @throws WorkspaceCommunicationException if a communication error occurs.
@@ -100,10 +98,7 @@ public interface WorkspaceDatabase {
 	 * @throws IllegalArgumentException if no metadata is supplied or the 
 	 * updated metadata exceeds the allowed size.
 	 */
-	Optional<Instant> setWorkspaceMeta(
-			ResolvedWorkspaceID wsid,
-			WorkspaceUserMetadata meta,
-			List<String> remove)
+	Optional<Instant> setWorkspaceMeta(ResolvedWorkspaceID wsid, MetadataUpdate meta)
 			throws WorkspaceCommunicationException, CorruptWorkspaceDBException;
 
 	/** Clone a workspace.

--- a/src/us/kbase/workspace/test/database/UtilTest.java
+++ b/src/us/kbase/workspace/test/database/UtilTest.java
@@ -145,8 +145,10 @@ public class UtilTest {
 
 	@Test
 	public void noNullsPass() throws Exception {
-		Util.noNulls(NON_WHITESPACE_STRINGS, TYPE_NAME);
-		Util.noNulls(WHITESPACE_STRINGS, TYPE_NAME);
+		assertThat("incorrect return", Util.noNulls(NON_WHITESPACE_STRINGS, TYPE_NAME),
+				is(NON_WHITESPACE_STRINGS));
+		assertThat("incorrect return", Util.noNulls(WHITESPACE_STRINGS, TYPE_NAME),
+				is(WHITESPACE_STRINGS));
 	}
 
 	@Test

--- a/src/us/kbase/workspace/test/workspace/MetadataUpdateTest.java
+++ b/src/us/kbase/workspace/test/workspace/MetadataUpdateTest.java
@@ -1,0 +1,82 @@
+package us.kbase.workspace.test.workspace;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static us.kbase.common.test.TestCommon.assertExceptionCorrect;
+import static us.kbase.common.test.TestCommon.set;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import us.kbase.workspace.database.MetadataUpdate;
+import us.kbase.workspace.database.WorkspaceUserMetadata;
+
+public class MetadataUpdateTest {
+	
+	@Test
+	public void equals() throws Exception {
+		EqualsVerifier.forClass(MetadataUpdate.class).usingGetClass().verify();
+	}
+	
+	@Test
+	public void constructNulls() throws Exception {
+		final MetadataUpdate mu = new MetadataUpdate(null, null);
+		assertThat("incorrect meta", mu.getMeta(), is(Optional.empty()));
+		assertThat("incorrect remove", mu.getToRemove(), is(Optional.empty()));
+		assertThat("incorrect hasUpdate", mu.hasUpdate(), is(false));
+	}
+	
+	@Test
+	public void constructEmpties() throws Exception {
+		final MetadataUpdate mu = new MetadataUpdate(new WorkspaceUserMetadata(), set());
+		assertThat("incorrect meta", mu.getMeta(), is(Optional.empty()));
+		assertThat("incorrect remove", mu.getToRemove(), is(Optional.empty()));
+		assertThat("incorrect hasUpdate", mu.hasUpdate(), is(false));
+	}
+
+	@Test
+	public void constructWithMeta() throws Exception {
+		final MetadataUpdate mu = new MetadataUpdate(
+				new WorkspaceUserMetadata(ImmutableMap.of("a", "b")), null);
+		assertThat("incorrect meta", mu.getMeta(), is(Optional.of(
+				new WorkspaceUserMetadata(ImmutableMap.of("a", "b")))));
+		assertThat("incorrect remove", mu.getToRemove(), is(Optional.empty()));
+		assertThat("incorrect hasUpdate", mu.hasUpdate(), is(true));
+	}
+	
+	@Test
+	public void constructWithRemove() throws Exception {
+		final MetadataUpdate mu = new MetadataUpdate(null, Arrays.asList("foo", "bar"));
+		assertThat("incorrect meta", mu.getMeta(), is(Optional.empty()));
+		assertThat("incorrect remove", mu.getToRemove(), is(Optional.of(set("bar", "foo"))));
+		assertThat("incorrect hasUpdate", mu.hasUpdate(), is(true));
+	}
+	
+	@Test
+	public void constructWithBoth() throws Exception {
+		final MetadataUpdate mu = new MetadataUpdate(
+				new WorkspaceUserMetadata(ImmutableMap.of("a", "b")), set("baz", "bat"));
+		assertThat("incorrect meta", mu.getMeta(), is(Optional.of(
+				new WorkspaceUserMetadata(ImmutableMap.of("a", "b")))));
+		assertThat("incorrect remove", mu.getToRemove(), is(Optional.of(set("baz", "bat"))));
+		assertThat("incorrect hasUpdate", mu.hasUpdate(), is(true));
+	}
+	
+	@Test
+	public void constructFailNullInRemove() throws Exception {
+		try {
+			new MetadataUpdate(null, Arrays.asList("foo", null));
+			fail("expected exception");
+		} catch (Exception got) {
+			assertExceptionCorrect(got, new NullPointerException(
+					"null metadata keys are not allowed in the remove parameter"));
+		}
+		
+	}
+}

--- a/src/us/kbase/workspace/test/workspace/WorkspaceListenerTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceListenerTest.java
@@ -38,6 +38,7 @@ import us.kbase.typedobj.idref.IdReferenceHandlerSetFactory;
 import us.kbase.typedobj.idref.IdReferenceHandlerSetFactoryBuilder;
 import us.kbase.workspace.database.AllUsers;
 import us.kbase.workspace.database.CopyResult;
+import us.kbase.workspace.database.MetadataUpdate;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIDResolvedWS;
 import us.kbase.workspace.database.ObjectIdentifier;
@@ -204,7 +205,7 @@ public class WorkspaceListenerTest {
 				PermissionSet.getBuilder(user, new AllUsers('*'))
 						.withWorkspace(rwsi, Permission.ADMIN, Permission.NONE).build());
 		
-		ws.setWorkspaceMetadata(user, wsi, META, null);
+		ws.setWorkspaceMetadata(user, wsi, new MetadataUpdate(META, null));
 		
 		verify(m.l1, never()).setWorkspaceMetadata(
 				any(WorkspaceUser.class), anyLong(), any(Instant.class));
@@ -226,10 +227,11 @@ public class WorkspaceListenerTest {
 		when(m.db.getPermissions(user, set(rwsi))).thenReturn(
 				PermissionSet.getBuilder(user, new AllUsers('*'))
 						.withWorkspace(rwsi, Permission.ADMIN, Permission.NONE).build());
-		when(m.db.setWorkspaceMeta(rwsi, meta, null)).thenReturn(Optional.of(inst(20000)));
+		when(m.db.setWorkspaceMeta(rwsi, new MetadataUpdate(meta, null)))
+				.thenReturn(Optional.of(inst(20000)));
 
 		
-		ws.setWorkspaceMetadata(user, wsi, meta, null);
+		ws.setWorkspaceMetadata(user, wsi, new MetadataUpdate(meta, null));
 		
 		verify(m.l1).setWorkspaceMetadata(user, 24L, Instant.ofEpochMilli(20000));
 	}
@@ -250,10 +252,11 @@ public class WorkspaceListenerTest {
 		when(m.db.getPermissions(user, set(rwsi))).thenReturn(
 				PermissionSet.getBuilder(user, new AllUsers('*'))
 						.withWorkspace(rwsi, Permission.ADMIN, Permission.NONE).build());
-		when(m.db.setWorkspaceMeta(rwsi, meta, null)).thenReturn(Optional.of(inst(20000)));
+		when(m.db.setWorkspaceMeta(rwsi, new MetadataUpdate(meta, null)))
+				.thenReturn(Optional.of(inst(20000)));
 
 		
-		ws.setWorkspaceMetadata(user, wsi, meta, null);
+		ws.setWorkspaceMetadata(user, wsi, new MetadataUpdate(meta, null));
 		
 		verify(m.l1).setWorkspaceMetadata(user, 24L, Instant.ofEpochMilli(20000));
 		verify(m.l2).setWorkspaceMetadata(user, 24L, Instant.ofEpochMilli(20000));
@@ -277,9 +280,9 @@ public class WorkspaceListenerTest {
 						.withWorkspace(rwsi, Permission.ADMIN, Permission.NONE).build());
 		
 		doThrow(new WorkspaceCommunicationException("whee"))
-				.when(m.db).setWorkspaceMeta(rwsi, meta, Arrays.asList("foo"));
+				.when(m.db).setWorkspaceMeta(rwsi, new MetadataUpdate(meta, Arrays.asList("foo")));
 		try {
-			ws.setWorkspaceMetadata(user, wsi, meta, Arrays.asList("foo"));
+			ws.setWorkspaceMetadata(user, wsi, new MetadataUpdate(meta, Arrays.asList("foo")));
 		} catch(WorkspaceCommunicationException e) {
 			//fine
 		}

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -60,6 +60,7 @@ import us.kbase.typedobj.idref.IdReferenceType;
 import us.kbase.workspace.database.AllUsers;
 import us.kbase.workspace.database.DynamicConfig.DynamicConfigUpdate;
 import us.kbase.workspace.database.ListObjectsParameters;
+import us.kbase.workspace.database.MetadataUpdate;
 import us.kbase.workspace.database.ObjectIDNoWSNoVer;
 import us.kbase.workspace.database.ObjectIDResolvedWS;
 import us.kbase.workspace.database.ObjectIdentifier;
@@ -528,7 +529,7 @@ public class WorkspaceTester {
 			final String key,
 			final Exception e) {
 		try {
-			ws.setWorkspaceMetadata(user, wsi, null, Arrays.asList(key));
+			ws.setWorkspaceMetadata(user, wsi, new MetadataUpdate(null, Arrays.asList(key)));
 			fail("expected remove ws meta to fail");
 		} catch (Exception exp) {
 			assertExceptionCorrect(exp, e);
@@ -551,7 +552,8 @@ public class WorkspaceTester {
 			final List<String> remove,
 			final Exception e) {
 		try {
-			ws.setWorkspaceMetadata(user, wsi, new WorkspaceUserMetadata(meta), remove);
+			ws.setWorkspaceMetadata(
+					user, wsi, new MetadataUpdate(new WorkspaceUserMetadata(meta), remove));
 			fail("expected set ws meta to fail");
 		} catch (Exception exp) {
 			assertExceptionCorrect(exp, e);

--- a/src/us/kbase/workspace/test/workspace/WorkspaceUnitTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceUnitTest.java
@@ -164,6 +164,17 @@ public class WorkspaceUnitTest {
 	}
 	
 	@Test
+	public void setWorkspaceMetadataFailNullMeta() throws Exception {
+		try {
+			initMocks().ws.setWorkspaceMetadata(
+					new WorkspaceUser("u"), new WorkspaceIdentifier(1), null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("meta"));
+		}
+	}
+	
+	@Test
 	public void setWorkspaceDescriptionNull() throws Exception {
 		setWorkspaceDescription(null, null);
 	}


### PR DESCRIPTION
So we can pass a Map<ObjectIDResolvedWS, MetadataUpdate> to the method