### PR TITLE
Add method to set admin meta to DAO

### DIFF
--- a/src/us/kbase/workspace/database/ObjectIDResolvedWS.java
+++ b/src/us/kbase/workspace/database/ObjectIDResolvedWS.java
@@ -4,6 +4,10 @@ import static us.kbase.workspace.database.ObjectIDNoWSNoVer.checkObjectName;
 
 public class ObjectIDResolvedWS {
 	
+	// TODO JAVADOC
+	// TODO TEST
+	// TODO CODE use optionals vs nulls in returns
+	
 	private final ResolvedWorkspaceID rwsi;
 	private final String name;
 	private final Long id;

--- a/src/us/kbase/workspace/database/WorkspaceDatabase.java
+++ b/src/us/kbase/workspace/database/WorkspaceDatabase.java
@@ -101,6 +101,19 @@ public interface WorkspaceDatabase {
 	Optional<Instant> setWorkspaceMeta(ResolvedWorkspaceID wsid, MetadataUpdate meta)
 			throws WorkspaceCommunicationException, CorruptWorkspaceDBException;
 
+	/** Sets administrative metadata on one or more objects, overwriting existing keys if
+	 * duplicate keys are supplied.
+	 * @param update object identifiers mapped to the metadata update for each object.
+	 * @throws NoSuchObjectException if any of the objects don't exist.
+	 * @throws WorkspaceCommunicationException if a communication error occurs.
+	 * @throws CorruptWorkspaceDBException if the workspace database is corrupt.
+	 * @throws IllegalArgumentException if no metadata is supplied or the 
+	 * updated metadata exceeds the allowed size.
+	 */
+	void setAdminObjectMeta(Map<ObjectIDResolvedWS, MetadataUpdate> update)
+			throws NoSuchObjectException, WorkspaceCommunicationException,
+				CorruptWorkspaceDBException;
+	
 	/** Clone a workspace.
 	 * @param user the user cloning the workspace
 	 * @param wsid the ID of the workspace to be cloned.

--- a/src/us/kbase/workspace/database/mongo/Fields.java
+++ b/src/us/kbase/workspace/database/mongo/Fields.java
@@ -65,10 +65,22 @@ public class Fields {
 	public static final String VER_TYPE_MINOR_VERSION = "tymin";
 	public static final String VER_SIZE = "size";
 	public static final String VER_RVRT = "revert";
-	public static final String VER_META = "meta";
 	public static final String VER_COPIED = "copied";
 	//in 0.3.0, if missing assume no external IDs
 	public static final String VER_EXT_IDS = "extids";
+	/*
+	 * Metadata provided by the user and / or automatically extracted from the object, stored
+	 * as a list of dictionaries, each with a key and value field (see below), storing the
+	 * metadata key and metadata value for each metadata key/value pair. It is stored this
+	 * way rather than a simple mapping so that mongo can index the metadata.
+	 */
+	public static final String VER_META = "meta"; 
+	/*
+	 * Metadata provided by an administrative user, stored the same way as user metadata.
+	 * As of 2023/10/12 administrative metadata is not indexed and there are no plans to index it.
+	 */
+	public static final String VER_ADMINMETA = "adminmeta";
+	// may want a moddate for admin meta in the future? YAGNI for now
 	
 	// meta document key & value
 	public static final String META_KEY = "k";

--- a/src/us/kbase/workspace/database/mongo/ObjectInfoUtils.java
+++ b/src/us/kbase/workspace/database/mongo/ObjectInfoUtils.java
@@ -121,8 +121,13 @@ public class ObjectInfoUtils {
 	}
 	
 	static ObjectInformation generateObjectInfo(
-			final ResolvedObjectID roi, final Map<String, Object> ver) {
-		return generateObjectInfo(roi.getWorkspaceIdentifier(), roi.getId(), roi.getName(), ver);
+			final ResolvedObjectID roi,
+			final Map<String, Object> ver) {
+		return generateObjectInfo(
+				roi.getWorkspaceIdentifier(),
+				roi.getId(),
+				roi.getName(),
+				ver);
 	}
 	
 	static ObjectInformation generateObjectInfo(
@@ -134,6 +139,9 @@ public class ObjectInfoUtils {
 		@SuppressWarnings("unchecked")
 		final List<Map<String, String>> meta =
 				(List<Map<String, String>>) ver.get(Fields.VER_META);
+		@SuppressWarnings("unchecked")
+		final List<Map<String, String>> adminmeta =
+				(List<Map<String, String>>) ver.get(Fields.VER_ADMINMETA);
 		final AbsoluteTypeDefId type = new AbsoluteTypeDefId(
 				new TypeDefName((String) ver.get(Fields.VER_TYPE_NAME)),
 				(int) ver.get(Fields.VER_TYPE_MAJOR_VERSION),
@@ -148,8 +156,10 @@ public class ObjectInfoUtils {
 				.withWorkspace(rwsi)
 				.withChecksum((String) ver.get(Fields.VER_CHKSUM))
 				.withSize((long) ver.get(Fields.VER_SIZE))
-				.withUserMetadata(meta == null ? null :
+				.withUserMetadata(
 					new UncheckedUserMetadata(metaMongoArrayToHash(meta)))
+				.withAdminUserMetadata(
+					new UncheckedUserMetadata(metaMongoArrayToHash(adminmeta)))
 				.build();
 	}
 	

--- a/src/us/kbase/workspace/database/mongo/ObjectLister.java
+++ b/src/us/kbase/workspace/database/mongo/ObjectLister.java
@@ -103,9 +103,14 @@ public class ObjectLister {
 				}
 				// this method accesses the DB, so we batch calls to it to reduce transport time
 				final Map<Map<String, Object>, ObjectInformation> objs =
-						infoUtils.generateObjectInfo(pset, verobjs, params.isShowHidden(),
-								params.isShowDeleted(), params.isShowOnlyDeleted(),
-								params.isShowAllVersions(), params.asAdmin()
+						infoUtils.generateObjectInfo(
+								pset,
+								verobjs,
+								params.isShowHidden(),
+								params.isShowDeleted(),
+								params.isShowOnlyDeleted(),
+								params.isShowAllVersions(),
+								params.asAdmin()
 								);
 				//maintain the ordering from Mongo
 				final Iterator<Map<String, Object>> veriter = verobjs.iterator();
@@ -128,6 +133,7 @@ public class ObjectLister {
 		FLDS_LIST_OBJ_VER.forEach(field -> projection.put(field, 1));
 		if (params.isIncludeMetaData()) {
 			projection.put(Fields.VER_META, 1);
+			projection.put(Fields.VER_ADMINMETA, 1);
 		}
 		return projection;
 	}

--- a/src/us/kbase/workspace/test/database/mongo/ObjectListerTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/ObjectListerTest.java
@@ -167,6 +167,7 @@ public class ObjectListerTest {
 
 		if (includeMeta) {
 			p.append("meta", 1);
+			p.append("adminmeta", 1);
 		}
 		return p;
 	}

--- a/src/us/kbase/workspace/test/database/mongo/PartialMock.java
+++ b/src/us/kbase/workspace/test/database/mongo/PartialMock.java
@@ -26,6 +26,7 @@ import us.kbase.workspace.database.Reference;
 import us.kbase.workspace.database.ResolvedWorkspaceID;
 import us.kbase.workspace.database.WorkspaceSaveObject;
 import us.kbase.workspace.database.WorkspaceUser;
+import us.kbase.workspace.database.WorkspaceUserMetadata;
 import us.kbase.workspace.database.mongo.BlobStore;
 import us.kbase.workspace.database.mongo.MongoWorkspaceDB;
 import us.kbase.workspace.database.provenance.Provenance;
@@ -66,6 +67,19 @@ public class PartialMock {
 			final String md5,
 			final long size)
 			throws Exception {
+		return saveTestObject(wsid, u, prov, name, absoluteTypeDef, md5, size, null);
+	}
+	
+	public Reference saveTestObject(
+			final ResolvedWorkspaceID wsid,
+			final WorkspaceUser u,
+			final Provenance prov,
+			final String name,
+			final String absoluteTypeDef,
+			final String md5,
+			final long size,
+			final WorkspaceUserMetadata meta)
+			throws Exception {
 		final ValidatedTypedObject vto = mock(ValidatedTypedObject.class);
 		when(vto.getValidationTypeDefId()).thenReturn(
 				AbsoluteTypeDefId.fromAbsoluteTypeString(absoluteTypeDef));
@@ -78,7 +92,7 @@ public class PartialMock {
 						new ObjectIDNoWSNoVer(name),
 						new UObject(ImmutableMap.of("foo", "bar")),
 						new TypeDefId("DroppedAfter.Resolve", "1.0"),
-						null,
+						meta,
 						prov,
 						false)
 						.resolve(


### PR DESCRIPTION
... and alter all the methods that touch object information to copy or return it correctly.

Ideally we would've:
* Made some type of field manager so mongo field lists aren't respecified all over the place
* Added less integration-y tests for the altered methods in MongoWorkspaceDBTest, rather than jamming tests into WorkspaceTest

However, that would have added several days to this project which we don't have.