### PR TITLE
Update documentation for Gradle changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,6 @@ var IN_JAR_JAVA_DOC_DIR = "$IN_JAR_DOC_DIR/javadoc"
 var LOC_WS_SPEC = "$rootDir/workspace.spec"
 var LOC_DOC_HTML = "$rootDir/docshtml"
 
-// TODO NOW update any ant refs in docs to gradle & the update schema script build & location
-
 repositories {
 	mavenCentral()
 }
@@ -278,6 +276,14 @@ java -cp $buildDir/classes/java/main:\$CLASSPATH us.kbase.workspace.kbase.Schema
 		file(outfile).text = scriptContent
 		file(outfile).setExecutable(true)
 	}
+}
+
+task buildAll {
+	dependsOn buildDocs
+	dependsOn jar
+	dependsOn war
+	dependsOn shadowJar
+	dependsOn generateUpdateSchemaScript
 }
 
 configurations {

--- a/docsource/buildandconfigure.rst
+++ b/docsource/buildandconfigure.rst
@@ -3,79 +3,30 @@
 Build, configure, and deploy
 ============================
 
-These instructions assume the reader is familiar with the process of deploying
-a KBase module, including the `runtime <https://github.com/kbase/bootstrap>`_
-and `dev_container <https://github.com/kbase/dev_container>`_, and has access to
-a system with the KBase runtime installed. These instructions are based on the
-``kbase-image-v26`` runtime image.
-
-Unlike many modules the WSS can be built and tested outside the
-``dev_container``, but the ``dev_container`` is required to build and test the
-scripts. These instructions are for deploying the server and so do not
-address the scripts. Building outside the ``dev_container`` means the Makefile
-uses several default values for deployment - if you wish to use other values
-deploy from the ``dev_container`` as usual.
-
 Build the workspace service
 ---------------------------
 
-First checkout the ``dev_container``::
-
-    /kb$ sudo git clone https://github.com/kbase/dev_container
-    Cloning into 'dev_container'...
-    remote: Counting objects: 1097, done.
-    remote: Total 1097 (delta 0), reused 0 (delta 0), pack-reused 1097
-    Receiving objects: 100% (1097/1097), 138.81 KiB, done.
-    Resolving deltas: 100% (661/661), done.
-
-.. note::
-   In the v26 image, ``/kb`` is owned by ``root``. As an alternative to
-   repetitive ``sudo`` s, ``chown`` ``/kb`` to the user.
-
-Bootstrap and source the user environment file, which sets up Java and Perl
-paths which the WSS build needs::
-
-    /kb$ cd dev_container/
-    /kb/dev_container$ sudo ./bootstrap /kb/runtime/
-    /kb/dev_container$ source user-env.sh
-
-Now the WSS may be built. If building inside the ``dev_container`` all the
-dependencies from the ``DEPENDENCIES`` file are required, but to build outside
-the ``dev_container``, only the ``jars`` and ``workspace_deluxe`` repos are
-necessary::
+Get the code::
 
     ~$ mkdir kb
     ~$ cd kb
     ~/kb$ git clone https://github.com/kbase/workspace_deluxe
-    Cloning into 'workspace_deluxe'...
-    remote: Counting objects: 21961, done.
-    remote: Compressing objects: 100% (40/40), done.
-    remote: Total 21961 (delta 20), reused 0 (delta 0), pack-reused 21921
-    Receiving objects: 100% (21961/21961), 21.42 MiB | 16.27 MiB/s, done.
-    Resolving deltas: 100% (13979/13979), done.
 
-    ~/kb$ git clone https://github.com/kbase/jars
-    Cloning into 'jars'...
-    remote: Counting objects: 1466, done.
-    remote: Total 1466 (delta 0), reused 0 (delta 0), pack-reused 1466
-    Receiving objects: 100% (1466/1466), 59.43 MiB | 21.49 MiB/s, done.
-    Resolving deltas: 100% (626/626), done.
+Build::
 
     ~/kb$ cd workspace_deluxe/
-    ~/kb/workspace_deluxe$ make
+    ~/kb/workspace_deluxe$ ./gradlew buildAll
     *snip*
 
-``make`` will build:
+``buildAll`` will build 3 jars in ``build/libs``:
 
-* A workspace client jar in ``/dist/client``
-* A workspace server jar in ``/dist``
-* This documentation in ``/docs``
+* A workspace client jar
+* A workspace server WAR file
+* A workspace shadow jar containing all test code. This is useful for starting a workpace server
+  from other processes without needing a docker container, but should **only** be used for testing.
 
-.. note::
-   If the build fails due to a sphinx error, sphinx may require an upgrade to
-   >= 1.3::
-
-       $ sudo pip install sphinx --upgrade
+It will also build the ``build\update_workspace_database_schema`` script which is used to
+update the workspace schema if it changes from one version to another.
 
 .. _servicedeps:
 
@@ -133,10 +84,7 @@ to create the file.
    It is especially important to protect the credentials that the WSS uses
    to talk to S3 (``backend-token``) as they can be used to delete
    or corrupt the workspace data. At minimum, only the user that runs the WSS (which
-   should **not** be ``root``) should have read access to ``deploy.cfg``. Also be
-   aware that the ``deploy.cfg`` contents are copied to, by default,
-   ``/kb/deployment/deployment.cfg`` when the workspace is deployed from the
-   ``dev_container``.
+   should **not** be ``root``) should have read access to ``deploy.cfg``.
 
 .. _configurationparameters:
 
