### PR TITLE
 Add shadow jar and workspace controller that starts said jar

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,4 +153,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ var BUILD_DOC_ROOT = "$buildDir/docs/"
 var BUILD_JAVA_DOC_DIR = "$BUILD_DOC_ROOT/javadoc"
 var BUILD_OTHER_DOC_DIR = "$BUILD_DOC_ROOT/otherdoc/"
 // This is where the DocServer will look for docs, if it changes it needs to change
-// in deloy.cfg as well
+// in deploy.cfg as well
 // TODO DOCS just get rid of configuring this in the DocServer, make things hardcoded
 //           or pass in constructor when we subume into a Jersey style service
 var IN_JAR_DOCS_DIR = "/server_docs"

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,14 @@ plugins {
 	id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
-var buildDocsDir = "$buildDir/docs/otherdoc/"
+var BUILD_DOC_ROOT = "$buildDir/docs/"
+var BUILD_JAVA_DOC_DIR = "$BUILD_DOC_ROOT/javadoc"
+var BUILD_OTHER_DOC_DIR = "$BUILD_DOC_ROOT/otherdoc/"
+// This is where the DocServer will look for docs, if it changes it needs to change
+// in deloy.cfg as well
+// TODO DOCS just get rid of configuring this in the DocServer, make things hardcoded
+//           or pass in constructor when we subume into a Jersey style service
+var IN_JAR_DOCS_DIR = "/server_docs"
 
 // TODO NOW test shadow jar works in groups - need test controller - commit 2
 // TODO NOW get docserver working in WAR and test in docker-compose <- edit to start test server - commit 3
@@ -63,18 +70,18 @@ task buildDocs {
 	dependsOn javadoc
 	doLast {
 		// need to make sure we remove any docs that no longer exist in the source
-		delete "$buildDocsDir"
+		delete "$BUILD_OTHER_DOC_DIR"
 		copy {
-			from "$rootDir/workspace.spec" into "$buildDocsDir"
+			from "$rootDir/workspace.spec" into "$BUILD_OTHER_DOC_DIR"
 		}
 		copy {
-			from "$rootDir/docshtml/" into "$buildDocsDir" include "*"
+			from "$rootDir/docshtml/" into "$BUILD_OTHER_DOC_DIR" include "*"
 		}
 		exec {	
-			commandLine "pod2html", "--infile=$rootDir/lib/Bio/KBase/workspace/Client.pm", "--outfile=$buildDocsDir/workspace_perl.html"
+			commandLine "pod2html", "--infile=$rootDir/lib/Bio/KBase/workspace/Client.pm", "--outfile=$BUILD_OTHER_DOC_DIR/workspace_perl.html"
 		}
 		exec {
-			commandLine "sphinx-build", "$rootDir/docsource/", "$buildDocsDir"
+			commandLine "sphinx-build", "$rootDir/docsource/", "$BUILD_OTHER_DOC_DIR"
 		}
 		delete fileTree(".").matching { include "pod2htm*.tmp" }
 	}
@@ -130,6 +137,26 @@ task testQuick(type: Test) {
 task jacocoTestQuickReport(type: JacocoReport, dependsOn: testQuick) {
 	sourceSets sourceSets.main
 	executionData(testQuick)
+}
+
+shadowJar {
+	// Be careful when updating jars - you may want to set the duplicates strategy to WARN
+	// to see if any of the jars are shadowing the others when building the fat jar, which
+	// has been the case in the past
+	dependsOn buildDocs
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+	archiveAppendix = 'test-shadow'
+	from sourceSets.test.output
+	// we don't want to package the auth shadow jar, so no test runtime classpath
+	configurations = [project.configurations.runtimeClasspath]
+
+	enableRelocation true
+	relocationPrefix 'us.kbase.workspace.shadow'
+	
+	mergeServiceFiles()
+	
+	from(BUILD_JAVA_DOC_DIR) { into "$IN_JAR_DOCS_DIR/javadoc" }
+	from(BUILD_OTHER_DOC_DIR) { into IN_JAR_DOCS_DIR }
 }
 
 // Custom java project layout
@@ -267,10 +294,9 @@ dependencies {
 	)
 	testImplementation 'com.arangodb:arangodb-java-driver:6.7.2'
 	testImplementation 'com.github.zafarkhaja:java-semver:0.9.0'
-	testImplementation 'org.hamcrest:hamcrest-core:1.3'
-	testImplementation 'commons-lang:commons-lang:2.4'
 	testImplementation 'junit:junit:4.12'
 	testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.1.10'
+	testImplementation 'org.hamcrest:hamcrest-core:1.3'
 	testImplementation 'org.mockito:mockito-core:3.0.0'
 	
 }

--- a/src/us/kbase/workspace/test/controllers/workspace/WorkspaceController.java
+++ b/src/us/kbase/workspace/test/controllers/workspace/WorkspaceController.java
@@ -1,0 +1,115 @@
+package us.kbase.workspace.test.controllers.workspace;
+
+import static us.kbase.common.test.controllers.ControllerCommon.findFreePort;
+import static us.kbase.common.test.controllers.ControllerCommon.makeTempDirs;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.ini4j.Ini;
+import org.ini4j.Profile.Section;
+
+import us.kbase.workspace.WorkspaceServer;
+
+
+/** Q&D Utility to run a Workspace server for the purposes of testing from
+ * Java. Expected to be packaged in a test jar with all dependencies.
+ * 
+ * Initializes a GridFS backend and does not support handles, byte streams, or listeners.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class WorkspaceController {
+
+	private final static String DATA_DIR = "temp_data";
+	private static final String WS_CLASS = WorkspaceServer.class.getName();
+	private static final String JAR_PATH = WorkspaceServer.class.getProtectionDomain()
+			.getCodeSource().getLocation().getPath();
+
+	private final static List<String> tempDirectories = new LinkedList<String>();
+	static {
+		tempDirectories.add(DATA_DIR);
+	}
+
+	private final Path tempDir;
+
+	private final Process workspace;
+	private final int port;
+
+	public WorkspaceController(
+			final String mongoHost,
+			final String mongoDatabase,
+			final String mongoTypeDatabase,
+			final String adminUser,
+			final URL authServiceRootURL, // expected to include /testmode endpoint
+			final Path rootTempDir)
+			throws Exception {
+		tempDir = makeTempDirs(rootTempDir, "WorkspaceController-", tempDirectories);
+		port = findFreePort();
+		System.out.println("Using classpath " + JAR_PATH);
+		
+		final Path deployCfg = createDeployCfg(
+				mongoHost, mongoDatabase, mongoTypeDatabase, authServiceRootURL, adminUser);
+		final List<String> command = new LinkedList<String>();
+		command.addAll(Arrays.asList("java", "-classpath", JAR_PATH, WS_CLASS, "" + port));
+		final ProcessBuilder servpb = new ProcessBuilder(command)
+				.redirectErrorStream(true)
+				.redirectOutput(tempDir.resolve("workspace.log").toFile());
+
+		final Map<String, String> env = servpb.environment();
+		env.put("KB_DEPLOYMENT_CONFIG", deployCfg.toString());
+
+		workspace = servpb.start();
+		// TODO TEST add periodic check w/ exponential backoff
+		Thread.sleep(5000);
+	}
+
+	private Path createDeployCfg(
+			final String mongoHost,
+			final String mongoDatabase,
+			final String mongoTypeDatabase,
+			final URL authRootURL,
+			final String adminUser)
+					throws IOException {
+		final File iniFile = new File(tempDir.resolve("test.cfg").toString());
+		System.out.println("Created temporary workspace config file: " +
+				iniFile.getAbsolutePath());
+		final Ini ini = new Ini();
+		Section ws = ini.add("Workspace");
+		ws.add("mongodb-host", mongoHost);
+		ws.add("mongodb-database", mongoDatabase);
+		ws.add("mongodb-type-database", mongoTypeDatabase);
+		ws.add("backend-type", "GridFS");
+		ws.add("auth2-service-url", authRootURL);
+		ws.add("ws-admin", adminUser);
+		ws.add("temp-dir", tempDir.resolve("temp_data"));
+		ws.add("ignore-handle-service", "true");
+		ini.store(iniFile);
+		return iniFile.toPath();
+	}
+
+	public int getServerPort() {
+		return port;
+	}
+
+	public Path getTempDir() {
+		return tempDir;
+	}
+
+	public void destroy(boolean deleteTempFiles) throws IOException {
+		if (workspace != null) {
+			workspace.destroy();
+		}
+		if (tempDir != null && deleteTempFiles) {
+			FileUtils.deleteDirectory(tempDir.toFile());
+		}
+	}
+}
+


### PR DESCRIPTION
This PR is a duplicate of https://github.com/kbase/workspace_deluxe/pull/726 as codecov seems to be unable to pass without a token, and the token isn't available in a fork. As such, it has already been approved.

Tested this setup in the Groups service, replacing the workspace controller there