### PR TITLE
Add admin mode to PermissionsChecker

### DIFF
--- a/src/us/kbase/workspace/database/ObjectResolver.java
+++ b/src/us/kbase/workspace/database/ObjectResolver.java
@@ -71,7 +71,8 @@ public class ObjectResolver {
 				ReferenceSearchMaximumSizeExceededException {
 		this.db = db;
 		this.user = user;
-		this.permissionsFactory = new PermissionsCheckerFactory(db, user);
+		this.permissionsFactory = PermissionsCheckerFactory.getBuilder(db)
+				.withUser(user).withAsAdmin(asAdmin).build();
 		this.objects = Collections.unmodifiableList(objects);
 		this.nullIfInaccessible = nullIfInaccessible;
 		this.asAdmin = asAdmin;
@@ -197,9 +198,9 @@ public class ObjectResolver {
 		//handle the faster cases first, fail before the searches
 		Map<ObjectIdentifier, ObjectIDResolvedWS> ws = new HashMap<>();
 		if (!nolookup.isEmpty()) {
-			ws = permissionsFactory.getObjectChecker(
-					nolookup, asAdmin ? Permission.NONE : Permission.READ)
-					.withSuppressErrors(nullIfInaccessible).check();
+			ws = permissionsFactory.getObjectChecker(nolookup, Permission.READ)
+					.withSuppressErrors(nullIfInaccessible)
+					.check();
 		}
 		nolookup = null; //gc
 		
@@ -634,7 +635,7 @@ public class ObjectResolver {
 		
 		/** Run the resolution as an admin - e.g. all workspaces are accessible.
 		 * @param asAdmin
-		 * @return
+		 * @return this builder.
 		 */
 		public Builder withAsAdmin(final boolean asAdmin) {
 			this.asAdmin = asAdmin;

--- a/src/us/kbase/workspace/kbase/admin/AdministrationCommandSetInstaller.java
+++ b/src/us/kbase/workspace/kbase/admin/AdministrationCommandSetInstaller.java
@@ -363,11 +363,10 @@ public class AdministrationCommandSetInstaller {
 						cmd, SetWorkspaceOwnerParams.class);
 				final WorkspaceIdentifier wsi = processWorkspaceIdentifier(params.wsi);
 				final WorkspaceInformation info = wsmeth.getWorkspace().setWorkspaceOwner(
-						null,
 						wsi,
 						params.new_user == null ?
 								null : wsmeth.validateUser(params.new_user, token),
-						Optional.ofNullable(params.new_name), true);
+						Optional.ofNullable(params.new_name));
 				getLogger().info(SET_WORKSPACE_OWNER + " " + info.getId() + " " +
 						info.getOwner().getUser());
 				return wsInfoToTuple(info);

--- a/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
+++ b/src/us/kbase/workspace/test/database/mongo/MongoInternalsTest.java
@@ -370,8 +370,8 @@ public class MongoInternalsTest {
 		WorkspaceTester.failWSRename(ws, user1, cloning, "foo", noWSExcp);
 
 		//test set ws owner
-		WorkspaceTester.failSetWorkspaceOwner(ws, user1, cloning,
-				new WorkspaceUser("barbaz"), Optional.of("barbaz"), false, noWSExcp);
+		WorkspaceTester.failSetWorkspaceOwner(ws, cloning,
+				new WorkspaceUser("barbaz"), Optional.of("barbaz"), noWSExcp);
 
 		//test list workspaces
 		List<WorkspaceInformation> wsl = ws.listWorkspaces(

--- a/src/us/kbase/workspace/test/kbase/admin/AdministrationCommandSetInstallerTest.java
+++ b/src/us/kbase/workspace/test/kbase/admin/AdministrationCommandSetInstallerTest.java
@@ -512,7 +512,7 @@ public class AdministrationCommandSetInstallerTest {
 		when(mocks.ah.getAdminRole(new AuthToken("tok", "fake"))).thenReturn(AdminRole.ADMIN);
 		when(mocks.ws.setWorkspaceOwner(
 				// really ws will throw an exception if a null user is passed
-				null, new WorkspaceIdentifier(3), null, Optional.empty(), true))
+				new WorkspaceIdentifier(3), null, Optional.empty()))
 				.thenReturn(WorkspaceInformation.getBuilder()
 						.withID(3)
 						.withName("na")
@@ -557,8 +557,8 @@ public class AdministrationCommandSetInstallerTest {
 				.thenReturn(new WorkspaceUser("usern"));
 		when(mocks.ws.setWorkspaceOwner(
 				// really ws will throw an exception if a null user is passed
-				null, new WorkspaceIdentifier("myws"), new WorkspaceUser("usern"),
-						Optional.of("usern:foo"), true))
+				new WorkspaceIdentifier("myws"), new WorkspaceUser("usern"),
+						Optional.of("usern:foo")))
 				.thenReturn(WorkspaceInformation.getBuilder()
 						.withID(10)
 						.withName("usern:foo")

--- a/src/us/kbase/workspace/test/workspace/WorkspaceListenerTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceListenerTest.java
@@ -519,38 +519,13 @@ public class WorkspaceListenerTest {
 		
 		final Workspace ws = new Workspace(m.db, m.cfg, m.tv, m.tfm, Arrays.asList(m.l1));
 		
-		when(m.db.resolveWorkspaces(set(wsi))).thenReturn(ImmutableMap.of(wsi, rwsi));
-		when(m.db.getPermissions(user, set(rwsi))).thenReturn(
-				PermissionSet.getBuilder(user, new AllUsers('*'))
-						.withWorkspace(rwsi, Permission.OWNER, Permission.NONE).build());
-		when(m.db.getPermission(newUser, rwsi)).thenReturn(Permission.ADMIN);
-		when(m.db.setWorkspaceOwner(rwsi, user, newUser, Optional.empty()))
-				.thenReturn(Instant.ofEpochMilli(30000));
-		
-		ws.setWorkspaceOwner(user, wsi, newUser, Optional.empty(), false);
-
-		verify(m.l1).setWorkspaceOwner(user, 24L, newUser, Optional.empty(),
-				Instant.ofEpochMilli(30000));
-	}
-	
-	@Test
-	public void setWorkspaceOwner1AsAdmin() throws Exception {
-		final Mocks m = new Mocks();
-		
-		final WorkspaceUser user = new WorkspaceUser("foo");
-		final WorkspaceUser newUser = new WorkspaceUser("bar");
-		final WorkspaceIdentifier wsi = new WorkspaceIdentifier(24);
-		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "foobar", false, false);
-		
-		final Workspace ws = new Workspace(m.db, m.cfg, m.tv, m.tfm, Arrays.asList(m.l1));
-		
 		when(m.db.resolveWorkspace(wsi)).thenReturn(rwsi);
 		when(m.db.getWorkspaceOwner(rwsi)).thenReturn(user);
 		when(m.db.getPermission(newUser, rwsi)).thenReturn(Permission.ADMIN);
 		when(m.db.setWorkspaceOwner(rwsi, user, newUser, Optional.empty()))
 				.thenReturn(Instant.ofEpochMilli(30000));
 		
-		ws.setWorkspaceOwner(null, wsi, newUser, Optional.empty(), true);
+		ws.setWorkspaceOwner(wsi, newUser, Optional.empty());
 
 		verify(m.l1).setWorkspaceOwner(null, 24L, newUser, Optional.empty(),
 				Instant.ofEpochMilli(30000));
@@ -568,19 +543,17 @@ public class WorkspaceListenerTest {
 		
 		final Workspace ws = new Workspace(m.db, m.cfg, m.tv, m.tfm, Arrays.asList(m.l1, m.l2));
 		
-		when(m.db.resolveWorkspaces(set(wsi))).thenReturn(ImmutableMap.of(wsi, rwsi));
-		when(m.db.getPermissions(user, set(rwsi))).thenReturn(
-				PermissionSet.getBuilder(user, new AllUsers('*'))
-						.withWorkspace(rwsi, Permission.OWNER, Permission.NONE).build());
+		when(m.db.resolveWorkspace(wsi)).thenReturn(rwsi);
+		when(m.db.getWorkspaceOwner(rwsi)).thenReturn(user);
 		when(m.db.getPermission(newUser, rwsi)).thenReturn(Permission.ADMIN);
 		when(m.db.setWorkspaceOwner(rwsi, user, newUser, Optional.of("bar:foobar")))
 				.thenReturn(Instant.ofEpochMilli(30000));
 		
-		ws.setWorkspaceOwner(user, wsi, newUser, Optional.empty(), false);
+		ws.setWorkspaceOwner(wsi, newUser, Optional.empty());
 
-		verify(m.l1).setWorkspaceOwner(user, 24L, newUser, Optional.of("bar:foobar"),
+		verify(m.l1).setWorkspaceOwner(null, 24L, newUser, Optional.of("bar:foobar"),
 				Instant.ofEpochMilli(30000));
-		verify(m.l2).setWorkspaceOwner(user, 24L, newUser, Optional.of("bar:foobar"),
+		verify(m.l2).setWorkspaceOwner(null, 24L, newUser, Optional.of("bar:foobar"),
 				Instant.ofEpochMilli(30000));
 	}
 	

--- a/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceTester.java
@@ -1596,27 +1596,23 @@ public class WorkspaceTester {
 	}
 
 	protected void failSetWorkspaceOwner(
-			final WorkspaceUser user,
 			final WorkspaceIdentifier wsi,
 			final WorkspaceUser newuser,
 			final Optional<String> name,
-			final boolean asAdmin,
 			final Exception expected)
 			throws Exception {
-		failSetWorkspaceOwner(ws, user, wsi, newuser, name, asAdmin, expected);
+		failSetWorkspaceOwner(ws, wsi, newuser, name, expected);
 	}
 
 	public static void failSetWorkspaceOwner(
 			final Workspace ws,
-			final WorkspaceUser user,
 			final WorkspaceIdentifier wsi,
 			final WorkspaceUser newuser,
 			final Optional<String> name,
-			final boolean asAdmin,
 			final Exception expected)
 			throws Exception {
 		try {
-			ws.setWorkspaceOwner(user, wsi, newuser, name, asAdmin);
+			ws.setWorkspaceOwner(wsi, newuser, name);
 			fail("expected set owner to fail");
 		} catch (Exception got) {
 			assertExceptionCorrect(got, expected);

--- a/src/us/kbase/workspace/test/workspace/WorkspaceUnitTest.java
+++ b/src/us/kbase/workspace/test/workspace/WorkspaceUnitTest.java
@@ -221,7 +221,8 @@ public class WorkspaceUnitTest {
 		final TestMocks mocks = initMocks();
 		
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ws", false, false);
-		when(mocks.db.resolveWorkspace(new WorkspaceIdentifier("ws"))).thenReturn(rwsi);
+		when(mocks.db.resolveWorkspaces(set(new WorkspaceIdentifier("ws")))).thenReturn(
+				ImmutableMap.of(new WorkspaceIdentifier("ws"), rwsi));
 		
 		final long id = mocks.ws.setWorkspaceDescription(
 				null, new WorkspaceIdentifier("ws"), "foo", true);
@@ -236,7 +237,8 @@ public class WorkspaceUnitTest {
 		final TestMocks mocks = initMocks();
 		
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ws", false, false);
-		when(mocks.db.resolveWorkspace(new WorkspaceIdentifier("ws"))).thenReturn(rwsi);
+		when(mocks.db.resolveWorkspaces(set(new WorkspaceIdentifier("ws")))).thenReturn(
+				ImmutableMap.of(new WorkspaceIdentifier("ws"), rwsi));
 		
 		when(mocks.db.getWorkspaceDescription(rwsi)).thenReturn("my desc");
 		
@@ -256,7 +258,8 @@ public class WorkspaceUnitTest {
 		final TestMocks mocks = initMocks();
 		
 		final ResolvedWorkspaceID rwsi = new ResolvedWorkspaceID(24, "ws", true, false);
-		when(mocks.db.resolveWorkspace(new WorkspaceIdentifier("ws"))).thenReturn(rwsi);
+		when(mocks.db.resolveWorkspaces(set(new WorkspaceIdentifier("ws")))).thenReturn(
+				ImmutableMap.of(new WorkspaceIdentifier("ws"), rwsi));
 		
 		setWorkspaceDescriptionFail(mocks.ws, new WorkspaceIdentifier("ws"), true,
 				new WorkspaceAuthorizationException(


### PR DESCRIPTION
Surprised it's not already there. Anyway, will be needed for the admin object metadata method and also allows us to clean up some other methods that were doing hacky things to get around it.