@@ -338,9 +286,6 @@ is checked against ``bytestream-user``, and if the names differ, the server will
 .. warning:: Once any data containing Shock node IDs has been saved by the workspace, changing the
    shock user will result in unspecified behavior, including data corruption.
 
-.. note:: It is strongly encouraged to use different accounts for the backend shock user and
-   the linking shock user so that core workspace data can be distinguished from linked data.
-
 bytestream-token
 """"""""""""""""
 **Required**: If linking WSS objects to Shock nodes is desired.
@@ -407,6 +352,17 @@ for a request, in order of precedence, is 1) the first address in
 
 Deploy and start the server
 ---------------------------
+
+.. todo::
+   This section needs an entire rewrite from scratch with Tomcat as the application server and
+   a clean, easy install instruction set or a script to set things up correctly (e.g.
+   the port and memory settings in the ``deploy.cfg`` file are currently ignored).
+   Currently, the easiest way to run the service locally is via ``docker compose up -d --build``
+   which will start a KBase auth server in testmode and the workspace. If deploying outside
+   a docker container is required, the best option for now is to inspect the Dockerfile and
+   attempt to follow the steps there.
+
+   Also, the developer and administrator server startup documentation should be unified.
 
 To avoid various issues when deploying, ``chown`` the deployment directory
 to the user. Alternatively, chown ``/kb/`` to the user, or deploy as root.

--- a/docsource/builddocs.rst
+++ b/docsource/builddocs.rst
@@ -1,9 +1,8 @@
 Build documentation
 ===================
 
-This documentation assumes the documentation build occurs on Ubuntu 12.04LTS,
-but things should work similarly on other distributions. It does **not**
-assume that the KBase runtime or ``dev_container`` are installed.
+This documentation assumes the documentation build occurs on Ubuntu 18.04LTS,
+but things should work similarly on other distributions.
 
 Requirements
 ------------
@@ -12,43 +11,17 @@ The build requires:
 
 Java JDK 11
 
-`Java ant <http://ant.apache.org/>`_::
+`Python <https://www.python.org/>`_ `Sphinx <https://www.sphinx-doc.org/>`_ 1.3+
 
-    sudo apt-get install ant
-
-`Python <https://www.python.org/>`_ `Sphinx <http://sphinx-doc.org/>`_ 1.3+::
-
-Either
-
-    sudo apt-get install python3-sphinx
-
-or, if the `python3-sphinx` package is not available for your distribution
-
-    curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
-    sudo python get-pip.py
-    sudo pip install sphinx --upgrade
 
 .. _getcode:
 
 Getting the code
 ----------------
 
-Clone the jars and workspace_deluxe repos::
-
-    bareubuntu@bu:~/ws$ git clone https://github.com/kbase/jars
-    Cloning into 'jars'...
-    remote: Counting objects: 1466, done.
-    remote: Total 1466 (delta 0), reused 0 (delta 0), pack-reused 1466
-    Receiving objects: 100% (1466/1466), 59.43 MiB | 2.43 MiB/s, done.
-    Resolving deltas: 100% (626/626), done.
+Clone the workspace_deluxe repo::
 
     bareubuntu@bu:~/ws$ git clone https://github.com/kbase/workspace_deluxe
-    Cloning into 'workspace_deluxe'...
-    remote: Counting objects: 22004, done.
-    remote: Compressing objects: 100% (82/82), done.
-    remote: Total 22004 (delta 41), reused 0 (delta 0), pack-reused 21921
-    Receiving objects: 100% (22004/22004), 21.44 MiB | 2.44 MiB/s, done.
-    Resolving deltas: 100% (14000/14000), done.
 
 Build
 -----
@@ -56,6 +29,6 @@ Build
 Build the documentation::
 
     bareubuntu@bu:~/ws$ cd workspace_deluxe/
-    bareubuntu@bu:~/ws/workspace_deluxe$ make build-docs
+    bareubuntu@bu:~/ws/workspace_deluxe$ ./gradlew buildDocs
 
-The build directory is ``docs``.
+The build directory is ``build/docs``.

--- a/docsource/developers.rst
+++ b/docsource/developers.rst
@@ -22,9 +22,13 @@ Branches:
 
 Recompiling the generated code
 ------------------------------
-To compile, simply run ``make compile``. The
-`kb-sdk <https://github.com/kbase/kb_sdk>`_ executable must be in the system
-path.
+To compile, run ``./gradlew compile``.
+
+Note that:
+
+* The `kb-sdk <https://github.com/kbase/kb_sdk>`_ executable must be in the system path.
+* The WorkspaceServer class compiled in constructor has been commented out in order to use
+  a custom constructor. That must be reversed for the compile to work.
 
 Release checklist
 -----------------
@@ -52,6 +56,16 @@ Release checklist
 
 Deploying the Workspace Service locally
 ----------------------------------------
+
+.. todo::
+   This section needs an entire rewrite from scratch with Tomcat as the application server.
+   Currently, the easiest way to run the service locally is via ``docker compose up -d --build``
+   which will start a KBase auth server in testmode and the workspace. If deploying outside
+   a docker container is required, the best option for now is to inspect the Dockerfile and
+   attempt to follow the steps there.
+
+   Also, the developer and administrator server startup documentation should be unified.
+
 These instructions are known to work on Ubuntu 16.04 LTS.
 
 1. Install the dependencies `Java8 <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`_, `Apache Ant <https://ant.apache.org/bindownload.cgi>`_, pymongo v2.8, `GlassFish v3.1.2.2 <http://www.oracle.com/technetwork/middleware/glassfish/downloads/ogs-3-1-1-downloads-439803.html>`_ , `mongodb >=v2.6.* <https://www.mongodb.com/download-center#atlas>`_, `kb-sdk <https://github.com/kbase/kb_sdk>`_ and the `KBase Jars <https://github.com/kbase/jars>`_ directory.

--- a/docsource/test.rst
+++ b/docsource/test.rst
@@ -8,6 +8,10 @@ In order to run tests:
 
   * A Linux Shock binary is provided in ``shock_builds``.
 
+.. todo::
+   Update these instructions for the `Blobstore <https://github.com/kbase/blobstore>`_,
+   which has replaced Shock.
+
 * Minio must be installed, but not necessarily running.
 
   * Minio version must be greater than 2019-05-23T00-29-34Z.
@@ -15,11 +19,12 @@ In order to run tests:
 * The Handle Service must be installed, but not necessarily running. See ``test.cfg.example``
   for setup instructions.
   
-* The KBase Jars repo must be cloned into the parent directory of the workspace repo directory,
-  e.g::
+* The Sample Service must be installed, but not necessarily running. See ``test.cfg.example``
+  for setup instructions.
 
-    ls 
-    jars  workspace_deluxe
+* `ArangoDB <https://arangodb.com/>`_ must be installed but not necessarily running as it is a
+  requirement of the Sample Service.
+
 
 See :ref:`servicedeps` for more information about these test dependencies.
 
@@ -30,7 +35,9 @@ Then::
     cd python_dependencies/
     pipenv shell
     cd ..
-    make test
+    ./gradlew test
 
-The tests currently take 20-30 minutes to run on spinning disks, or 8-10 minutes on SSDs.
+The ``testQuick`` target is substantially faster but does not run all tests.
 
+.. todo::
+   Move to developer documentation vs. server administrator documenation.

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ use the WSS. The easiest way to read the documentation is to find an already
 built instance online:
 
 * [KBase Continuous Integration](https://ci.kbase.us/services/ws/docs/)
-* [KBase Next](https://next.kbase.us/services/ws/docs/)
+* [KBase Appdev](https://appdev.kbase.us/services/ws/docs/)
 * [KBase Production](https://kbase.us/services/ws/docs/)
 
 The documentation can also be read on Github as
@@ -37,53 +37,25 @@ yourself.
 
 ### Building documentation
 
-This documentation assumes the documentation build occurs on Ubuntu 12.04LTS,
-but things should work similarly on other distributions. It does **not**
-assume that the KBase runtime or `dev_container` are installed.
+This documentation assumes the documentation build occurs on Ubuntu 18.04LTS,
+but things should work similarly on other distributions.
 
 The build requires:
 
 Java JDK 11
 
-[Java ant](http://ant.apache.org):
+[Python](https://www.python.org) [Sphinx](http://sphinx-doc.org/) 1.3+
 
-    sudo apt-get install ant
-
-[Python](https://www.python.org) [Sphinx](http://sphinx-doc.org/) 1.3+:
-
-Either
-
-    sudo apt-get install python3-sphinx
-
-or
-
-    curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
-    sudo python get-pip.py
-    sudo pip install sphinx --upgrade
-
-Clone the jars and workspace_deluxe repos:
-
-    bareubuntu@bu:~/ws$ git clone https://github.com/kbase/jars
-    Cloning into 'jars'...
-    remote: Counting objects: 1466, done.
-    remote: Total 1466 (delta 0), reused 0 (delta 0), pack-reused 1466
-    Receiving objects: 100% (1466/1466), 59.43 MiB | 2.43 MiB/s, done.
-    Resolving deltas: 100% (626/626), done.
+Clone the workspace_deluxe repos:
 
     bareubuntu@bu:~/ws$ git clone https://github.com/kbase/workspace_deluxe
-    Cloning into 'workspace_deluxe'...
-    remote: Counting objects: 22004, done.
-    remote: Compressing objects: 100% (82/82), done.
-    remote: Total 22004 (delta 41), reused 0 (delta 0), pack-reused 21921
-    Receiving objects: 100% (22004/22004), 21.44 MiB | 2.44 MiB/s, done.
-    Resolving deltas: 100% (14000/14000), done.
 
 Build the documentation:
 
     bareubuntu@bu:~/ws$ cd workspace_deluxe/
-    bareubuntu@bu:~/ws/workspace_deluxe$ make build-docs
+    bareubuntu@bu:~/ws/workspace_deluxe$ ./gradlew buildDocs
 
-The build directory is `docs`.
+The build directory is `build/docs`.
 
 ### Notes on GitHub Actions automated tests
 
@@ -94,24 +66,25 @@ Therefore, run the full test suite locally at least prior to every release.
 
 ### Downloading the Docker image
 
-The latest `workspace_deluxe` image is available from the GitHub Container Repository; it can be downloaded [from the repository releases page](https://github.com/kbase/workspace_deluxe/releases/latest) or on the command line:
+The latest `workspace_deluxe` image is available from the GitHub Container Repository:
 
     docker login ghcr.io
     docker pull ghcr.io/kbase/workspace_deluxe:latest
 
 ### Setting up a local instance
 
-The included [docker-compose file](docker-compose.yml) allows developers to stand up a local workspace instance with an [auth2](http://github.com/kbase/auth2) instance in test mode. To mount the images:
+The included [docker-compose file](docker-compose.yml) allows developers to stand up a local
+workspace instance with an [auth2](http://github.com/kbase/auth2) instance in test mode:
 
-    # build the workspace docker image
-    docker compose build
-    # mount the images
-    docker compose up
+    docker compose up --build -d
 
-The workspace has started up when the logs show a line that looks like
+The workspace has started when the logs show a line that looks like
 
     <timestamp> INFO [main] org.apache.catalina.startup.Catalina.start Server startup in 3198ms
 
-Developers can then create a user and token using the auth2 service and use one of the clients in the [`lib/`](lib/) directory to interact with the workspace. See [workspace_container_test.py](scripts/workspace_container_test.py) as an example of this process.
+Developers can then create a user and token using the auth2 service and use one of the clients
+in the [`lib/`](lib/) directory to interact with the workspace. See
+[workspace_container_test.py](scripts/workspace_container_test.py) as an example of this process.
 
-See the [auth2 documentation](http://github.com/kbase/auth2) for details of the test mode interface.
+See the [auth2 documentation](http://github.com/kbase/auth2) for details of the test mode
+interface.


### PR DESCRIPTION
Also deleted a no longer relevant Shock warning. The documentation needs to be updated for Shock -> Blobstore all over the place, but that's another commit or two.