### PR TITLE
Update ubuntu in tests action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ on:
 jobs:
 
   workspace_container_tests:
-    runs-on: ubuntu-24.04 
+    runs-on: ubuntu-20.04 
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ on:
 jobs:
 
   workspace_container_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04 
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:

March 4 14:00 UTC – 22:00 UTC
March 11 13:00 UTC – 21:00 UTC
March 18 13:00 UTC – 21:00 UTC
March 25 13:00 UTC – 21:00 UTC
What you need to do

Jobs using the ubuntu-20.04 YAML workflow label should be updated to ubuntu-22.04, ubuntu-24.04 or ubuntu-latest. You can always get up-to-date information on our tools by reading about the software in the runner images repository. Please contact GitHub Support if you run into any problems or need help.